### PR TITLE
fix lastLogin killing the BEC when it doesn't work

### DIFF
--- a/Durable_BECRun/run.ps1
+++ b/Durable_BECRun/run.ps1
@@ -49,6 +49,7 @@ try {
     } while ($LogsTenant.count % 5000 -eq 0 -and $LogsTenant.count -ne 0)
   }
   #Get user last logon
+  try {
   $uri = "https://login.microsoftonline.com/$($TenantFilter)/oauth2/token"
   $body = "resource=https://admin.microsoft.com&grant_type=refresh_token&refresh_token=$($ENV:ExchangeRefreshToken)"
   Write-Host "getting token"
@@ -61,8 +62,15 @@ try {
     'x-ms-correlation-id'    = [guid]::NewGuid()
     'X-Requested-With'       = 'XMLHttpRequest' 
   }
-  #List all users devices
   Write-Host "Last Sign in is: $LastSignIn"
+}
+catch{
+  Write-Host "Last Sign in is: Unknown"
+  $LastSignIn = "Unknown"
+}
+
+  #List all users devices
+
   $Bytes = [System.Text.Encoding]::UTF8.GetBytes($SuspectUser)
   $base64IdentityParam = [Convert]::ToBase64String($Bytes)
   Try {


### PR DESCRIPTION
Fetching last login seems to be broken currently and mostly returning 401. This wraps the call in a try block and stamps the lastLogin as unknown allowing the function to continue with the rest of the checks instead of halting. If Microsoft fix their API it will just work as it should again.