### PR TITLE
Update powershell-analysis.yml

### DIFF
--- a/.github/workflows/powershell-analysis.yml
+++ b/.github/workflows/powershell-analysis.yml
@@ -37,6 +37,6 @@ jobs:
       
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Corrected line 40 to use codeql-action/upload-sarif@v2 as upload-sarif@v1 is now deprecated.
See: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/