### PR TITLE
Support new "mx.microsoft" MX records in the domain analyzer

### DIFF
--- a/Modules/DNSHealth/1.0.7/MailProviders/Microsoft365.json
+++ b/Modules/DNSHealth/1.0.7/MailProviders/Microsoft365.json
@@ -1,6 +1,6 @@
 {
     "Name": "Microsoft 365",
-    "MxMatch": "mail.protection.outlook.com",
+    "MxMatch": "mail.protection.outlook.com|mx.microsoft",
     "SpfInclude": "spf.protection.outlook.com",
     "Selectors": ["selector1","selector2"],
     "MinimumSelectorPass": 1,


### PR DESCRIPTION
Adds "mx.microsoft" to the regex lookup under the Microsoft 365 mail provider to support the new MX endpoint