### PR TITLE
fix: invalid choco.exe command line argument

### DIFF
--- a/AddChocoApp/IntunePackage/Install.ps1
+++ b/AddChocoApp/IntunePackage/Install.ps1
@@ -35,7 +35,7 @@ try {
 
     try {
         $localprograms = & "$chocoPath" list --localonly
-        $CustomRepoString = if ($CustomRepo) { "--source $customrepo" } else { $null }
+        $CustomRepoString = if ($CustomRepo) { "--source=$customrepo" } else { $null }
         if ($localprograms -like "*$Packagename*" ) {
             Write-Host "Upgrading $packagename"
             & "$chocoPath" upgrade $Packagename $CustomRepoString


### PR DESCRIPTION
The `--source` parameter is not properly defined, the supported format is either `-s <SourceUri>` -or `--source=<SourceUri>`. As is the custom repository is not passed to choco and installing packages from custom repositories fails.