### PR TITLE
Enforce Registration After Allowed Snoozes

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardNudgeMFA.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardNudgeMFA.ps1
@@ -59,6 +59,7 @@ function Invoke-CIPPStandardNudgeMFA {
                 $Body = $CurrentInfo
                 $body.registrationEnforcement.authenticationMethodsRegistrationCampaign.state = $Settings.state
                 $body.registrationEnforcement.authenticationMethodsRegistrationCampaign.snoozeDurationInDays = $Settings.snoozeDurationInDays
+                $body.registrationEnforcement.authenticationMethodsRegistrationCampaign.enforceRegistrationAfterAllowedSnoozes = $true
 
                 $body = ConvertTo-Json -Depth 10 -InputObject ($body | Select-Object registrationEnforcement)
                 New-GraphPostRequest -tenantid $tenant -Uri 'https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy' -Type patch -Body $body -ContentType 'application/json'


### PR DESCRIPTION
Ensuring enforceRegistrationAfterAllowedSnoozes is set to true. Enabled is the default value; however, if previously disabled, the standard would not force users to set up Microsoft Authenticator after the allowed number of snoozes.