### PR TITLE
adds check for basic complexity requirements to New-passwordstring

### DIFF
--- a/Modules/CIPPCore/Public/GraphHelper/New-passwordString.ps1
+++ b/Modules/CIPPCore/Public/GraphHelper/New-passwordString.ps1
@@ -13,6 +13,23 @@ function New-passwordString {
         $Words = Get-Content .\words.txt
         (Get-Random -InputObject $words -Count 4) -join '-'
     } else {
-        -join ('abcdefghkmnrstuvwxyzABCDEFGHKLMNPRSTUVWXYZ23456789$%&*#'.ToCharArray() | Get-Random -Count $count)
+        # Generate a complex password with a maximum of 100 tries
+        $maxTries = 100
+        $tryCount = 0
+
+        do {
+            $Password = -join ('abcdefghkmnrstuvwxyzABCDEFGHKLMNPRSTUVWXYZ23456789$%&*#'.ToCharArray() | Get-Random -Count $count)
+
+            $containsUppercase = $Password -cmatch '[A-Z]'
+            $containsLowercase = $Password -cmatch '[a-z]'
+            $containsDigit = $Password -cmatch '\d'
+            $containsSpecialChar = $Password -cmatch "[$%&*#]"
+
+            $isComplex = $containsUppercase -and $containsLowercase -and $containsDigit -and $containsSpecialChar
+
+            $tryCount++
+        } while (!$isComplex -and ($tryCount -lt $maxTries))
+
+        $Password
     }
 }


### PR DESCRIPTION
Previously New-passwordstring had no checks for complexity requirements. This causes random failures on Invoke-AddUser and others.

Rather than overengineering password generation, it will simply check if the random password is complex and retry up to a max count of 100. In testing almost all requests find a complex password within 10 tries.