### PR TITLE
Add-CIPPDelegatedPermission: Ignore app permissions

### DIFF
--- a/Modules/CIPPCore/Public/Add-CIPPDelegatedPermission.ps1
+++ b/Modules/CIPPCore/Public/Add-CIPPDelegatedPermission.ps1
@@ -25,7 +25,8 @@ function Add-CIPPDelegatedPermission {
     foreach ($App in $requiredResourceAccess) {
         $svcPrincipalId = $ServicePrincipalList | Where-Object -Property AppId -EQ $App.resourceAppId
         if (!$svcPrincipalId) { continue }
-        $NewScope = ($Translator | Where-Object { $_.id -in $App.ResourceAccess.id }).value -join ' '
+        $Scopes = $App.ResourceAccess | Where-Object -Property Type -EQ 'Scope'
+        $NewScope = ($Translator | Where-Object { $_.id -in $Scopes.id }).value -join ' '
         $OldScope = ($CurrentDelegatedScopes | Where-Object -Property Resourceid -EQ $svcPrincipalId.id)
 
         if (!$OldScope) {


### PR DESCRIPTION
When investigating `Add-CIPPDelegatedPermission.ps1`, I noticed that the script didn't properly filter for scopes. Therefore in the old situation, it registers delegated permissions for both scopes and roles. This seemed incorrect to me, therefore I changed the script to only take delegated permissions (Type: Scope) from the manifest into account and ignore app permissions (Type: Role)