### PR TITLE
Update run.ps1

### DIFF
--- a/Standards_SecurityDefaults/run.ps1
+++ b/Standards_SecurityDefaults/run.ps1
@@ -6,7 +6,7 @@ try {
     if ($SecureDefaultsState.IsEnabled -ne $true) {
         Write-Host "Secure Defaults is disabled. Enabling for $tenant" -ForegroundColor Yellow
         $body = '{ "isEnabled": true }'
-    (Invoke-RestMethod -Uri "$baseuri/policies/identitySecurityDefaultsEnforcementPolicy" -Headers $Header -Method patch -Body $body -ContentType "application/json")
+    (Invoke-RestMethod -Uri "https://graph.microsoft.com/beta/policies/identitySecurityDefaultsEnforcementPolicy" -Headers $Header -Method patch -Body $body -ContentType "application/json")
     }
     Log-request -API "Standards" -tenant $tenant -message "Standards API: Security Defaults Enabled." -sev Info
 }


### PR DESCRIPTION
Got debug error message in logs, hostname wasn't being specified due to $baseuri not being defined, replaced with full URI from the get query
Standards|Failed to enable Security Defaults Error: Invalid URI: The hostname could not be parsed.|CIPP|