### PR TITLE
SPF record - The domain include himself

### DIFF
--- a/Modules/DNSHealth/1.0.4/DNSHealth.psm1
+++ b/Modules/DNSHealth/1.0.4/DNSHealth.psm1
@@ -1507,24 +1507,31 @@ function Read-SpfRecord {
 
                     # Include mechanism
                     elseif ($Term -match '^(?<Qualifier>[+-~?])?include:(?<Value>.+)$') {
-                        $LookupCount++
-                        Write-Verbose '-----INCLUDE-----'
-                        Write-Verbose "Looking up include $($Matches.Value)"
-                        $IncludeLookup = Read-SpfRecord -Domain $Matches.Value -Level 'Include'
+                        if ($Matches.Value -ne $Domain) {
+                            $LookupCount++
+                            Write-Verbose '-----INCLUDE-----'
+                            Write-Verbose "Looking up include $($Matches.Value)"
+                            $IncludeLookup = Read-SpfRecord -Domain $Matches.Value -Level 'Include'
 
-                        if ([string]::IsNullOrEmpty($IncludeLookup.Record) -and $Level -eq 'Parent') {
-                            Write-Verbose '-----END INCLUDE (SPF MISSING)-----'
-                            $ValidationFails.Add("Include lookup for $($Matches.Value) does not contain a SPF record, this will result in a failure.") | Out-Null
-                            $Status = 'permerror'
+                            if ([string]::IsNullOrEmpty($IncludeLookup.Record) -and $Level -eq 'Parent') {
+                                Write-Verbose '-----END INCLUDE (SPF MISSING)-----'
+                                $ValidationFails.Add("Include lookup for $($Matches.Value) does not contain a SPF record, this will result in a failure.") | Out-Null
+                                $Status = 'permerror'
+                            }
+
+                            else {
+                                Write-Verbose '-----END INCLUDE (SPF FOUND)-----'
+                                $RecordList.Add($IncludeLookup) | Out-Null
+                                $ValidationFails.AddRange([string[]]$IncludeLookup.ValidationFails) | Out-Null
+                                $ValidationWarns.AddRange([string[]]$IncludeLookup.ValidationWarns) | Out-Null
+                                $ValidationPasses.AddRange([string[]]$IncludeLookup.ValidationPasses) | Out-Null
+                                $IPAddresses.AddRange([string[]]$IncludeLookup.IPAddresses) | Out-Null
+                            }
                         }
-
                         else {
-                            Write-Verbose '-----END INCLUDE (SPF FOUND)-----'
-                            $RecordList.Add($IncludeLookup) | Out-Null
-                            $ValidationFails.AddRange([string[]]$IncludeLookup.ValidationFails) | Out-Null
-                            $ValidationWarns.AddRange([string[]]$IncludeLookup.ValidationWarns) | Out-Null
-                            $ValidationPasses.AddRange([string[]]$IncludeLookup.ValidationPasses) | Out-Null
-                            $IPAddresses.AddRange([string[]]$IncludeLookup.IPAddresses) | Out-Null
+                            Write-Verbose "-----END INCLUDE (INFINITE LOOP -> $Domain SHOULD NOT INCLUDE HIMSELF)-----"
+                            $ValidationFails.Add("Include lookup for $($Matches.Value) should not exist. It will cause an infinite loop.") | Out-Null
+                            $Status = 'permerror'
                         }
                     }
 


### PR DESCRIPTION
Hello

I had an issue with function "Read-SpfRecord" with this domain name : littleguestcollection.com
The domain name was included in the SPF record which caused an infinite loop 

![image](https://user-images.githubusercontent.com/53898397/231163819-3afef4ca-64a1-48d3-a8b1-d054897df860.png)

The PR fixes the infinite loop but I'm not sure about the validity of this fix. 

Futhermore, I have a question about the "$LookupCount", do I need to set it to a number greater than 10 (if smaller) ? -> To make sure that the script adds the error "Lookup count: $LookupCount/10. The SPF evaluation will fail with a permanent error (RFC 7208 Section 4.6.4). ? Or it's not required ?
