### PR TITLE
Disable guest user use lastSuccessfulSignInDateTime

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
@@ -30,7 +30,7 @@ function Invoke-CIPPStandardDisableGuests {
     ##$Rerun -Type Standard -Tenant $Tenant -Settings $Settings 'DisableGuests'
 
     $Lookup = (Get-Date).AddDays(-90).ToUniversalTime().ToString('o')
-    $GraphRequest = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users?`$filter=(signInActivity/lastNonInteractiveSignInDateTime le $Lookup)&`$select=id,UserPrincipalName,signInActivity,mail,userType,accountEnabled" -scope 'https://graph.microsoft.com/.default' -tenantid $Tenant | Where-Object { $_.userType -EQ 'Guest' -and $_.AccountEnabled -EQ $true }
+    $GraphRequest = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users?`$filter=(signInActivity/lastSuccessfulSignInDateTime le $Lookup)&`$select=id,UserPrincipalName,signInActivity,mail,userType,accountEnabled" -scope 'https://graph.microsoft.com/.default' -tenantid $Tenant | Where-Object { $_.userType -EQ 'Guest' -and $_.AccountEnabled -EQ $true }
 
     If ($Settings.remediate -eq $true) {
 


### PR DESCRIPTION
I was thinking of doing something like `$filter=(signInActivity/lastNonInteractiveSignInDateTime le $Lookup or signInActivity/lastSignInDateTime le $Lookup)` which seemed to not work, but why not just use lastSuccessfulSignInDateTime as it works with Interactive and Non-Interactive sign-ins?

* Resolves https://github.com/KelvinTegelaar/CIPP/issues/2861

```pwsh
User 1:
signInActivity: @{
    lastSignInDateTime=2/8/2024 2:06:29 PM
    lastNonInteractiveSignInDateTime=10/25/2023 11:53:05 AM
    lastSuccessfulSignInDateTime=1/3/2024 11:53:51 AM
}

User 2:
signInActivity: @{
    lastSignInDateTime=
    lastNonInteractiveSignInDateTime=3/12/2024 4:24:34 PM
    lastSuccessfulSignInDateTime=3/12/2024 4:24:34 PM
}

User 3:
signInActivity: @{
    lastSignInDateTime=11/1/2023 5:24:13 PM
    lastNonInteractiveSignInDateTime=4/1/2024 1:47:23 AM
    lastSuccessfulSignInDateTime=4/1/2024 1:47:23 AM
}
```