### PR TITLE
Get-CIPPAlertSharepointQuota - Add quota data to AlertData

### DIFF
--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertSharepointQuota.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertSharepointQuota.ps1
@@ -27,7 +27,7 @@ function Get-CIPPAlertSharepointQuota {
         }
         $UsedStoragePercentage = [int](($sharepointQuota.GeoUsedStorageMB / $sharepointQuota.TenantStorageMB) * 100)
         if ($UsedStoragePercentage -gt $Value) {
-            $AlertData = "SharePoint Storage is at $($UsedStoragePercentage)%. Your alert threshold is $($Value)%"
+            $AlertData = "SharePoint Storage is at $($UsedStoragePercentage)% [$([math]::Round($sharepointQuota.GeoUsedStorageMB / 1024, 2)) GB/$([math]::Round($sharepointQuota.TenantStorageMB / 1024, 2)) GB]. Your alert threshold is $($Value)%"
             Write-AlertTrace -cmdletName $MyInvocation.MyCommand -tenantFilter $TenantFilter -data $AlertData
         }
     }


### PR DESCRIPTION
Had a request from some of the team to have the SharePoint storage quota values included with the alert 'Alert on % SharePoint quota used', thought it may be beneficial for others that use this alert.