### PR TITLE
Improve calDefaults speed

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
@@ -6,7 +6,7 @@ function Invoke-CIPPStandardDisableGuests {
     param($Tenant, $Settings)
     $lookup = (Get-Date).AddDays(-90).ToUniversalTime().ToString('o')
     $GraphRequest = New-GraphgetRequest -uri "https://graph.microsoft.com/beta/users?`$filter=(signInActivity/lastSignInDateTime le $lookup)&`$select=id,UserPrincipalName,signInActivity,mail,userType,accountEnabled" -scope 'https://graph.microsoft.com/.default' -tenantid $Tenant | Where-Object { $_.userType -EQ 'Guest' -and $_.AccountEnabled -EQ $true }
-         
+
     If ($Settings.remediate) {
         try {
             foreach ($guest in $GraphRequest) {

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
@@ -9,18 +9,41 @@ function Invoke-CIPPStandardcalDefault {
         $Mailboxes = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-Mailbox'
 
         # BRRRRRRRRRR
-        $Mailboxes | ForEach-Object -ThrottleLimit 15 -Parallel {
+        $Mailboxes | ForEach-Object -ThrottleLimit 25 -Parallel {
             Import-Module CIPPcore
             $Tenant = $Using:Tenant
             $Settings = $Using:Settings
             $Mailbox = $_
             try {
-                New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MailboxFolderStatistics' -cmdParams @{identity = $Mailbox.UserPrincipalName; FolderScope = 'Calendar' } -Anchor $Mailbox.UserPrincipalName | 
-                    # Set permissions for each calendar found
-                    Where-Object { $_.FolderType -eq 'Calendar' } | ForEach-Object {
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'Set-MailboxFolderPermission' -cmdparams @{Identity = "$($Mailbox.UserPrincipalName):$($_.FolderId)"; User = 'Default'; AccessRights = $Settings.permissionlevel } -Anchor $Mailbox.UserPrincipalName 
-                        Write-LogMessage -API 'Standards' -tenant $tenant -message "Set default folder permission for $($Mailbox.UserPrincipalName):\$($_.Name) to $($Settings.permissionlevel)" -sev Info 
-                    }
+                $GetRetryCount = 0
+                
+                do {
+                    # Get all calendars for the mailbox, retry if it fails
+                    try {
+                        New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MailboxFolderStatistics' -cmdParams @{identity = $Mailbox.UserPrincipalName; FolderScope = 'Calendar' } -Anchor $Mailbox.UserPrincipalName | 
+                            # Set permissions for each calendar found
+                            Where-Object { $_.FolderType -eq 'Calendar' } | ForEach-Object {
+                                $SetRetryCount = 0
+                                do {
+                                    try {
+                                        New-ExoRequest -tenantid $Tenant -cmdlet 'Set-MailboxFolderPermission' -cmdparams @{Identity = "$($Mailbox.UserPrincipalName):$($_.FolderId)"; User = 'Default'; AccessRights = $Settings.permissionlevel } -Anchor $Mailbox.UserPrincipalName 
+                                        Write-LogMessage -API 'Standards' -tenant $tenant -message "Set default folder permission for $($Mailbox.UserPrincipalName):\$($_.Name) to $($Settings.permissionlevel)" -sev Info 
+                                        $SetRetryCount = 3
+                                    } catch {
+                                        # Set part
+                                        Start-Sleep -Milliseconds 250
+                                        $SetRetryCount++
+                                    }
+                                } Until ($SetRetryCount -ge 3 )
+                            }
+                            $GetRetryCount = 3
+                        } catch {
+                            # Get part
+                            Start-Sleep -Milliseconds 250
+                            $GetRetryCount++
+                        }
+
+                    } until ($GetRetryCount -ge 3)
                 } catch {
                     Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not set default calendar permissions for $($Mailbox.UserPrincipalName). Error: $($_.exception.message)" -sev Error
                 }        

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
@@ -5,21 +5,24 @@ function Invoke-CIPPStandardcalDefault {
     #>
     param($Tenant, $Settings)
     If ($Settings.remediate) {
+
         $Mailboxes = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-Mailbox'
-        foreach ($Mailbox in $Mailboxes) {
-            try {
+        try {
+            # BRRRRRRRRRR
+            $Mailboxes | ForEach-Object -ThrottleLimit 25 -Parallel {
+                Import-Module CIPPcore
+                $Tenant = $Using:Tenant
+                $Settings = $Using:Settings
+                $Mailbox = $_
+                
                 New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MailboxFolderStatistics' -cmdParams @{identity = $Mailbox.UserPrincipalName; FolderScope = 'Calendar' } -Anchor $Mailbox.UserPrincipalName | Where-Object { $_.FolderType -eq 'Calendar' } | ForEach-Object {
                     New-ExoRequest -tenantid $Tenant -cmdlet 'Set-MailboxFolderPermission' -cmdparams @{Identity = "$($Mailbox.UserPrincipalName):$($_.FolderId)"; User = 'Default'; AccessRights = $Settings.permissionlevel } -Anchor $Mailbox.UserPrincipalName 
-                    Write-LogMessage -API 'Standards' -tenant $tenant -message "Set default folder permission for $($Mailbox.UserPrincipalName):\$($_.Name) to $($Settings.permissionlevel)" -sev Info
-                }
+                    Write-LogMessage -API 'Standards' -tenant $tenant -message "Set default folder permission for $($Mailbox.UserPrincipalName):\$($_.Name) to $($Settings.permissionlevel)" -sev Info }
             }
-            catch {
-                Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not set default calendar permissions for $($Mailbox.UserPrincipalName). Error: $($_.exception.message)" -sev Error
-            }
-            
-        }
+        } catch {
+            Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not set default calendar permissions for $($Mailbox.UserPrincipalName). Error: $($_.exception.message)" -sev Error
+        }        
         Write-LogMessage -API 'Standards' -tenant $tenant -message 'Done setting default calendar permissions.' -sev Info
-
     }
 
 }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
@@ -5,10 +5,11 @@ function Invoke-CIPPStandardcalDefault {
     #>
     param($Tenant, $Settings)
     If ($Settings.remediate) {
-
         $Mailboxes = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-Mailbox'
+        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Started setting default calendar permissions for $($Mailboxes.Count) mailboxes." -sev Info
 
         # BRRRRRRRRRR
+        $global:UserSuccesses = 0
         $Mailboxes | ForEach-Object -ThrottleLimit 25 -Parallel {
             Import-Module CIPPcore
             $Tenant = $Using:Tenant
@@ -27,28 +28,29 @@ function Invoke-CIPPStandardcalDefault {
                                 do {
                                     try {
                                         New-ExoRequest -tenantid $Tenant -cmdlet 'Set-MailboxFolderPermission' -cmdparams @{Identity = "$($Mailbox.UserPrincipalName):$($_.FolderId)"; User = 'Default'; AccessRights = $Settings.permissionlevel } -Anchor $Mailbox.UserPrincipalName 
-                                        Write-LogMessage -API 'Standards' -tenant $tenant -message "Set default folder permission for $($Mailbox.UserPrincipalName):\$($_.Name) to $($Settings.permissionlevel)" -sev Info 
-                                        $SetRetryCount = 3
+                                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Set default folder permission for $($Mailbox.UserPrincipalName):\$($_.Name) to $($Settings.permissionlevel)" -sev Debug 
+                                        $Success = $true
                                     } catch {
                                         # Set part
                                         Start-Sleep -Milliseconds 250
                                         $SetRetryCount++
                                     }
-                                } Until ($SetRetryCount -ge 3 )
+                                } Until ($SetRetryCount -ge 3 -or $Success -eq $true)
                             }
-                            $GetRetryCount = 3
+                            $Success = $true
+                            $global:UserSuccesses++
                         } catch {
                             # Get part
                             Start-Sleep -Milliseconds 250
                             $GetRetryCount++
                         }
 
-                    } until ($GetRetryCount -ge 3)
+                    } until ($GetRetryCount -ge 3 -or $Success -eq $true)
                 } catch {
-                    Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not set default calendar permissions for $($Mailbox.UserPrincipalName). Error: $($_.exception.message)" -sev Error
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Could not set default calendar permissions for $($Mailbox.UserPrincipalName). Error: $($_.exception.message)" -sev Error
                 }        
             }
-            Write-LogMessage -API 'Standards' -tenant $tenant -message 'Done setting default calendar permissions.' -sev Info
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Done setting default calendar permissions for $global:UserSuccesses out of $($Mailboxes.Count) mailboxes." -sev Info
 
         }
     }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
@@ -7,22 +7,25 @@ function Invoke-CIPPStandardcalDefault {
     If ($Settings.remediate) {
 
         $Mailboxes = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-Mailbox'
-        try {
-            # BRRRRRRRRRR
-            $Mailboxes | ForEach-Object -ThrottleLimit 25 -Parallel {
-                Import-Module CIPPcore
-                $Tenant = $Using:Tenant
-                $Settings = $Using:Settings
-                $Mailbox = $_
-                
-                New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MailboxFolderStatistics' -cmdParams @{identity = $Mailbox.UserPrincipalName; FolderScope = 'Calendar' } -Anchor $Mailbox.UserPrincipalName | Where-Object { $_.FolderType -eq 'Calendar' } | ForEach-Object {
-                    New-ExoRequest -tenantid $Tenant -cmdlet 'Set-MailboxFolderPermission' -cmdparams @{Identity = "$($Mailbox.UserPrincipalName):$($_.FolderId)"; User = 'Default'; AccessRights = $Settings.permissionlevel } -Anchor $Mailbox.UserPrincipalName 
-                    Write-LogMessage -API 'Standards' -tenant $tenant -message "Set default folder permission for $($Mailbox.UserPrincipalName):\$($_.Name) to $($Settings.permissionlevel)" -sev Info }
-            }
-        } catch {
-            Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not set default calendar permissions for $($Mailbox.UserPrincipalName). Error: $($_.exception.message)" -sev Error
-        }        
-        Write-LogMessage -API 'Standards' -tenant $tenant -message 'Done setting default calendar permissions.' -sev Info
-    }
 
-}
+        # BRRRRRRRRRR
+        $Mailboxes | ForEach-Object -ThrottleLimit 15 -Parallel {
+            Import-Module CIPPcore
+            $Tenant = $Using:Tenant
+            $Settings = $Using:Settings
+            $Mailbox = $_
+            try {
+                New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MailboxFolderStatistics' -cmdParams @{identity = $Mailbox.UserPrincipalName; FolderScope = 'Calendar' } -Anchor $Mailbox.UserPrincipalName | 
+                    # Set permissions for each calendar found
+                    Where-Object { $_.FolderType -eq 'Calendar' } | ForEach-Object {
+                        New-ExoRequest -tenantid $Tenant -cmdlet 'Set-MailboxFolderPermission' -cmdparams @{Identity = "$($Mailbox.UserPrincipalName):$($_.FolderId)"; User = 'Default'; AccessRights = $Settings.permissionlevel } -Anchor $Mailbox.UserPrincipalName 
+                        Write-LogMessage -API 'Standards' -tenant $tenant -message "Set default folder permission for $($Mailbox.UserPrincipalName):\$($_.Name) to $($Settings.permissionlevel)" -sev Info 
+                    }
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not set default calendar permissions for $($Mailbox.UserPrincipalName). Error: $($_.exception.message)" -sev Error
+                }        
+            }
+            Write-LogMessage -API 'Standards' -tenant $tenant -message 'Done setting default calendar permissions.' -sev Info
+
+        }
+    }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
@@ -54,7 +54,7 @@ function Invoke-CIPPStandardcalDefault {
                     Write-LogMessage -API 'Standards' -tenant $Tenant -message "Could not set default calendar permissions for $($Mailbox.UserPrincipalName). Error: $($_.exception.message)" -sev Error
                 }        
             }
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Done setting default calendar permissions for $($UserSuccesses.Counter) out of $($Mailboxes.Count) mailboxes." -sev Info
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Successfully set default calendar permissions for $($UserSuccesses.Counter) out of $($Mailboxes.Count) mailboxes." -sev Info
 
         }
     }


### PR DESCRIPTION
Changed to use -Parallel ForEach-Object. Should be around 20 times faster now.
Retries 3 times on failures.
Changed individual logging of sucesses to be debug. 
Added a started processing X mailboxes and done processing X out of X mailboxes.