### PR TITLE
Fix: Add TenantID to ListLogs

### DIFF
--- a/ListLogs/run.ps1
+++ b/ListLogs/run.ps1
@@ -38,6 +38,11 @@ else {
             Message  = $Row.Message
             User     = $Row.Username
             Severity = $Row.Severity
+            TenantID = if ($Row.TenantID -ne $null) {
+                            $Row.TenantID
+                        } else {
+                            'None'
+                        }
         }
     }
 


### PR DESCRIPTION
This commit wasn't cherry picked in my prior PR by mistake.

This fixes:
- The missing Selector for filtering on the frontend
- TenantIDs not appearing at all in the logbook

The check for $null is so that things look nicer on the frontend - if we fed nulls through, CippDataTable would render as No Data if we unselected/reselected the column. This way we feed in a 'None' string if it's $null, which looks much nicer.

![image](https://github.com/KelvinTegelaar/CIPP-API/assets/7742139/c2e88df3-2439-4b5b-999e-b4b1263c4190)
