### PR TITLE
Add more URLs to whitelist

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-PublicPhishingCheck.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-PublicPhishingCheck.ps1
@@ -13,8 +13,10 @@ Function Invoke-PublicPhishingCheck {
     $validList = @(
         'https://login.microsoftonline.com',
         'https://login.microsoft.net',
-        'https://login.microsoft.com'
-        'https://autologon.microsoftazuread-sso.com'
+        'https://login.microsoft.com',
+        'https://autologon.microsoftazuread-sso.com',
+        'https://tasks.office.com',
+        'https://login.windows.net'
     )
 
     $matchedUrls = $validList | Where-Object { ([uri]$_).Host -in ([uri]$($request.headers.Referer)).Host }


### PR DESCRIPTION
Zolder made a follow up post where they identified a few extra locations that can trigger branding. https://zolder.io/microsoft-365-aitm-detection-the-lessons-learned/