### PR TITLE
TenantID in Alerts

### DIFF
--- a/GraphHelper.psm1
+++ b/GraphHelper.psm1
@@ -116,7 +116,7 @@ function Get-GraphToken($tenantid, $scope, $AsApp, $AppID, $refreshToken, $Retur
     }
 }
 
-function Write-LogMessage ($message, $tenant = 'None', $API = 'None', $user, $sev) {
+function Write-LogMessage ($message, $tenant = 'None', $API = 'None', $tenantId = 'None', $user, $sev) {
     try {
         $username = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($user)) | ConvertFrom-Json).userDetails
     }
@@ -135,6 +135,7 @@ function Write-LogMessage ($message, $tenant = 'None', $API = 'None', $user, $se
     $PartitionKey = (Get-Date -UFormat '%Y%m%d').ToString()
     $TableRow = @{
         'Tenant'       = [string]$tenant
+        'TenantID'     = [string]$tenantId
         'API'          = [string]$API
         'Message'      = [string]$message
         'Username'     = [string]$username

--- a/Scheduler_Alert/run.ps1
+++ b/Scheduler_Alert/run.ps1
@@ -378,7 +378,7 @@ try {
 
     $ShippedAlerts | ForEach-Object {
         if ($_ -notin $currentlog.Message) {
-            Write-LogMessage -message $_ -API 'Alerts' -tenant $tenant.tenant -sev Alert
+            Write-LogMessage -message $_ -API 'Alerts' -tenant $tenant.tenant -sev Alert -tenantid $Tenant.tenantid
         }
     }
     [PSCustomObject]@{


### PR DESCRIPTION
The following PR is based on an FR I had made in the CIPP repo, https://github.com/KelvinTegelaar/CIPP/issues/1780
FR was rejected, so I attempted it myself.

These changes have achieved the desired result and we get a TenantID field in Alerts now, so I'd like to have these changes included in CIPP-API for others to enjoy.

Note that I made $tenantid in Write-LogMessage an optional param because there's many usages of Write-LogMessage that would need updating to pass a $tenantid in. I've only updated the Alert Scheduler for the time being.

Front end logbook changes will be needed to display tenantid, happy to make a PR for that in the CIPP repo.