### PR TITLE
fix: use timespan from days in RetentionPolicyTag

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardRetentionPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardRetentionPolicy.ps1
@@ -19,7 +19,7 @@ function Invoke-CIPPStandardRetentionPolicyTag {
     $StateIsCorrect =   ($CurrentState.Name -eq $PolicyName) -and
                         ($CurrentState.RetentionEnabled -eq $true) -and
                         ($CurrentState.RetentionAction -eq 'PermanentlyDelete') -and
-                        ($CurrentState.AgeLimitForRetention -eq $Settings.AgeLimitForRetention) -and
+                        ($CurrentState.AgeLimitForRetention -eq ([timespan]::FromDays($Settings.AgeLimitForRetention))) -and
                         ($CurrentState.Type -eq 'DeletedItems') -and
                         ($PolicyState.RetentionPolicyTagLinks -contains $PolicyName)
 


### PR DESCRIPTION
$CurrentState.AgeLimitForRetention apparently returns in this format `30.00:00:00`