### PR TITLE
Add Clear-CIPPImmutableId function and update Invoke-CIPPOffboardingJob to include it

### DIFF
--- a/Modules/CIPPCore/Public/Clear-CIPPImmutableId.ps1
+++ b/Modules/CIPPCore/Public/Clear-CIPPImmutableId.ps1
@@ -1,0 +1,22 @@
+function Clear-CIPPImmutableId {
+    [CmdletBinding()]
+    param (
+        $TenantFilter,
+        $userid,
+        $Headers,
+        $APIName
+    )
+
+    try {
+        $Body = [pscustomobject]@{ onPremisesImmutableId = $null }
+        $Body = ConvertTo-Json -InputObject $Body -Depth 5 -Compress
+        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$userid" -tenantid $TenantFilter -type PATCH -body $Body
+        Write-LogMessage -headers $Headers -API $APIName -message "Successfully cleared immutable ID for $userid" -sev Info
+        return 'Successfully cleared immutable ID for user.'
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        $Message = "Could not clear immutable ID for $($userid): $($ErrorMessage.NormalizedError)"
+        Write-LogMessage -headers $Headers -API $APIName -message $Message -sev Error -LogData $ErrorMessage
+        return $Message
+    }
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecClrImmId.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecClrImmId.ps1
@@ -11,28 +11,23 @@ Function Invoke-ExecClrImmId {
     param($Request, $TriggerMetadata)
 
     $APIName = $Request.Params.CIPPEndpoint
-    Write-LogMessage -headers $Request.Headers -API $APINAME -message 'Accessed this API' -Sev 'Debug'
+    $TenantFilter = $Request.Query.tenantFilter ?? $Request.Body.tenantFilter
+    Write-LogMessage -headers $Request.Headers -API $APIName -message 'Accessed this API' -Sev Debug
+    $UserID = $Request.Query.ID ?? $Request.Body.ID
 
-    # Write to the Azure Functions log stream.
-    Write-Host 'PowerShell HTTP trigger function processed a request.'
-
-    # Interact with query parameters or the body of the request.
     Try {
-        $TenantFilter = $Request.Query.TenantFilter
-        $UserID = $Request.Query.ID
-        $Body = [pscustomobject]@{ onPremisesImmutableId = $null }
-        $Body = ConvertTo-Json -InputObject $Body -Depth 5 -Compress
-        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$UserID" -tenantid $TenantFilter -type PATCH -body $Body
-        $Results = [pscustomobject]@{'Results' = 'Successfully Cleared ImmutableId' }
+        $Result = Clear-CIPPImmutableId -userid $UserID -TenantFilter $TenantFilter -Headers $Request.Headers -APIName $APIName
+        $StatusCode = [HttpStatusCode]::OK
     } catch {
-        $ErrorMessage = Get-NormalizedError -Message $_.Exception
-        $Results = [pscustomobject]@{'Results' = "Failed. $ErrorMessage"; colour = 'danger' }
-        $_.Exception
+        $ErrorMessage = Get-CippException -Exception $_
+        $Result = $ErrorMessage.NormalizedError
+        $StatusCode = [HttpStatusCode]::InternalServerError
     }
 
+    $Results = [pscustomobject]@{'Results' = $Result }
     # Associate values to output bindings by calling 'Push-OutputBinding'.
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
-            StatusCode = [HttpStatusCode]::OK
+            StatusCode = $StatusCode
             Body       = $Results
         })
 }

--- a/Modules/CIPPCore/Public/Invoke-CIPPOffboardingJob.ps1
+++ b/Modules/CIPPCore/Public/Invoke-CIPPOffboardingJob.ps1
@@ -22,13 +22,13 @@ function Invoke-CIPPOffboardingJob {
             Revoke-CIPPSessions -tenantFilter $tenantFilter -username $username -userid $userid -Headers $Headers -APIName $APIName
         }
         { $_.ResetPass -eq $true } {
-            Set-CIPPResetPassword -tenantFilter $tenantFilter -userid $username -Headers $Headers -APIName $APIName
+            Set-CIPPResetPassword -tenantFilter $tenantFilter -UserID $username -Headers $Headers -APIName $APIName
         }
         { $_.RemoveGroups -eq $true } {
             Remove-CIPPGroups -userid $userid -tenantFilter $Tenantfilter -Headers $Headers -APIName $APIName -Username "$Username"
         }
         { $_.'HideFromGAL' -eq $true } {
-            Set-CIPPHideFromGAL -tenantFilter $tenantFilter -userid $username -HideFromGAL $true -Headers $Headers -APIName $APIName
+            Set-CIPPHideFromGAL -tenantFilter $tenantFilter -UserID $username -hidefromgal $true -Headers $Headers -APIName $APIName
         }
         { $_.'DisableSignIn' -eq $true } {
             Set-CIPPSignInState -TenantFilter $tenantFilter -userid $username -AccountEnabled $false -Headers $Headers -APIName $APIName
@@ -95,6 +95,9 @@ function Invoke-CIPPOffboardingJob {
         }
         { $_.'RemoveMFADevices' } {
             Remove-CIPPUserMFA -UserPrincipalName $Username -TenantFilter $TenantFilter -Headers $Headers
+        }
+        { $_.'ClearImmutableId' -eq $true } {
+            Clear-CIPPImmutableId -userid $userid -TenantFilter $TenantFilter -Headers $Headers -APIName $APIName
         }
     }
     return $Return


### PR DESCRIPTION
Introduce a new function to clear the on-premises immutable ID for a user and integrate this functionality into the offboarding job process.

Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/3608