### PR TITLE
Fixed error - You can only set email address that belongs to your org…

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardUserSubmissions.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardUserSubmissions.ps1
@@ -106,8 +106,11 @@ function Invoke-CIPPStandardUserSubmissions {
                     $PolicyParams = @{
                         EnableReportToMicrosoft          = $true
                         ReportJunkToCustomizedAddress    = $false
+                        ReportJunkAddresses              = $null
                         ReportNotJunkToCustomizedAddress = $false
+                        ReportNotJunkAddresses           = $null
                         ReportPhishToCustomizedAddress   = $false
+                        ReportPhishAddresses             = $null
                     }
                 } else {
                     $PolicyParams = @{


### PR DESCRIPTION
…anization in report submission policy Identity:"DefaultReportSubmissionPolicy".

Issue #3714