### PR TITLE
Add warnings for enable/disable and password reset on AD synced users

### DIFF
--- a/Modules/CIPPCore/Public/Set-CIPPResetPassword.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPResetPassword.ps1
@@ -28,11 +28,7 @@ function Set-CIPPResetPassword {
         Write-LogMessage -user $ExecutingUser -API $APIName -message "Reset the password for $($userid). User must change password is set to $forceChangePasswordNextSignIn" -Sev 'Info' -tenant $TenantFilter
         
         if($UserDetails.onPremisesSyncEnabled -eq $true){
-            return @"
-Reset the password for $($userid). User must change password is set to $forceChangePasswordNextSignIn. The new password is $password.
-
-WARNING: This user is AD synced. Please confirm passthrough or writeback is enabled.
-"@
+            return "Reset the password for $($userid). User must change password is set to $forceChangePasswordNextSignIn. The new password is $password. WARNING: This user is AD synced. Please confirm passthrough or writeback is enabled."
         }else{
             return "Reset the password for $($userid). User must change password is set to $forceChangePasswordNextSignIn. The new password is $password"
         }

--- a/Modules/CIPPCore/Public/Set-CIPPResetPassword.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPResetPassword.ps1
@@ -17,6 +17,7 @@ function Set-CIPPResetPassword {
             }
         } | ConvertTo-Json -Compress
 
+        $UserDetails = New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/users/$($UserId)?`$select=onPremisesSyncEnabled" -noPagination $true -tenantid $TenantFilter -verbose
         $null = New-GraphPostRequest -uri "https://graph.microsoft.com/v1.0/users/$($userid)" -tenantid $TenantFilter -type PATCH -body $passwordProfile -verbose
 
         #PWPush
@@ -25,7 +26,16 @@ function Set-CIPPResetPassword {
             $password = $PasswordLink
         }
         Write-LogMessage -user $ExecutingUser -API $APIName -message "Reset the password for $($userid). User must change password is set to $forceChangePasswordNextSignIn" -Sev 'Info' -tenant $TenantFilter
-        return "Reset the password for $($userid). User must change password is set to $forceChangePasswordNextSignIn. The new password is $password"
+        
+        if($UserDetails.onPremisesSyncEnabled -eq $true){
+            return @"
+Reset the password for $($userid). User must change password is set to $forceChangePasswordNextSignIn. The new password is $password.
+
+WARNING: This user is AD synced. Please confirm passthrough or writeback is enabled.
+"@
+        }else{
+            return "Reset the password for $($userid). User must change password is set to $forceChangePasswordNextSignIn. The new password is $password"
+        }
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
         Write-LogMessage -user $ExecutingUser -API $APIName -message "Could not reset password for $($userid). Error: $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage

--- a/Modules/CIPPCore/Public/Set-CIPPSignInState.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPSignInState.ps1
@@ -13,13 +13,19 @@ function Set-CIPPSignInState {
             accountEnabled = [bool]$AccountEnabled
         }
         $body = ConvertTo-Json -InputObject $body -Compress -Depth 5
+        $UserDetails = New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/users/$($UserId)?`$select=onPremisesSyncEnabled" -noPagination $true -tenantid $TenantFilter -verbose
         $null = New-GraphPostRequest -uri "https://graph.microsoft.com/v1.0/users/$($UserId)" -tenantid $TenantFilter -type PATCH -body $body -verbose
         Write-LogMessage -user $ExecutingUser -API $APIName -message "Set account enabled state to $AccountEnabled for $UserId" -Sev 'Info' -tenant $TenantFilter
-        return "Set account enabled state to $AccountEnabled for $UserId"
+        
+        if($UserDetails.onPremisesSyncEnabled -eq $true){
+            return "WARNING: User is AD Sync enabled. Please enable/disable in AD."
+        }else{
+            return "Set account enabled state to $AccountEnabled for $UserId"
+        }
+
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
         Write-LogMessage -user $ExecutingUser -API $APIName -message "Could not disable sign in for $UserId. Error: $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
         return "Could not disable $UserId. Error: $($ErrorMessage.NormalizedError)"
     }
 }
-


### PR DESCRIPTION
Both in the offboarding and per-user action page, if you reset a users password or disable/enable them, it does not mention anything about AD sync. If a synced user is disabled in O365 and not AD, they will be re-enabled at next AD sync.

Similarly, if password writeback or passthrough authentication is not setup, the password will ALSO be overwritten at next sync.

Added a check and a subsequent warning on both to make it more apparent (and prevent accidental re-enablements of terminated/offboarded users)