### PR TITLE
SharePoint Admin URL Fix

### DIFF
--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertSharepointQuota.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertSharepointQuota.ps1
@@ -12,7 +12,7 @@ function Get-CIPPAlertSharepointQuota {
         $TenantFilter
     )
     Try {
-        $tenantName = (New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/domains' -tenantid $TenantFilter | Where-Object { $_.isInitial -eq $true }).id.Split('.')[0]
+        $tenantName = (New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/sites/root' -tenantid $TenantFilter).id.Split('.')[0]
         $sharepointToken = (Get-GraphToken -scope "https://$($tenantName)-admin.sharepoint.com/.default" -tenantid $TenantFilter)
         $sharepointToken.Add('accept', 'application/json')
         $sharepointQuota = (Invoke-RestMethod -Method 'GET' -Headers $sharepointToken -Uri "https://$($tenantName)-admin.sharepoint.com/_api/StorageQuotas()?api-version=1.3.2" -ErrorAction Stop).value

--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-ListSharepointQuota.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-ListSharepointQuota.ps1
@@ -23,7 +23,7 @@ Function Invoke-ListSharepointQuota {
         $UsedStoragePercentage = 'Not Supported'
     } else {
         try {
-            $tenantName = (New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/domains' -tenantid $TenantFilter | Where-Object { $_.isInitial -eq $true }).id.Split('.')[0]
+            $tenantName = (New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/sites/root' -tenantid $TenantFilter).id.Split('.')[0]
 
             $sharepointToken = (Get-GraphToken -scope "https://$($tenantName)-admin.sharepoint.com/.default" -tenantid $TenantFilter)
             $sharepointToken.Add('accept', 'application/json')

--- a/Modules/CIPPCore/Public/Set-CIPPSharePointPerms.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPSharePointPerms.ps1
@@ -19,8 +19,8 @@ function Set-CIPPSharePointPerms {
     if (!$URL) {
       $URL = (New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/users/$($UserId)/Drives" -asapp $true -tenantid $TenantFilter).WebUrl
     }
-    $OnMicrosoft = (New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/domains?$top=999' -tenantid $TenantFilter | Where-Object -Property isInitial -EQ $true).id.split('.') | Select-Object -First 1
-    $AdminUrl = "https://$($OnMicrosoft)-admin.sharepoint.com"
+    $tenantName = (New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/sites/root' -tenantid $TenantFilter).id.Split('.')[0]
+    $AdminUrl = "https://$($tenantName)-admin.sharepoint.com"
     $XML = @"
 <Request xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009" AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName=".NET Library">
   <Actions>

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableAddShortcutsToOneDrive.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableAddShortcutsToOneDrive.ps1
@@ -60,9 +60,8 @@ function Invoke-CIPPStandardDisableAddShortcutsToOneDrive {
         }
 
         try {
-            $OnMicrosoft = (New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/domains?$top=999' -tenantid $tenant |
-                    Where-Object -Property isInitial -EQ $true).id.split('.') | Select-Object -First 1
-            $AdminUrl = "https://$($OnMicrosoft)-admin.sharepoint.com"
+            $tenantName = (New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/sites/root' -tenantid $TenantFilter).id.Split('.')[0]
+            $AdminUrl = "https://$($tenantName)-admin.sharepoint.com"
             $graphRequest = @{
                 'scope'       = "$AdminURL/.default"
                 'tenantid'    = $tenant


### PR DESCRIPTION
After an Advanced Tenant Rename, the admin SharePoint URL changes and is no longer the initial domain. I changed the way in which the admin URL is crafted.

- Fixed merge conflict