### PR TITLE
made ListSite data consistently report to 2 decimal places

### DIFF
--- a/ListSites/run.ps1
+++ b/ListSites/run.ps1
@@ -29,9 +29,9 @@ try {
     @{ Name = 'displayName'; Expression = { $_.'Owner Display Name' } },
     @{ Name = 'LastActive'; Expression = { $_.'Last Activity Date' } },
     @{ Name = 'FileCount'; Expression = { [int]$_.'File Count' } },
-    @{ Name = 'UsedGB'; Expression = { [math]::round($_.'Storage Used (Byte)' / 1GB, 0) } },
+    @{ Name = 'UsedGB'; Expression = { [math]::round($_.'Storage Used (Byte)' / 1GB, 2) } },
     @{ Name = 'URL'; Expression = { $_.'Site URL' } },
-    @{ Name = 'Allocated'; Expression = { $_.'Storage Allocated (Byte)' / 1GB } },
+    @{ Name = 'Allocated'; Expression = { [math]::round($_.'Storage Allocated (Byte)' / 1GB, 2) } },
     @{ Name = 'Template'; Expression = { $_.'Root Web Template' } }
     $StatusCode = [HttpStatusCode]::OK
 }


### PR DESCRIPTION
A simple remedy. Users with barely any onedrive useage were having "No data" displayed for the % in the UI, and 0GB usage. This is of course incorrect as even if they have 1 single byte used on OneDrive, it is a % albeit a small one, so I feel like "No data" is inappropriate in this case and indeed it is confusing to see no data reported in the UI, it gives the aura of an error when it is not.

In saying that, I have restricted the % to 2 decimal places as this is effectively the norm in AU/US/GB cultures, can't speak for other cultures. I point this out because there are still situations where there are 1 or 2 files only on OneDrive, and they are < 0.01% so they still report as 0, but I don't think we should be entertaining 0.001% shown in the UI, this isn't Bitcoin.