### PR TITLE
Fixing logsToInclude Array

### DIFF
--- a/ListNotificationConfig/run.ps1
+++ b/ListNotificationConfig/run.ps1
@@ -10,7 +10,7 @@ $Table = Get-CIPPTable -TableName SchedulerConfig
 $Filter = "RowKey eq 'CippNotifications' and PartitionKey eq 'CippNotifications'"
 $Config = Get-AzDataTableEntity @Table -Filter $Filter | ConvertTo-Json -Depth 10 | ConvertFrom-Json -depth 10
 $config | Add-Member -NotePropertyValue @() -NotePropertyName 'logsToInclude' -Force
-$config.logsToInclude = ([pscustomobject]$config | Select-Object * -ExcludeProperty schedule, type, tenantid, onepertenant, partitionkey, rowkey, tenant, ETag, email, logsToInclude, timestamp, webhook).psobject.properties.name
+$config.logsToInclude = @(([pscustomobject]$config | Select-Object * -ExcludeProperty schedule, type, tenantid, onepertenant, partitionkey, rowkey, tenant, ETag, email, logsToInclude, timestamp, webhook).psobject.properties.name)
 if (!$config.logsToInclude) {
     $config.logsToInclude = @('None')
 }


### PR DESCRIPTION
If logsToInclude is not null and contains only 1 item it is not an array and generates mapping errors.