### PR TITLE
Fix for .com.au WHOIS lookups

### DIFF
--- a/DNSHelper.psm1
+++ b/DNSHelper.psm1
@@ -1403,8 +1403,8 @@ function Read-WhoisRecord {
     )
     $HasReferral = $false
 
-    # Top level referring servers, IANA and ARIN
-    $TopLevelReferrers = @('whois.iana.org', 'whois.arin.net')
+    # Top level referring servers, IANA, ARIN and AUDA
+    $TopLevelReferrers = @('whois.iana.org', 'whois.arin.net', 'whois.auda.org.au')
 
     # Record Pattern Matching
     $ServerPortRegex = '(?<refsvr>[^:\r\n]+)(:(?<port>\d+))?'
@@ -1418,7 +1418,7 @@ function Read-WhoisRecord {
 
     # List of properties for Registrars
     $RegistrarProps = @(
-        'Registrar'
+        'Registrar', 'Registrar Name'
     )
 
     # Whois parser, generic Property: Value format with some multi-line support and comment handlers
@@ -1465,7 +1465,9 @@ function Read-WhoisRecord {
         foreach ($RegistrarProp in $RegistrarProps) {
             if ($Results.Contains($RegistrarProp)) {
                 $Results._Registrar = $Results.$RegistrarProp
-                break
+                if($Results.$RegistrarProp -eq 'Registrar') {
+                    break  # Means we always favour Registrar if it exists, or keep looking
+                }
             }
         }
 


### PR DESCRIPTION
.com.au WHOIS records do not have a 'Registrar' and appear to be using the 'Registrar Name' field as a comparative to the .com 'Registrar'. This patch allows for 'Registrar Name' to be displayed if and only if the 'Registrar' does not exist. As a result .com.au domains no longer incorrectly show as no WHOIS available.