### PR TITLE
Fix duplicate request in group add - Bug fix

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-AddGroup.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-AddGroup.ps1
@@ -65,7 +65,6 @@ Function Invoke-AddGroup {
                     }
                     $GraphRequest = New-ExoRequest -tenantid $tenant -cmdlet 'New-DistributionGroup' -cmdParams $params
                 }
-                $GraphRequest = New-ExoRequest -tenantid $tenant -cmdlet 'New-DistributionGroup' -cmdParams $params
                 # At some point add logic to use AddOwner/AddMember for New-DistributionGroup, but idk how we're going to brr that - rvdwegen
             }
             "Successfully created group $($groupobj.displayname) for $($tenant)"


### PR DESCRIPTION
## Bug Details
In the `Invoke-AddGroup` function, the series of `if/else` statements to determine the type of group to add has a duplicate ExoRequest if the group is of type Distribution or Dynamic Distribution. The group will create, but the `$GraphRequest` variable will then be overwritten with the failure to create due to duplicate error from the second ExoRequest, and return an error to the front end

## Fix Details
As the inner `if/else` statements to determine the distribution group type contain an existing ExoRequest function, remove the extra request.