### PR TITLE
FIX: User Exchange tab forwarding address error

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListUserMailboxDetails.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListUserMailboxDetails.ps1
@@ -129,7 +129,15 @@ Function Invoke-ListUserMailboxDetails {
 
     # Get forwarding address
     $ForwardingAddress = if ($MailboxDetailedRequest.ForwardingAddress) {
-        (New-GraphGetRequest -TenantId $TenantFilter -Uri "https://graph.microsoft.com/beta/users/$($MailboxDetailedRequest.ForwardingAddress)").UserPrincipalName
+        try {
+            (New-GraphGetRequest -TenantId $TenantFilter -Uri "https://graph.microsoft.com/beta/users/$($MailboxDetailedRequest.ForwardingAddress)").UserPrincipalName
+        } catch {
+            try {
+                '{0} ({1})' -f $MailboxDetailedRequest.ForwardingAddress, (($((New-GraphGetRequest -TenantId $TenantFilter -Uri "https://graph.microsoft.com/beta/users?`$filter=displayName eq '$($MailboxDetailedRequest.ForwardingAddress)'") | Select-Object -First 1 -ExpandProperty UserPrincipalName)))
+            } catch {
+                $MailboxDetailedRequest.ForwardingAddress
+            }
+        }
     } elseif ($MailboxDetailedRequest.ForwardingSmtpAddress -and $MailboxDetailedRequest.ForwardingAddress) {
         "$($MailboxDetailedRequest.ForwardingAddress) $($MailboxDetailedRequest.ForwardingSmtpAddress)"
     } else {


### PR DESCRIPTION
Enhance error handling when retrieving the ForwardingAddress to accommodate cases where it is a display name. otherwise the whole tab would not load and fail