### PR TITLE
Compliance API support

### DIFF
--- a/Modules/CIPPCore/Public/AdditionalPermissions.json
+++ b/Modules/CIPPCore/Public/AdditionalPermissions.json
@@ -2,14 +2,5 @@
   {
     "resourceAppId": "00000003-0000-0ff1-ce00-000000000000",
     "resourceAccess": [{ "id": "AllProfiles.Manage", "type": "Scope" }]
-  },
-  {
-    "resourceAppId": "fb78d390-0c51-40cd-8e17-fdbfab77341b",
-    "resourceAccess": [
-      { "id": "AdminApi.AccessAsUser.All", "type": "Scope" },
-      { "id": "FfoPowerShell.AccessAsUser.All", "type": "Scope" },
-      { "id": "RemotePowerShell.AccessAsUser.All", "type": "Scope" },
-      { "id": "VivaFeatureAccessPolicy.Manage.All", "type": "Scope" }
-    ]
   }
 ]

--- a/Modules/CIPPCore/Public/GraphHelper/New-ExoRequest.ps1
+++ b/Modules/CIPPCore/Public/GraphHelper/New-ExoRequest.ps1
@@ -1,23 +1,60 @@
-function New-ExoRequest ($tenantid, $cmdlet, $cmdParams, $useSystemMailbox, $Anchor, $NoAuthCheck, $Select) {
+function New-ExoRequest {
     <#
     .FUNCTIONALITY
     Internal
     #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$cmdlet,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$cmdParams,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Select,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Anchor,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$useSystemMailbox,
+
+        [Parameter(Mandatory = $false)]
+        [string]$tenantid,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$NoAuthCheck,
+
+        [switch]$Compliance,
+        [ValidateSet('v1.0', 'beta')]
+        [string]$ApiVersion = 'beta'
+    )
     if ((Get-AuthorisedRequest -TenantID $tenantid) -or $NoAuthCheck -eq $True) {
-        $token = Get-ClassicAPIToken -resource 'https://outlook.office365.com' -Tenantid $tenantid
-        $Tenant = Get-Tenants -IncludeErrors | Where-Object { $_.defaultDomainName -eq $tenantid -or $_.customerId -eq $tenantid }
+
+        if ($Compliance.IsPresent) {
+            $Resource = 'https://ps.compliance.protection.outlook.com'
+            $token = Get-GraphToken -tenantid $tenantid -scope "$Resource/.default"
+            $token = @{ 'access_token' = $token.Authorization -replace 'Bearer ' }
+        } else {
+            $Resource = 'https://outlook.office365.com'
+            $token = Get-ClassicAPIToken -resource $Resource -Tenantid $tenantid
+        }
 
         if ($cmdParams) {
             $Params = $cmdParams
         } else {
             $Params = @{}
         }
-        $ExoBody = ConvertTo-Json -Depth 5 -InputObject @{
+        $ExoBody = ConvertTo-Json -Depth 5 -Compress -InputObject @{
             CmdletInput = @{
                 CmdletName = $cmdlet
                 Parameters = $Params
             }
         }
+
+        $Tenant = Get-Tenants -IncludeErrors | Where-Object { $_.defaultDomainName -eq $tenantid -or $_.customerId -eq $tenantid }
+
         if (!$Anchor) {
             if ($cmdparams.Identity) { $Anchor = $cmdparams.Identity }
             if ($cmdparams.anr) { $Anchor = $cmdparams.anr }
@@ -43,21 +80,40 @@ function New-ExoRequest ($tenantid, $cmdlet, $cmdParams, $useSystemMailbox, $Anc
                 }
             }
         }
-        Write-Host "Using $Anchor"
+
+        Write-Verbose "Using $Anchor"
+
         $Headers = @{
-            Authorization             = "Bearer $($token.access_token)"
-            Prefer                    = 'odata.maxpagesize = 1000'
-            'parameter-based-routing' = $true
-            'X-AnchorMailbox'         = $anchor
-
+            Authorization     = "Bearer $($token.access_token)"
+            Prefer            = 'odata.maxpagesize=1000'
+            'X-AnchorMailbox' = $anchor
         }
-        try {
-            if ($Select) { $Select = "`$select=$Select" }
-            $URL = "https://outlook.office365.com/adminapi/beta/$($tenant.customerId)/InvokeCommand?$Select"
 
-            $ReturnedData =
-            do {
-                $Return = Invoke-RestMethod $URL -Method POST -Body $ExoBody -Headers $Headers -ContentType 'application/json; charset=utf-8'
+        # Compliance API trickery. Capture Location headers on redirect, extract subdomain and prepend to compliance URL
+        if ($Compliance.IsPresent) {
+            $URL = "$Resource/adminapi/$ApiVersion/$($tenant.customerId)/EXOBanner('AutogenSession')?Version=3.4.0"
+            Invoke-RestMethod -ResponseHeadersVariable ComplianceHeaders -MaximumRedirection 0 -ErrorAction SilentlyContinue -Uri $URL -Headers $Headers -SkipHttpErrorCheck | Out-Null
+            $RedirectedHost = ([System.Uri]($ComplianceHeaders.Location | Select-Object -First 1)).Host
+            $RedirectedHostname = '{0}.ps.compliance.protection.outlook.com' -f ($RedirectedHost -split '\.' | Select-Object -First 1)
+            $Resource = "https://$($RedirectedHostname)"
+            Write-Verbose "Redirecting to $Resource"
+        }
+
+        try {
+            if ($Select) { $Select = "?`$select=$Select" }
+            $URL = "$Resource/adminapi/$ApiVersion/$($tenant.customerId)/InvokeCommand$Select"
+
+            Write-Verbose "POST [ $URL ]"
+            $ReturnedData = do {
+                $ExoRequestParams = @{
+                    Uri         = $URL
+                    Method      = 'POST'
+                    Body        = $ExoBody
+                    Headers     = $Headers
+                    ContentType = 'application/json'
+                }
+
+                $Return = Invoke-RestMethod @ExoRequestParams
                 $URL = $Return.'@odata.nextLink'
                 $Return
             } until ($null -eq $URL)
@@ -67,11 +123,14 @@ function New-ExoRequest ($tenantid, $cmdlet, $cmdParams, $useSystemMailbox, $Anc
             }
         } catch {
             $ErrorMess = $($_.Exception.Message)
-            $ReportedError = ($_.ErrorDetails | ConvertFrom-Json -ErrorAction SilentlyContinue)
-            $Message = if ($ReportedError.error.details.message) {
-                $ReportedError.error.details.message
-            } elseif ($ReportedError.error.message) { $ReportedError.error.message }
-            else { $ReportedError.error.innererror.internalException.message }
+            try {
+                $ReportedError = ($_.ErrorDetails.Message | ConvertFrom-Json -ErrorAction SilentlyContinue)
+                $Message = if ($ReportedError.error.details.message) {
+                    $ReportedError.error.details.message
+                } elseif ($ReportedError.error.innererror) {
+                    $ReportedError.error.innererror.internalException.message
+                } elseif ($ReportedError.error.message) { $ReportedError.error.message }
+            } catch { $Message = $_.ErrorDetails }
             if ($null -eq $Message) { $Message = $ErrorMess }
             throw $Message
         }


### PR DESCRIPTION
- Extend New-ExoRequest for ps.compliance.protection.outlook.com API
- Add -Compliance switch
- Tidy parameters, parameter-based-routing only required when there are no anchors
- Adjust error handling to get more detailed error if available