### PR TITLE
Fix SharePointQuota casing issue

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-ListAlertsQueue.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-ListAlertsQueue.ps1
@@ -37,7 +37,7 @@ Function Invoke-ListAlertsQueue {
             DepTokenExpiry    = [bool]$QueueFile.DepTokenExpiry
             NoCAConfig        = [bool]$QueueFile.NoCAConfig
             SecDefaultsUpsell = [bool]$QueueFile.SecDefaultsUpsell
-            SharepointQuota   = [bool]$QueueFile.SharePointQuota
+            SharePointQuota   = [bool]$QueueFile.SharePointQuota
             ExpiringLicenses  = [bool]$QueueFile.ExpiringLicenses
             tenantId          = $QueueFile.tenantid
         }


### PR DESCRIPTION
The front end does not accurately display "Alert on 90% SharePoint quota used" when enabled due to a casing issue in ListAlertsQueue.