### PR TITLE
fix: delete template prod branch

### DIFF
--- a/Modules/CIPPCore/Public/Invoke-RemoveStandardTemplate.ps1
+++ b/Modules/CIPPCore/Public/Invoke-RemoveStandardTemplate.ps1
@@ -14,7 +14,7 @@ Function Invoke-RemoveStandardTemplate {
     $User = $request.headers.'x-ms-client-principal'
     Write-LogMessage -user $User -API $APINAME -message 'Accessed this API' -Sev 'Debug'
 
-    $ID = $request.body.ID
+    $ID = $request.query.ID
     try {
         $Table = Get-CippTable -tablename 'templates'
 


### PR DESCRIPTION
In Production deleting a template causes this error because this commit got merged to dev https://github.com/KelvinTegelaar/CIPP-API/commit/fe5930144cf28ea7d844da955320ae8d010a1c94#diff-69373acdd7a7f0a3ab9900040df2a8921173a7593e5904d48f158f89dcdc7859

You'll decide if its worth reverting it on dev and then committing the breaking change only to Interface-Rewrite since it will be a merge conflict

> Failed to remove template: Cannot validate argument on parameter 'Entity'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.

https://discord.com/channels/905453405936447518/905454344265162812/1308710213800427582