### PR TITLE
Update display names for multi-factor authentication and block legacy authentication + change to his all cloud apps

### DIFF
--- a/Config/49a8069e-3b46-4680-a035-9250bc675446.CATemplate.json
+++ b/Config/49a8069e-3b46-4680-a035-9250bc675446.CATemplate.json
@@ -37,5 +37,5 @@
       "excludeApplications": []
     }
   },
-  "displayName": "Enforce Multi factor authentication for each application"
+  "displayName": "CIPP: Enforce Multi factor authentication for each application"
 }

--- a/Config/cba836bb-33b7-4c50-88be-ee80f74cbeac.CATemplate.json
+++ b/Config/cba836bb-33b7-4c50-88be-ee80f74cbeac.CATemplate.json
@@ -32,5 +32,5 @@
     "times": null,
     "clientApplications": null
   },
-  "displayName": "Enforce Multi-factor authentication for Static Web Apps"
+  "displayName": "CIPP: Enforce Multi-factor authentication for Static Web Apps"
 }

--- a/Config/f8be7e58-2419-40a8-a739-714bf5deff90.CATemplate.json
+++ b/Config/f8be7e58-2419-40a8-a739-714bf5deff90.CATemplate.json
@@ -26,11 +26,11 @@
     "platforms": null,
     "clientApplications": null,
     "applications": {
-      "includeApplications": ["None"],
+      "includeApplications": ["All"],
       "includeUserActions": [],
       "includeAuthenticationContextClassReferences": [],
       "excludeApplications": []
     }
   },
-  "displayName": "Block Legacy Authentication"
+  "displayName": "CIPP: Block Legacy Authentication"
 }


### PR DESCRIPTION
This pull request updates the display names for multi-factor authentication and block legacy authentication. The display names have been changed to include the prefix "CIPP" 
Change block legacy authentication to hit all cloud apps