### PR TITLE
fix: remove deprecated command line argument

### DIFF
--- a/AddChocoApp/IntunePackage/Install.ps1
+++ b/AddChocoApp/IntunePackage/Install.ps1
@@ -34,7 +34,7 @@ try {
     }
 
     try {
-        $localprograms = & "$chocoPath" list --localonly
+        $localprograms = & "$chocoPath" list
         $CustomRepoString = if ($CustomRepo) { "--source $customrepo" } else { $null }
         if ($localprograms -like "*$Packagename*" ) {
             Write-Host "Upgrading $packagename"


### PR DESCRIPTION
Fixes an error message when listing chocolatey packages: Invalid argument --localonly. This argument has been removed from the list command and cannot be used