### PR TITLE
Use Join-Path instead of $PSScriptRoot\Path

### DIFF
--- a/Modules/CIPPCore/CIPPCore.psm1
+++ b/Modules/CIPPCore/CIPPCore.psm1
@@ -1,5 +1,5 @@
-$Public = @(Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse -ErrorAction SilentlyContinue)
-$Private = @(Get-ChildItem -Path $PSScriptRoot\private\*.ps1 -Recurse -ErrorAction SilentlyContinue)
+$Public = @(Get-ChildItem -Path (Join-Path $PSScriptRoot "Public\*.ps1") -Recurse -ErrorAction SilentlyContinue)
+$Private = @(Get-ChildItem -Path (Join-Path $PSScriptRoot "Private\*.ps1") -Recurse -ErrorAction SilentlyContinue)
 $Functions = $Public + $Private
 foreach ($import in @($Functions)) {
     try {

--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-ExecOnboardTenantQueue.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-ExecOnboardTenantQueue.ps1
@@ -312,8 +312,8 @@ Function Push-ExecOnboardTenantQueue {
                     $LastCPVError = ''
                     do {
                         try {
-                            Add-CIPPApplicationPermission -RequiredResourceAccess 'CippDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $Relationship.customer.tenantId
-                            Add-CIPPDelegatedPermission -RequiredResourceAccess 'CippDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $Relationship.customer.tenantId
+                            Add-CIPPApplicationPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $Relationship.customer.tenantId
+                            Add-CIPPDelegatedPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $Relationship.customer.tenantId
                             $CPVSuccess = $true
                             $Refreshing = $false
                         } catch {

--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-UpdatePermissionsQueue.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-UpdatePermissionsQueue.ps1
@@ -23,8 +23,8 @@ function Push-UpdatePermissionsQueue {
             $DomainRefreshRequired = $true
         }
         Write-Information 'Updating permissions'
-        Add-CIPPApplicationPermission -RequiredResourceAccess 'CippDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $Item.customerId
-        Add-CIPPDelegatedPermission -RequiredResourceAccess 'CippDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $Item.customerId
+        Add-CIPPApplicationPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $Item.customerId
+        Add-CIPPDelegatedPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $Item.customerId
         Write-LogMessage -tenant $Item.defaultDomainName -tenantId $Item.customerId -message "Updated permissions for $($Item.displayName)" -Sev 'Info' -API 'UpdatePermissionsQueue'
 
         Write-Information 'Pushing CIPP-SAM admin roles'

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecCPVPermissions.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecCPVPermissions.ps1
@@ -33,8 +33,8 @@ Function Invoke-ExecCPVPermissions {
         } else {
             $TenantFilter = $env:TenantID
         }
-        Add-CIPPApplicationPermission -RequiredResourceAccess 'CippDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $TenantFilter
-        Add-CIPPDelegatedPermission -RequiredResourceAccess 'CippDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $TenantFilter
+        Add-CIPPApplicationPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $TenantFilter
+        Add-CIPPDelegatedPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $ENV:ApplicationID -tenantfilter $TenantFilter
         Set-CIPPSAMAdminRoles -TenantFilter $TenantFilter
         $Success = $true
     } catch {

--- a/Modules/CIPPCore/Public/Get-CIPPTimerFunctions.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPTimerFunctions.ps1
@@ -19,7 +19,7 @@ function Get-CIPPTimerFunctions {
 
     if (!('NCronTab.Advanced.CrontabSchedule' -as [type])) {
         try {
-            $NCronTab = Join-Path -Path $CIPPCoreModuleRoot -ChildPath 'lib\Ncrontab.Advanced.dll'
+            $NCronTab = Join-Path -Path $CIPPCoreModuleRoot -ChildPath 'lib\NCrontab.Advanced.dll'
             Add-Type -Path $NCronTab
         } catch {}
     }

--- a/Modules/CIPPCore/Public/GraphHelper/Get-CippSamPermissions.ps1
+++ b/Modules/CIPPCore/Public/GraphHelper/Get-CippSamPermissions.ps1
@@ -25,14 +25,14 @@ function Get-CippSamPermissions {
 
     if (!$SavedOnly.IsPresent) {
         $ModuleBase = Get-Module -Name CIPPCore | Select-Object -ExpandProperty ModuleBase
-        $SamManifestFile = Get-Item "$ModuleBase\Public\SAMManifest.json"
-        $AdditionalPermissions = Get-Item "$ModuleBase\Public\AdditionalPermissions.json"
+        $SamManifestFile = Get-Item (Join-Path $ModuleBase "Public\SAMManifest.json")
+        $AdditionalPermissions = Get-Item (Join-Path $ModuleBase "Public\AdditionalPermissions.json")
 
         $ServicePrincipals = New-GraphGetRequest -Uri 'https://graph.microsoft.com/beta/servicePrincipals?$top=999&$select=appId,displayName,appRoles,publishedPermissionScopes' -tenantid $env:TenantID -NoAuthCheck $true
         $SAMManifest = Get-Content -Path $SamManifestFile.FullName | ConvertFrom-Json
         $AdditionalPermissions = Get-Content -Path $AdditionalPermissions.FullName | ConvertFrom-Json
 
-        $RequiredResources = $SamManifest.requiredResourceAccess
+        $RequiredResources = $SAMManifest.requiredResourceAccess
 
         $AppIds = ($RequiredResources.resourceAppId + $AdditionalPermissions.resourceAppId) | Sort-Object -Unique
 

--- a/Modules/CippExtensions/CippExtensions.psm1
+++ b/Modules/CippExtensions/CippExtensions.psm1
@@ -1,5 +1,5 @@
-$Public = @(Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse -ErrorAction SilentlyContinue)
-$Private = @(Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -Recurse -ErrorAction SilentlyContinue)
+$Public = @(Get-ChildItem -Path (Join-Path $PSScriptRoot "Public\*.ps1") -Recurse -ErrorAction SilentlyContinue)
+$Private = @(Get-ChildItem -Path (Join-Path $PSScriptRoot "Private\*.ps1") -Recurse -ErrorAction SilentlyContinue)
 $Functions = $Public + $Private
 foreach ($import in @($Functions)) {
     try {


### PR DESCRIPTION
* Use Join-Path instead of $PSScriptRoot\Path to Cross-Platform madness
* i THINK it should be CIPPDefaults instead of CippDefaults as all the other ones also use that? I can undo this one if its actually correct