### PR TITLE
Fix being unable to remove Exchange connectors

### DIFF
--- a/Modules/CIPPCore/Public/Invoke-RemoveExConnector.ps1
+++ b/Modules/CIPPCore/Public/Invoke-RemoveExConnector.ps1
@@ -11,19 +11,15 @@ Function Invoke-RemoveExConnector {
     $APIName = $TriggerMetadata.FunctionName
     Write-LogMessage -user $request.headers.'x-ms-client-principal' -API $APINAME -message 'Accessed this API' -Sev 'Debug'
     $Tenantfilter = $request.Query.tenantfilter
-
-
-    $Params = @{
-        Identity = $request.query.guid
-    }
-
+    
     try {
+        
         $Params = @{ Identity = $request.query.GUID }
-
-        $GraphRequest = New-ExoRequest -tenantid $Tenantfilter -cmdlet "Remove-$($Request.query.Type)Connector" -cmdParams $params
+        $GraphRequest = New-ExoRequest -tenantid $Tenantfilter -cmdlet "Remove-$($Request.query.Type)Connector" -cmdParams $params -useSystemMailbox $true
         $Result = "Deleted $($Request.query.guid)"
         Write-LogMessage -API 'TransportRules' -tenant $tenantfilter -message "Deleted transport rule $($Request.query.guid)" -sev Debug
-    } catch {
+    }
+    catch {
         $ErrorMessage = Get-NormalizedError -Message $_.Exception
         $Result = $ErrorMessage
     }


### PR DESCRIPTION
Fixes Exhange connectors not being able to be removed. 
Throws the following errors:  
1. System.Management.Automation.RuntimeException: |Microsoft.Exchange.Data.Directory.ADServerSettingsChangedException|An error caused a change in the current set of domain controllers.  2. System.Management.Automation.RuntimeException: |Microsoft.Exchange.Data.Directory.InsufficientPermissionsException|Source server:FR6P281MB3483.DEUP281.PROD.OUTLOOK.COM doesn't have write permission to target DC:. Usually it indicates that target forest isn't an account partition of source forest. The user has insufficient access rights.