### PR TITLE
FIX: Unreliable TAP creation during new JIT admin user creation

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecJITAdmin.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecJITAdmin.ps1
@@ -92,6 +92,7 @@ Function Invoke-ExecJITAdmin {
             Start-Sleep -Seconds 1
         }
 
+        #Region TAP creation
         if ($Request.Body.UseTAP) {
             try {
                 if ($Start -gt (Get-Date)) {
@@ -102,7 +103,7 @@ Function Invoke-ExecJITAdmin {
                 } else {
                     $TapBody = '{}'
                 }
-                Write-Information "https://graph.microsoft.com/beta/users/$Username/authentication/temporaryAccessPassMethods"
+                # Write-Information "https://graph.microsoft.com/beta/users/$Username/authentication/temporaryAccessPassMethods"
                 # Retry creating the TAP up to 10 times, since it can fail due to the user not being fully created yet. Sometimes it takes 2 reties, sometimes it takes 8+. Very annoying. -Bobby
                 $Retries = 0
                 $MAX_TAP_RETRIES = 10
@@ -136,6 +137,7 @@ Function Invoke-ExecJITAdmin {
                 }
             }
         }
+        #EndRegion TAP creation
 
         $Parameters = @{
             TenantFilter = $TenantFilter

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecJITAdmin.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecJITAdmin.ps1
@@ -103,18 +103,19 @@ Function Invoke-ExecJITAdmin {
                     $TapBody = '{}'
                 }
                 Write-Information "https://graph.microsoft.com/beta/users/$Username/authentication/temporaryAccessPassMethods"
-                # Retry creating the TAP up to 5 times, since it can fail due to the user not being fully created yet
+                # Retry creating the TAP up to 10 times, since it can fail due to the user not being fully created yet. Sometimes it takes 2 reties, sometimes it takes 8+. Very annoying. -Bobby
                 $Retries = 0
+                $MAX_TAP_RETRIES = 10
                 do {
                     try {
                         $TapRequest = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($Username)/authentication/temporaryAccessPassMethods" -tenantid $TenantFilter -type POST -body $TapBody
                     } catch {
                         Start-Sleep -Seconds 2
-                        Write-Information 'ERROR: Failed to create TAP, retrying'
-                        Write-Information ( ConvertTo-Json -Depth 5 -InputObject (Get-CippException -Exception $_))
+                        Write-Information "ERROR: Run $Retries of $MAX_TAP_RETRIES : Failed to create TAP, retrying"
+                        # Write-Information ( ConvertTo-Json -Depth 5 -InputObject (Get-CippException -Exception $_))
                     }
                     $Retries++
-                } while ( $null -eq $TapRequest.temporaryAccessPass -and $Retries -le 5 )
+                } while ( $null -eq $TapRequest.temporaryAccessPass -and $Retries -le $MAX_TAP_RETRIES )
 
                 $TempPass = $TapRequest.temporaryAccessPass
                 $PasswordExpiration = $TapRequest.LifetimeInMinutes


### PR DESCRIPTION
Enhance reliability by increasing the retry limit for Temporary Access Pass (TAP) creation from 5 to 10 attempts. This change addresses intermittent failures related to user creation timing.