### PR TITLE
Fix Name Filter

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Scheduler/Invoke-ListScheduledItems.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Scheduler/Invoke-ListScheduledItems.ps1
@@ -29,7 +29,7 @@ Function Invoke-ListScheduledItems {
         $ScheduledItemFilter.Add('Hidden eq false')
     }
 
-    if ($Name -eq $true) {
+    if ($Name) {
         $ScheduledItemFilter.Add("Name eq '$($Name)'")
     }
 


### PR DESCRIPTION
Noticed CIPP > Application Settings > Manage Backups was not showing Automated Backups and Next Backup properly. /ListScheduledItems?Name=Automated+CIPP+Backup was returning all ScheduledTasks. This change seems to fix this issue, not sure if it introduces a regression risk.