### PR TITLE
chore: Speed up Safe Senders standard with reduced $Mailboxes response

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSafeSendersDisable.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSafeSendersDisable.ps1
@@ -7,7 +7,7 @@ function Invoke-CIPPStandardSafeSendersDisable {
 
     If ($Settings.remediate -eq $true) {
         try {
-            $Mailboxes = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-Mailbox'
+            $Mailboxes = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-Mailbox' -select 'UserPrincipalName'
             $Request = $Mailboxes | ForEach-Object {
                 @{
                     CmdletInput = @{


### PR DESCRIPTION
Dev instance is ~65% faster at this standard after these changes and https://github.com/KelvinTegelaar/CIPP-API/pull/798