### PR TITLE
Fix naming violations

### DIFF
--- a/EditUser/run.ps1
+++ b/EditUser/run.ps1
@@ -67,7 +67,7 @@ try {
         Write-Host $LicenseBody
         $LicRequest = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($userobj.Userid)/assignlicense" -tenantid $Userobj.tenantid -type POST -body $LicenseBody -verbose
 
-        Log-Request -API $APINAME -tenant ($UserObj.tenantid) -user $request.headers.'x-ms-client-principal' -message "Changed user $($userobj.displayname) license. Sent info: $licensebody" -Sev "Info"
+        Log-Request -API $APINAME -tenant ($UserObj.tenantid) -user $request.headers.'x-ms-client-principal' -message "Changed user $($userobj.displayName) license. Sent info: $licensebody" -Sev "Info"
         $results.add( "Success. User license has been edited." )
     }
 

--- a/GetDashboard/run.ps1
+++ b/GetDashboard/run.ps1
@@ -213,15 +213,15 @@ if ($psversiontable.psversion.toString() -lt 7.2) { $Alerts.add("Your Function A
 $APIName = $TriggerMetadata.FunctionName
 Log-Request -user $request.headers.'x-ms-client-principal' -API $APINAME  -message "Accessed this API" -Sev "Debug"
 $dash = [PSCustomObject]@{
-    NextStandardsRun  = (Get-CronNextExecutionTime -Expression '0 */3 * * *').tostring('s')
-    NextBPARun        = (Get-CronNextExecutionTime -Expression '0 3 * * *').tostring('s')
-    QueuedApps        = [int64](Get-ChildItem '.\ChocoApps.Cache' -ErrorAction SilentlyContinue).count
-    QueuedStandards   = [int64](Get-ChildItem '.\Cache_Standards' -ErrorAction SilentlyContinue).count
-    TenantCount       = [int64](Get-Content '.\tenants.cache.json' | ConvertFrom-Json -ErrorAction SilentlyContinue).count
-    RefreshTokenDate  = (Get-CronNextExecutionTime -Expression '0 0 * * 0').AddDays('-7').tostring('s') -split "T" | Select-Object -First 1
-    ExchangeTokenDate = (Get-CronNextExecutionTime -Expression '0 0 * * 0').AddDays('-7').tostring('s') -split "T" | Select-Object -First 1
-    LastLog           = @($SlimRows)
-    Alerts            = @($Alerts)
+    nextStandardsRun  = (Get-CronNextExecutionTime -Expression '0 */3 * * *').tostring('s')
+    nextBPARun        = (Get-CronNextExecutionTime -Expression '0 3 * * *').tostring('s')
+    queuedApps        = [int64](Get-ChildItem '.\ChocoApps.Cache' -ErrorAction SilentlyContinue).count
+    queuedStandards   = [int64](Get-ChildItem '.\Cache_Standards' -ErrorAction SilentlyContinue).count
+    tenantCount       = [int64](Get-Content '.\tenants.cache.json' | ConvertFrom-Json -ErrorAction SilentlyContinue).count
+    refreshTokenDate  = (Get-CronNextExecutionTime -Expression '0 0 * * 0').AddDays('-7').tostring('s') -split "T" | Select-Object -First 1
+    exchangeTokenDate = (Get-CronNextExecutionTime -Expression '0 0 * * 0').AddDays('-7').tostring('s') -split "T" | Select-Object -First 1
+    lastLog           = @($SlimRows)
+    alerts            = @($Alerts)
 }
 # Write to the Azure Functions log stream.
  

--- a/GetDashboard/run.ps1
+++ b/GetDashboard/run.ps1
@@ -215,9 +215,9 @@ Log-Request -user $request.headers.'x-ms-client-principal' -API $APINAME  -messa
 $dash = [PSCustomObject]@{
     NextStandardsRun  = (Get-CronNextExecutionTime -Expression '0 */3 * * *').tostring('s')
     NextBPARun        = (Get-CronNextExecutionTime -Expression '0 3 * * *').tostring('s')
-    queuedApps        = [int64](Get-ChildItem '.\ChocoApps.Cache' -ErrorAction SilentlyContinue).count
-    queuedStandards   = [int64](Get-ChildItem '.\Cache_Standards' -ErrorAction SilentlyContinue).count
-    tenantCount       = [int64](Get-Content '.\tenants.cache.json' | ConvertFrom-Json -ErrorAction SilentlyContinue).count
+    QueuedApps        = [int64](Get-ChildItem '.\ChocoApps.Cache' -ErrorAction SilentlyContinue).count
+    QueuedStandards   = [int64](Get-ChildItem '.\Cache_Standards' -ErrorAction SilentlyContinue).count
+    TenantCount       = [int64](Get-Content '.\tenants.cache.json' | ConvertFrom-Json -ErrorAction SilentlyContinue).count
     RefreshTokenDate  = (Get-CronNextExecutionTime -Expression '0 0 * * 0').AddDays('-7').tostring('s') -split "T" | Select-Object -First 1
     ExchangeTokenDate = (Get-CronNextExecutionTime -Expression '0 0 * * 0').AddDays('-7').tostring('s') -split "T" | Select-Object -First 1
     LastLog           = @($SlimRows)

--- a/GetDashboard/run.ps1
+++ b/GetDashboard/run.ps1
@@ -201,8 +201,8 @@ $Rows = Get-AzTableRow -Table $table -PartitionKey $PartitionKey -Top 10 -Select
 $SlimRows = New-Object System.Collections.ArrayList
 foreach ($Row in $Rows) {
     $SlimRows.Add(@{
-        Tenant = $Row.Tenant
-        Message = $Row.Message
+        tenant = $Row.Tenant
+        message = $Row.Message
     })
 }
 $Alerts = [System.Collections.ArrayList]@()

--- a/GetVersion/run.ps1
+++ b/GetVersion/run.ps1
@@ -13,12 +13,12 @@ $RemoteAPIVersion = Invoke-RestMethod -Uri "https://raw.githubusercontent.com/Ke
 $RemoteCIPPVersion = Invoke-RestMethod -Uri "https://raw.githubusercontent.com/KelvinTegelaar/CIPP/master/version_latest.txt"
 
 $version = [PSCustomObject]@{
-    LocalCIPPVersion     = $CIPPVersion
-    RemoteCIPPVersion    = $RemoteCIPPVersion
-    LocalCIPPAPIVersion  = $APIVersion
-    RemoteCIPPAPIVersion = $RemoteAPIVersion
-    OutOfDateCIPP        = ([version]$RemoteCIPPVersion -gt [version]$CIPPVersion)
-    OutOfDateCIPPAPI     = ([version]$RemoteAPIVersion -gt [version]$APIVersion)
+    localCIPPVersion     = $CIPPVersion
+    remoteCIPPVersion    = $RemoteCIPPVersion
+    localCIPPAPIVersion  = $APIVersion
+    remoteCIPPAPIVersion = $RemoteAPIVersion
+    outOfDateCIPP        = ([version]$RemoteCIPPVersion -gt [version]$CIPPVersion)
+    outOfDateCIPPAPI     = ([version]$RemoteAPIVersion -gt [version]$APIVersion)
 }
 # Write to the Azure Functions log stream.
 

--- a/ListUsers/run.ps1
+++ b/ListUsers/run.ps1
@@ -6,7 +6,7 @@ param($Request, $TriggerMetadata)
 $APIName = $TriggerMetadata.FunctionName
 Log-Request -user $request.headers.'x-ms-client-principal' -API $APINAME  -message "Accessed this API" -Sev "Debug"
 
-$selectlist = "id", "accountEnabled", "businessPhones", "city", "createdDateTime", "companyName", "country", "department", "displayName", "faxNumber", "givenName", "isResourceAccount", "jobTitle", "mail", "mailNickname", "mobilePhone", "onPremisesDistinguishedName", "officeLocation", "onPremisesLastSyncDateTime", "otherMails", "postalCode", "preferredDataLocation", "preferredLanguage", "proxyAddresses", "showInAddressList", "state", "streetAddress", "surname", "usageLocation", "userPrincipalName", "userType", "assignedLicenses", "onPremisesSyncEnabled", "LicJoined", "Aliases", "primDomain"
+$selectlist = "id", "accountEnabled", "businessPhones", "city", "createdDateTime", "companyName", "country", "department", "displayName", "faxNumber", "givenName", "isResourceAccount", "jobTitle", "mail", "mailNickname", "mobilePhone", "onPremisesDistinguishedName", "officeLocation", "onPremisesLastSyncDateTime", "otherMails", "postalCode", "preferredDataLocation", "preferredLanguage", "proxyAddresses", "showInAddressList", "state", "streetAddress", "surname", "usageLocation", "userPrincipalName", "userType", "assignedLicenses", "onPremisesSyncEnabled", "licJoined", "aliases", "primDomain"
 
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell HTTP trigger function processed a request."
@@ -16,9 +16,9 @@ $TenantFilter = $Request.Query.TenantFilter
 $userid = $Request.Query.UserID
 $GraphRequest = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users/$($userid)?`$top=999&`$select=$($selectlist -join ',')" -tenantid $TenantFilter | Select-Object $selectlist | ForEach-Object {
     $_.onPremisesSyncEnabled = [bool]($_.onPremisesSyncEnabled)
-    $_.Aliases = $_.Proxyaddresses -join ", "
-    $SkuID = $_.AssignedLicenses.skuid
-    $_.LicJoined = ($ConvertTable | Where-Object { $_.guid -in $skuid }).'Product_Display_Name' -join ", "
+    $_.aliases = $_.proxyAddresses -join ", "
+    $SkuID = $_.assignedLicenses.skuid
+    $_.licJoined = ($ConvertTable | Where-Object { $_.guid -in $skuid }).'Product_Display_Name' -join ", "
     $_.primDomain = ($_.userPrincipalName -split '@' | Select-Object -Last 1)
     $_
 }
@@ -35,11 +35,11 @@ if ($userid) {
         'X-Requested-With'       = 'XMLHttpRequest' 
     }
     $GraphRequest = $GraphRequest | Select-Object *, 
-    @{ Name = 'LastSigninApplication'; Expression = { $LastSignIn.AppDisplayName } },
-    @{ Name = 'LastSigninDate'; Expression = { $($LastSignIn.CreatedDateTime | Out-String) } },
-    @{ Name = 'LastSigninStatus'; Expression = { $LastSignIn.Status.AdditionalDetails } },
-    @{ Name = 'LastSigninResult'; Expression = { if ($LastSignIn.Status.ErrorCode -eq 0) { "Success" } else { "Failure" } } }, 
-    @{ Name = 'LastSigninFailureReason'; Expression = { if ($LastSignIn.Status.ErrorCode -eq 0) { "Sucessfully signed in" } else { $LastSignIn.status.FailureReason } } }
+    @{ Name = 'lastSigninApplication'; Expression = { $LastSignIn.AppDisplayName } },
+    @{ Name = 'lastSigninDate'; Expression = { $($LastSignIn.CreatedDateTime | Out-String) } },
+    @{ Name = 'lastSigninStatus'; Expression = { $LastSignIn.Status.AdditionalDetails } },
+    @{ Name = 'lastSigninResult'; Expression = { if ($LastSignIn.Status.ErrorCode -eq 0) { "Success" } else { "Failure" } } }, 
+    @{ Name = 'lastSigninFailureReason'; Expression = { if ($LastSignIn.Status.ErrorCode -eq 0) { "Sucessfully signed in" } else { $LastSignIn.status.FailureReason } } }
 }
 # Associate values to output bindings by calling 'Push-OutputBinding'.
 Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{


### PR DESCRIPTION
Visual Studio was giving me grief about some of the JSON parameters starting with lower case and others starting with upper case..... in fact, the JSON serialiser in VS is formatting all JSON parameters to start with lower case also, so I guess that is the standard.

But in any case, I know that a mixture of some starting upper case and some starting lower case is not a standard.

Fixed it. Matching commit for the front end as well.