### PR TITLE
fix: make standards work with autoComplete

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardGuestInvite.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardGuestInvite.ps1
@@ -19,7 +19,7 @@ function Invoke-CIPPStandardGuestInvite {
         IMPACT
             Medium Impact
         POWERSHELLEQUIVALENT
-            
+
         RECOMMENDEDBY
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
@@ -31,8 +31,7 @@ function Invoke-CIPPStandardGuestInvite {
 
     $CurrentState = New-GraphGetRequest -Uri 'https://graph.microsoft.com/beta/policies/authorizationPolicy/authorizationPolicy' -tenantid $Tenant
 
-    if ($null -eq $Settings.allowInvitesFrom) { $Settings.allowInvitesFrom = 'Everyone' } # none, adminsAndGuestInviters, adminsGuestInvitersAndAllMembers, everyone
-    $StateIsCorrect =   ($CurrentState.allowInvitesFrom -eq $Settings.allowInvitesFrom)
+    $StateIsCorrect =   ($CurrentState.allowInvitesFrom -eq $Settings.allowInvitesFrom.value)
 
     if ($Settings.remediate -eq $true) {
         if ($StateIsCorrect -eq $true) {
@@ -46,13 +45,13 @@ function Invoke-CIPPStandardGuestInvite {
                     Type        = 'PATCH'
                     ContentType = 'application/json; charset=utf-8'
                     Body        = [pscustomobject]@{
-                        allowInvitesFrom = $Settings.allowInvitesFrom
+                        allowInvitesFrom = $Settings.allowInvitesFrom.value
                     } | ConvertTo-Json -Compress
                 }
                 New-GraphPostRequest @GraphRequest
-                Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Successfully updated Guest Invite setting to $($Settings.allowInvitesFrom)" -Sev Info
+                Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Successfully updated Guest Invite setting to $($Settings.allowInvitesFrom.value)" -Sev Info
             } catch {
-                Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Failed to update Guest Invite setting to $($Settings.allowInvitesFrom)" -Sev Error -LogData $_
+                Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Failed to update Guest Invite setting to $($Settings.allowInvitesFrom.value)" -Sev Error -LogData $_
             }
         }
     }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardIntuneComplianceSettings.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardIntuneComplianceSettings.ps1
@@ -20,7 +20,7 @@ function Invoke-CIPPStandardIntuneComplianceSettings {
         IMPACT
             Low Impact
         POWERSHELLEQUIVALENT
-            
+
         RECOMMENDEDBY
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
@@ -32,9 +32,8 @@ function Invoke-CIPPStandardIntuneComplianceSettings {
 
     $CurrentState = New-GraphGetRequest -Uri 'https://graph.microsoft.com/beta/deviceManagement/settings' -tenantid $Tenant
 
-    if ($null -eq $Settings.secureByDefault) { $Settings.secureByDefault = $true }
     if ($null -eq $Settings.deviceComplianceCheckinThresholdDays) { $Settings.deviceComplianceCheckinThresholdDays = $CurrentState.deviceComplianceCheckinThresholdDays }
-    $StateIsCorrect =   ($CurrentState.secureByDefault -eq $Settings.secureByDefault) -and
+    $StateIsCorrect =   ($CurrentState.secureByDefault -eq $Settings.secureByDefault.value) -and
                         ($CurrentState.deviceComplianceCheckinThresholdDays -eq $Settings.deviceComplianceCheckinThresholdDays)
 
     if ($Settings.remediate -eq $true) {
@@ -50,7 +49,7 @@ function Invoke-CIPPStandardIntuneComplianceSettings {
                     ContentType = 'application/json; charset=utf-8'
                     Body        = [pscustomobject]@{
                         settings = [pscustomobject]@{
-                            secureByDefault = $Settings.secureByDefault
+                            secureByDefault = $Settings.secureByDefault.value
                             deviceComplianceCheckinThresholdDays = $Settings.deviceComplianceCheckinThresholdDays
                         }
                     } | ConvertTo-Json -Compress

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
@@ -46,16 +46,16 @@ function Invoke-CIPPStandardSpamFilterPolicy {
         Select-Object -Property *
 
     $StateIsCorrect = ($CurrentState.Name -eq $PolicyName) -and
-                        ($CurrentState.SpamAction -eq $Settings.SpamAction) -and
-                        ($CurrentState.SpamQuarantineTag -eq $Settings.SpamQuarantineTag) -and
-                        ($CurrentState.HighConfidenceSpamAction -eq $Settings.HighConfidenceSpamAction) -and
-                        ($CurrentState.HighConfidenceSpamQuarantineTag -eq $Settings.HighConfidenceSpamQuarantineTag) -and
-                        ($CurrentState.BulkSpamAction -eq $Settings.BulkSpamAction) -and
-                        ($CurrentState.BulkQuarantineTag -eq $Settings.BulkQuarantineTag) -and
-                        ($CurrentState.PhishSpamAction -eq $Settings.PhishSpamAction) -and
-                        ($CurrentState.PhishQuarantineTag -eq $Settings.PhishQuarantineTag) -and
+                        ($CurrentState.SpamAction -eq $Settings.SpamAction.value) -and
+                        ($CurrentState.SpamQuarantineTag -eq $Settings.SpamQuarantineTag.value) -and
+                        ($CurrentState.HighConfidenceSpamAction -eq $Settings.HighConfidenceSpamAction.value) -and
+                        ($CurrentState.HighConfidenceSpamQuarantineTag -eq $Settings.HighConfidenceSpamQuarantineTag.value) -and
+                        ($CurrentState.BulkSpamAction -eq $Settings.BulkSpamAction.value) -and
+                        ($CurrentState.BulkQuarantineTag -eq $Settings.BulkQuarantineTag.value) -and
+                        ($CurrentState.PhishSpamAction -eq $Settings.PhishSpamAction.value) -and
+                        ($CurrentState.PhishQuarantineTag -eq $Settings.PhishQuarantineTag.value) -and
                         ($CurrentState.HighConfidencePhishAction -eq 'Quarantine') -and
-                        ($CurrentState.HighConfidencePhishQuarantineTag -eq $Settings.HighConfidencePhishQuarantineTag) -and
+                        ($CurrentState.HighConfidencePhishQuarantineTag -eq $Settings.HighConfidencePhishQuarantineTag.value) -and
                         ($CurrentState.BulkThreshold -eq $Settings.BulkThreshold) -and
                         ($CurrentState.QuarantineRetentionPeriod -eq 30) -and
                         ($CurrentState.IncreaseScoreWithNumericIps -eq 'On') -and
@@ -86,16 +86,16 @@ function Invoke-CIPPStandardSpamFilterPolicy {
             Write-LogMessage -API 'Standards' -Tenant $Tenant -message 'Spam Filter Policy already correctly configured' -sev Info
         } else {
             $cmdparams = @{
-                SpamAction                           = $Settings.SpamAction
-                SpamQuarantineTag                    = $Settings.SpamQuarantineTag
-                HighConfidenceSpamAction             = $Settings.HighConfidenceSpamAction
-                HighConfidenceSpamQuarantineTag      = $Settings.HighConfidenceSpamQuarantineTag
-                BulkSpamAction                       = $Settings.BulkSpamAction
-                BulkQuarantineTag                    = $Settings.BulkQuarantineTag
-                PhishSpamAction                      = $Settings.PhishSpamAction
-                PhishQuarantineTag                   = $Settings.PhishQuarantineTag
+                SpamAction                           = $Settings.SpamAction.value
+                SpamQuarantineTag                    = $Settings.SpamQuarantineTag.value
+                HighConfidenceSpamAction             = $Settings.HighConfidenceSpamAction.value
+                HighConfidenceSpamQuarantineTag      = $Settings.HighConfidenceSpamQuarantineTag.value
+                BulkSpamAction                       = $Settings.BulkSpamAction.value
+                BulkQuarantineTag                    = $Settings.BulkQuarantineTag.value
+                PhishSpamAction                      = $Settings.PhishSpamAction.value
+                PhishQuarantineTag                   = $Settings.PhishQuarantineTag.value
                 HighConfidencePhishAction            = 'Quarantine'
-                HighConfidencePhishQuarantineTag     = $Settings.HighConfidencePhishQuarantineTag
+                HighConfidencePhishQuarantineTag     = $Settings.HighConfidencePhishQuarantineTag.value
                 BulkThreshold                        = $Settings.BulkThreshold
                 QuarantineRetentionPeriod            = 30
                 IncreaseScoreWithNumericIps          = 'On'
@@ -110,6 +110,8 @@ function Invoke-CIPPStandardSpamFilterPolicy {
                 PhishZapEnabled                      = $true
                 SpamZapEnabled                       = $true
             }
+            Write-Host "================== DEBUG =================="
+            Write-Host $cmdparams
 
             if ($CurrentState.Name -eq $PolicyName) {
                 try {

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTeamsEnrollUser.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTeamsEnrollUser.ps1
@@ -32,25 +32,23 @@ Function Invoke-CIPPStandardTeamsEnrollUser {
     $CurrentState = New-TeamsRequest -TenantFilter $Tenant -Cmdlet 'Get-CsTeamsMeetingPolicy' -CmdParams @{Identity = 'Global' }
     | Select-Object EnrollUserOverride
 
-    if ($null -eq $Settings.EnrollUserOverride) { $Settings.EnrollUserOverride = $CurrentState.EnrollUserOverride }
-
-    $StateIsCorrect = ($CurrentState.EnrollUserOverride -eq $Settings.EnrollUserOverride)
+    $StateIsCorrect = ($CurrentState.EnrollUserOverride -eq $Settings.EnrollUserOverride.value)
 
     if ($Settings.remediate -eq $true) {
         if ($StateIsCorrect -eq $true) {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Teams Enroll User Override settings already set to $($Settings.EnrollUserOverride)." -sev Info
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Teams Enroll User Override settings already set to $($Settings.EnrollUserOverride.value)." -sev Info
         } else {
             $cmdparams = @{
                 Identity           = 'Global'
-                EnrollUserOverride = $Settings.EnrollUserOverride
+                EnrollUserOverride = $Settings.EnrollUserOverride.value
             }
 
             try {
                 New-TeamsRequest -TenantFilter $Tenant -Cmdlet 'Set-CsTeamsMeetingPolicy' -CmdParams $cmdparams
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated Teams Enroll User Override setting to $($Settings.EnrollUserOverride)." -sev Info
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated Teams Enroll User Override setting to $($Settings.EnrollUserOverride.value)." -sev Info
             } catch {
                 $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to set Teams Enroll User Override setting to $($Settings.EnrollUserOverride)." -sev Error -LogData $ErrorMessage
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to set Teams Enroll User Override setting to $($Settings.EnrollUserOverride.value)." -sev Error -LogData $ErrorMessage
             }
         }
     }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTeamsFederationConfiguration.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTeamsFederationConfiguration.ps1
@@ -36,7 +36,7 @@ Function Invoke-CIPPStandardTeamsFederationConfiguration {
     $CurrentState = New-TeamsRequest -TenantFilter $Tenant -Cmdlet 'Get-CsTenantFederationConfiguration' -CmdParams @{Identity = 'Global' }
     | Select-Object *
 
-    Switch ($Settings.DomainControl) {
+    Switch ($Settings.DomainControl.value) {
         'AllowAllExternal' {
             $AllowFederatedUsers = $true
             $AllowedDomainsAsAList = 'AllowAllKnownDomains'
@@ -64,6 +64,10 @@ Function Invoke-CIPPStandardTeamsFederationConfiguration {
             } else {
                 $BlockedDomains = @()
             }
+        }
+        Default {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Federation Configuration: Invalid $($Settings.DomainControl.value) parameter" -sev Error
+            Return
         }
     }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTeamsGlobalMeetingPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTeamsGlobalMeetingPolicy.ps1
@@ -35,16 +35,12 @@ Function Invoke-CIPPStandardTeamsGlobalMeetingPolicy {
     $CurrentState = New-TeamsRequest -TenantFilter $Tenant -Cmdlet 'Get-CsTeamsMeetingPolicy' -CmdParams @{Identity = 'Global' }
     | Select-Object AllowAnonymousUsersToJoinMeeting, AllowAnonymousUsersToStartMeeting, AutoAdmittedUsers, AllowPSTNUsersToBypassLobby, MeetingChatEnabledType, DesignatedPresenterRoleMode, AllowExternalParticipantGiveRequestControl
 
-    if ($null -eq $Settings.DesignatedPresenterRoleMode) { $Settings.DesignatedPresenterRoleMode = $CurrentState.DesignatedPresenterRoleMode }
-    if ($null -eq $Settings.AllowAnonymousUsersToJoinMeeting) { $Settings.AllowAnonymousUsersToJoinMeeting = $CurrentState.AllowAnonymousUsersToJoinMeeting }
-    if ($null -eq $Settings.MeetingChatEnabledType) { $Settings.MeetingChatEnabledType = $CurrentState.MeetingChatEnabledType } # Enabled, EnabledExceptAnonymous, Disabled
-
     $StateIsCorrect = ($CurrentState.AllowAnonymousUsersToJoinMeeting -eq $Settings.AllowAnonymousUsersToJoinMeeting) -and
                         ($CurrentState.AllowAnonymousUsersToStartMeeting -eq $false) -and
                         ($CurrentState.AutoAdmittedUsers -eq 'EveryoneInCompanyExcludingGuests') -and
                         ($CurrentState.AllowPSTNUsersToBypassLobby -eq $false) -and
-                        ($CurrentState.MeetingChatEnabledType -eq $Settings.MeetingChatEnabledType) -and
-                        ($CurrentState.DesignatedPresenterRoleMode -eq $Settings.DesignatedPresenterRoleMode) -and
+                        ($CurrentState.MeetingChatEnabledType -eq $Settings.MeetingChatEnabledType.value) -and
+                        ($CurrentState.DesignatedPresenterRoleMode -eq $Settings.DesignatedPresenterRoleMode.value) -and
                         ($CurrentState.AllowExternalParticipantGiveRequestControl -eq $false)
 
     if ($Settings.remediate -eq $true) {
@@ -57,8 +53,8 @@ Function Invoke-CIPPStandardTeamsGlobalMeetingPolicy {
                 AllowAnonymousUsersToStartMeeting          = $false
                 AutoAdmittedUsers                          = 'EveryoneInCompanyExcludingGuests'
                 AllowPSTNUsersToBypassLobby                = $false
-                MeetingChatEnabledType                     = $Settings.MeetingChatEnabledType
-                DesignatedPresenterRoleMode                = $Settings.DesignatedPresenterRoleMode
+                MeetingChatEnabledType                     = $Settings.MeetingChatEnabledType.value
+                DesignatedPresenterRoleMode                = $Settings.DesignatedPresenterRoleMode.value
                 AllowExternalParticipantGiveRequestControl = $false
             }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTeamsMessagingPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTeamsMessagingPolicy.ps1
@@ -43,7 +43,6 @@ Function Invoke-CIPPStandardTeamsMessagingPolicy {
     if ($null -eq $Settings.AllowUserDeleteMessage) { $Settings.AllowUserDeleteMessage = $CurrentState.AllowUserDeleteMessage }
     if ($null -eq $Settings.AllowUserEditMessage) { $Settings.AllowUserEditMessage = $CurrentState.AllowUserEditMessage }
     if ($null -eq $Settings.AllowUserDeleteChat) { $Settings.AllowUserDeleteChat = $CurrentState.AllowUserDeleteChat }
-    if ($null -eq $Settings.ReadReceiptsEnabledType) { $Settings.ReadReceiptsEnabledType = $CurrentState.ReadReceiptsEnabledType }
     if ($null -eq $Settings.CreateCustomEmojis) { $Settings.CreateCustomEmojis = $CurrentState.CreateCustomEmojis }
     if ($null -eq $Settings.DeleteCustomEmojis) { $Settings.DeleteCustomEmojis = $CurrentState.DeleteCustomEmojis }
     if ($null -eq $Settings.AllowSecurityEndUserReporting) { $Settings.AllowSecurityEndUserReporting = $CurrentState.AllowSecurityEndUserReporting }
@@ -53,7 +52,7 @@ Function Invoke-CIPPStandardTeamsMessagingPolicy {
                         ($CurrentState.AllowUserDeleteMessage -eq $Settings.AllowUserDeleteMessage) -and
                         ($CurrentState.AllowUserEditMessage -eq $Settings.AllowUserEditMessage) -and
                         ($CurrentState.AllowUserDeleteChat -eq $Settings.AllowUserDeleteChat) -and
-                        ($CurrentState.ReadReceiptsEnabledType -eq $Settings.ReadReceiptsEnabledType) -and
+                        ($CurrentState.ReadReceiptsEnabledType -eq $Settings.ReadReceiptsEnabledType.value) -and
                         ($CurrentState.CreateCustomEmojis -eq $Settings.CreateCustomEmojis) -and
                         ($CurrentState.DeleteCustomEmojis -eq $Settings.DeleteCustomEmojis) -and
                         ($CurrentState.AllowSecurityEndUserReporting -eq $Settings.AllowSecurityEndUserReporting) -and
@@ -69,7 +68,7 @@ Function Invoke-CIPPStandardTeamsMessagingPolicy {
                 AllowUserDeleteMessage = $Settings.AllowUserDeleteMessage
                 AllowUserEditMessage = $Settings.AllowUserEditMessage
                 AllowUserDeleteChat = $Settings.AllowUserDeleteChat
-                ReadReceiptsEnabledType = $Settings.ReadReceiptsEnabledType
+                ReadReceiptsEnabledType = $Settings.ReadReceiptsEnabledType.value
                 CreateCustomEmojis = $Settings.CreateCustomEmojis
                 DeleteCustomEmojis = $Settings.DeleteCustomEmojis
                 AllowSecurityEndUserReporting = $Settings.AllowSecurityEndUserReporting


### PR DESCRIPTION
Should fix these standards
* GuestInvite
* SpamFilterPolicy
* IntuneComplianceSettings
    * https://github.com/KelvinTegelaar/CIPP/issues/3507
* TeamsGlobalMeetingPolicy
* TeamsEnrollUser
* TeamsFederationConfiguration
* TeamsMessagingPolicy