### PR TITLE
Update run.ps1

### DIFF
--- a/ExecAppApproval/run.ps1
+++ b/ExecAppApproval/run.ps1
@@ -15,7 +15,7 @@ $applicationid = if ($request.query.applicationid) { $request.query.applicationi
 $Results = get-tenants | ForEach-Object {
     [PSCustomObject]@{
         defaultDomainName = $_.defaultDomainName
-        link              = "https://login.microsoftonline.com/$($_.customerId)/v2.0/adminconsent?client_id=$applicationid"
+        link              = "https://login.microsoftonline.com/$($_.customerId)/v2.0/adminconsent?client_id=$applicationid&scope=https://graph.microsoft.com/.default"
     }
 }
 


### PR DESCRIPTION
v2 admin consent URLs require a scope.
Using a static (/.default) value, it will function like the v1.0 admin consent endpoint and request consent for all scopes found in the required permissions