### PR TITLE
AtpPolicyForO365 Standard

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAtpPolicyForO365.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAtpPolicyForO365.ps1
@@ -9,8 +9,8 @@ function Invoke-CIPPStandardAtpPolicyForO365 {
     Select-Object EnableATPForSPOTeamsODB, EnableSafeDocs, AllowSafeDocsOpen
 
     $StateIsCorrect = if (
-        ($AtpPolicyForO365State.EnableATPForSPOTeamsODB -eq $Settings.EnableATPForSPOTeamsODB) -and
-        ($AtpPolicyForO365State.EnableSafeDocs -eq $Settings.EnableSafeDocs) -and
+        ($AtpPolicyForO365State.EnableATPForSPOTeamsODB -eq $true) -and
+        ($AtpPolicyForO365State.EnableSafeDocs -eq $true) -and
         ($AtpPolicyForO365State.AllowSafeDocsOpen -eq $Settings.AllowSafeDocsOpen)
     ) { $true } else { $false }
 
@@ -19,8 +19,8 @@ function Invoke-CIPPStandardAtpPolicyForO365 {
             Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Atp Policy For O365 already set.' -sev Info
         } else {
             $cmdparams = @{
-                EnableATPForSPOTeamsODB = $Settings.EnableATPForSPOTeamsODB
-                EnableSafeDocs = $Settings.EnableSafeDocs
+                EnableATPForSPOTeamsODB = $true
+                EnableSafeDocs = $true
                 AllowSafeDocsOpen = $Settings.AllowSafeDocsOpen
             }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAtpPolicyForO365.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAtpPolicyForO365.ps1
@@ -1,0 +1,49 @@
+function Invoke-CIPPStandardAtpPolicyForO365 {
+    <#
+    .FUNCTIONALITY
+    Internal
+    #>
+
+    param($Tenant, $Settings)
+    $AtpPolicyForO365State = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AtpPolicyForO365' | 
+    Select-Object EnableATPForSPOTeamsODB, EnableSafeDocs, AllowSafeDocsOpen
+
+    $StateIsCorrect = if (
+        ($AtpPolicyForO365State.EnableATPForSPOTeamsODB -eq $Settings.EnableATPForSPOTeamsODB) -and
+        ($AtpPolicyForO365State.EnableSafeDocs -eq $Settings.EnableSafeDocs) -and
+        ($AtpPolicyForO365State.AllowSafeDocsOpen -eq $Settings.AllowSafeDocsOpen)
+    ) { $true } else { $false }
+
+    if ($Settings.remediate) {
+        if ($StateIsCorrect) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Atp Policy For O365 already set.' -sev Info
+        } else {
+            $cmdparams = @{
+                EnableATPForSPOTeamsODB = $Settings.EnableATPForSPOTeamsODB
+                EnableSafeDocs = $Settings.EnableSafeDocs
+                AllowSafeDocsOpen = $Settings.AllowSafeDocsOpen
+            }
+
+            try {
+                New-ExoRequest -tenantid $Tenant -cmdlet 'Set-AntiPhishPolicy' -cmdparams $cmdparams
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Updated Atp Policy For O365' -sev Info
+            } catch {
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to set Atp Policy For O365. Error: $($_.exception.message)" -sev Error
+            }
+        }
+    }
+
+    if ($Settings.alert) {
+
+        if ($StateIsCorrect) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Atp Policy For O365 is enabled' -sev Info
+        } else {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Atp Policy For O365 is not enabled' -sev Alert
+        }
+    }
+
+    if ($Settings.report) {
+        Add-CIPPBPAField -FieldName 'AtpPolicyForO365' -FieldValue [bool]$StateIsCorrect -StoreAs bool -Tenant $tenant
+    }
+    
+}


### PR DESCRIPTION
This PR is pretty straight forward

```
{
    "name": "standards.AtpPolicyForO365",
    "cat": "Defender Standards",
    "tag": ["lowimpact", "CIS"],
    "helpText": "Safe Attachments for SharePoint, OneDrive, and Microsoft Teams",
    "addedComponent": [
      {
        "type": "boolean",
        "label": "Defender for Office 365 for SharePoint, OneDrive, and Microsoft Teams",
        "name": "standards.AtpPolicyForO365.EnableATPForSPOTeamsODB",
        "default": true
      },
      {
        "type": "boolean",
        "label": "Safe Documents for Office clients.",
        "name": "standards.AtpPolicyForO365.EnableSafeDocs",
        "default": true
      },
      {
        "type": "boolean",
        "label": "Allow people to click through Protected View even if Safe Documents identified the file as malicious",
        "name": "standards.AtpPolicyForO365.AllowSafeDocsOpen",
        "default": false
      }
    ],
    "label": "Atp Policy For O365",
    "impact": "Low Impact",
    "impactColour": "info"
  },
```
![image](https://github.com/KelvinTegelaar/CIPP-API/assets/15158490/ecf522ac-d75d-4463-87c9-fd2f48afe4d9)
