### PR TITLE
Correct Detection rules ninjarmm.app.json

### DIFF
--- a/AddMSPApp/ninjarmm.app.json
+++ b/AddMSPApp/ninjarmm.app.json
@@ -19,8 +19,8 @@
   "detectionRules": [
     {
       "@odata.type": "#microsoft.graph.win32LobAppFileSystemDetection",
-      "path": "%ProgramData%\\Syncro\\Bin",
-      "fileOrFolderName": "Syncro.Overmind.Service.exe",
+      "path": "%ProgramData%\\NinjaRMMAgent",
+      "fileOrFolderName": "ninjarmm-cli.exe",
       "check32BitOn64System": false,
       "detectionType": "exists"
     }


### PR DESCRIPTION
The detection rules for NinjaRMM where looking for Syncro instead, updated to detect ninjarmm-cli.exe instead