### PR TITLE
API fixes

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-ListScheduledItems.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-ListScheduledItems.ps1
@@ -11,7 +11,10 @@ Function Invoke-ListScheduledItems {
     # Write to the Azure Functions log stream.
     Write-Host 'PowerShell HTTP trigger function processed a request.'
     $Table = Get-CIPPTable -TableName 'ScheduledTasks'
-    $ScheduledTasks = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'ScheduledTask' and Hidden ne 'True'"
+    $ScheduledTasks = foreach ($Task in Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'ScheduledTask' and Hidden ne 'True'") {
+        $Task.Parameters = $Task.Parameters | ConvertFrom-Json
+        $Task
+    }
 
     # Associate values to output bindings by calling 'Push-OutputBinding'.
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{

--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-ListWebhookAlert.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-ListWebhookAlert.ps1
@@ -11,12 +11,14 @@ Function Invoke-ListWebhookAlert {
     $APIName = $TriggerMetadata.FunctionName
     Write-LogMessage -user $request.headers.'x-ms-client-principal' -API $APINAME -message 'Accessed this API' -Sev 'Debug'
     $Table = get-cipptable -TableName 'SchedulerConfig'
-    $WebhookRow = Get-CIPPAzDataTableEntity @Table | Where-Object -Property PartitionKey -EQ 'WebhookAlert' 
-    
+    $WebhookRow = foreach ($Webhook in Get-CIPPAzDataTableEntity @Table | Where-Object -Property PartitionKey -EQ 'WebhookAlert') {
+        $Webhook.If = $Webhook.If | ConvertFrom-Json
+        $Webhook.execution = $Webhook.execution | ConvertFrom-Json
+        $Webhook
+    }
+
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
             StatusCode = [HttpStatusCode]::OK
             Body       = @($WebhookRow)
         })
-
-
 }

--- a/Modules/CIPPCore/Public/Invoke-CIPPStandardsRun.ps1
+++ b/Modules/CIPPCore/Public/Invoke-CIPPStandardsRun.ps1
@@ -78,7 +78,7 @@ function Invoke-CIPPStandardsRun {
 
     #For each item in our object, run the queue.
 
-    $Batch = foreach ($task in $object | Where-Object -Property Standard -NotLike 'v2*') {
+    $Batch = foreach ($task in $object | Where-Object { $_.Standard -NotLike 'v2*' -and ($_.Settings.remediate -eq $true -or $_.Settings.alert -eq $true -or $_.Settings.report -eq $true) }) {
         [PSCustomObject]@{
             Tenant       = $task.Tenant
             Standard     = $task.Standard

--- a/Scheduler_GetWebhooks/run.ps1
+++ b/Scheduler_GetWebhooks/run.ps1
@@ -2,12 +2,24 @@ param($Timer)
 
 $Table = Get-CIPPTable -TableName WebhookIncoming
 $Webhooks = Get-CIPPAzDataTableEntity @Table
-$InputObject = [PSCustomObject]@{
-    OrchestratorName = 'WebhookOrchestrator'
-    Batch            = @($Webhooks)
-    SkipLog          = $true
+$WebhookCount = ($Webhooks | Measure-Object).Count
+$Message = 'Processing {0} webhooks' -f $WebhookCount
+Write-LogMessage -API 'Webhooks' -message $Message -sev Info
+
+try {
+    for ($i = 0; $i -lt $WebhookCount; $i += 2500) {
+        $WebhookBatch = $Webhooks[$i..($i + 2499)]
+        $InputObject = [PSCustomObject]@{
+            OrchestratorName = 'WebhookOrchestrator'
+            Batch            = @($WebhookBatch)
+            SkipLog          = $true
+        }
+        #Write-Host ($InputObject | ConvertTo-Json)
+        $InstanceId = Start-NewOrchestration -FunctionName 'CIPPOrchestrator' -InputObject ($InputObject | ConvertTo-Json -Depth 5)
+        Write-Host "Started orchestration with ID = '$InstanceId'"
+    }
+} catch {
+    Write-LogMessage -API 'Webhooks' -message "Error processing webhooks - $($_.Exception.Message)" -sev Error
+} finally {
+    Write-LogMessage -API 'Webhooks' -message 'Webhook processing completed' -sev Info
 }
-#Write-Host ($InputObject | ConvertTo-Json)
-$InstanceId = Start-NewOrchestration -FunctionName 'CIPPOrchestrator' -InputObject ($InputObject | ConvertTo-Json -Depth 5)
-Write-Host "Started orchestration with ID = '$InstanceId'"
-#$Orchestrator = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId


### PR DESCRIPTION
- Limit standards to only ones with at least one setting enabled
- Convert alert rules and scheduler to json objects instead of strings for better display
- Batch webhooks to groups of 2500 for each orchestrator