### PR TITLE
Update BarracudaESS.json to allow non-US sending domains

### DIFF
--- a/Modules/DNSHealth/1.0.7/MailProviders/BarracudaESS.json
+++ b/Modules/DNSHealth/1.0.7/MailProviders/BarracudaESS.json
@@ -3,7 +3,7 @@
     "_MxComment": "https://campus.barracuda.com/product/essentials/doc/86545480/step-2-configure-office-365-for-inbound-and-outbound-mail/",
     "MxMatch": "ess(?<Country>.[a-z]{2})?.barracudanetworks.com",
     "_SpfComment": "https://campus.barracuda.com/product/essentials/doc/73702276/sender-policy-framework-for-outbound-mail",
-    "SpfInclude": "spf.ess{0}.barracudanetworks.com",
+    "SpfInclude": "spf.ess.(uk.|au.|ca.|de.)?barracudanetworks.com",
     "SpfReplace": ["Country"],
     "_DkimComment": "No configuration found",
     "Selectors": [""]


### PR DESCRIPTION
Currently Baracuda ESS is showing as failing on our UK Barracuda SPF records despite them looking ok. The changed line looks more like what is described at https://campus.barracuda.com/product/emailgatewaydefense/doc/96022990/how-to-configure-sender-policy-framework/

I am unsure how the Country replace works though, possibly that is a better way than listing those four codes like I have ?