### PR TITLE
Update run.ps1

### DIFF
--- a/Standards_DelegateSentItems/run.ps1
+++ b/Standards_DelegateSentItems/run.ps1
@@ -6,7 +6,7 @@ try {
     $credential = New-Object System.Management.Automation.PSCredential($upn, $tokenValue)
     $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri "https://ps.outlook.com/powershell-liveid?DelegatedOrg=$($Tenant)&BasicAuthToOAuthConversion=true" -Credential $credential -Authentication Basic -AllowRedirection -ErrorAction Continue
     Import-PSSession $session -ea Silentlycontinue -AllowClobber -CommandName "Get-Mailbox", "Set-mailbox"
-    Get-Mailbox -ResultSize Unlimited -RecipientTypeDetails UserMailbox, SharedMailbox | Where-Object { $_.MessageCopyForSendOnBehalfEnabled -eq $false -or $_.MessageCopyForSentAsEnabled -eq $false } | set-mailbox -erroraction SilentlyContinue -MessageCopyForSentAsEnabled $true -MessageCopyForSendOnBehalfEnabled $true 
+    Get-Mailbox -ResultSize Unlimited -RecipientTypeDetails UserMailbox, SharedMailbox | Where-Object { $_.MessageCopyForSendOnBehalfEnabled -eq $false -or $_.MessageCopyForSentAsEnabled -eq $false } | ForEach-Object {set-mailbox -erroraction SilentlyContinue $_.UserPrincipalName -MessageCopyForSentAsEnabled $true -MessageCopyForSendOnBehalfEnabled $true}
     Get-PSSession | Remove-PSSession
     Log-request  -API "Standards" -tenant $tenant -message "Delegate Sent Items Style enabled." -sev Info
 }


### PR DESCRIPTION
Without running the set-mailbox against a UPN, the default Identity value can return multiple results and prevent these mailbox's from applying the action.

For example, with the existing code, I'm receiving the "The operation couldn't be performed because 'Andrew Smith' matches multiple entries." error on many mail accounts where the user has multiple accounts and therefor matches multiple get-mailbox without specifying the actual UPN. My test user Andrew Smith returns the below data:

PS> get-mailbox -Identity "Andrew Smith"  | fl Identity,MessageCopy*

Identity                                  : Andrew Smith
MessageCopyForSentAsEnabled               : False
MessageCopyForSendOnBehalfEnabled         : False
MessageCopyForSMTPClientSubmissionEnabled : True

Identity                                  : Andrew Smith_aa40332fcb
MessageCopyForSentAsEnabled               : True
MessageCopyForSendOnBehalfEnabled         : True
MessageCopyForSMTPClientSubmissionEnabled : True