### PR TITLE
feat: Added DoNotRewriteUrls and AllowedSenderDomains

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
@@ -59,7 +59,7 @@ function Invoke-CIPPStandardSafeLinksPolicy {
 
         $CurrentState = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksPolicy' |
             Where-Object -Property Name -EQ $PolicyName |
-            Select-Object Name, EnableSafeLinksForEmail, EnableSafeLinksForTeams, EnableSafeLinksForOffice, TrackClicks, AllowClickThrough, ScanUrls, EnableForInternalSenders, DeliverMessageAfterScan, DisableUrlRewrite, EnableOrganizationBranding
+            Select-Object Name, EnableSafeLinksForEmail, EnableSafeLinksForTeams, EnableSafeLinksForOffice, TrackClicks, AllowClickThrough, ScanUrls, EnableForInternalSenders, DeliverMessageAfterScan, DisableUrlRewrite, EnableOrganizationBranding, DoNotRewriteUrls
 
         $StateIsCorrect = ($CurrentState.Name -eq $PolicyName) -and
                         ($CurrentState.EnableSafeLinksForEmail -eq $true) -and
@@ -71,7 +71,8 @@ function Invoke-CIPPStandardSafeLinksPolicy {
                         ($CurrentState.DeliverMessageAfterScan -eq $true) -and
                         ($CurrentState.AllowClickThrough -eq $Settings.AllowClickThrough) -and
                         ($CurrentState.DisableUrlRewrite -eq $Settings.DisableUrlRewrite) -and
-                        ($CurrentState.EnableOrganizationBranding -eq $Settings.EnableOrganizationBranding)
+                        ($CurrentState.EnableOrganizationBranding -eq $Settings.EnableOrganizationBranding) -and
+                        (!(Compare-Object -ReferenceObject $CurrentState.DoNotRewriteUrls -DifferenceObject ($Settings.DoNotRewriteUrls.value ?? $Settings.DoNotRewriteUrls)))
 
         $AcceptedDomains = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AcceptedDomain'
 
@@ -100,6 +101,7 @@ function Invoke-CIPPStandardSafeLinksPolicy {
                     AllowClickThrough          = $Settings.AllowClickThrough
                     DisableUrlRewrite          = $Settings.DisableUrlRewrite
                     EnableOrganizationBranding = $Settings.EnableOrganizationBranding
+                    DoNotRewriteUrls           = $Settings.DoNotRewriteUrls.value ?? @{"@odata.type" = "#Exchange.GenericHashTable"}
                 }
 
                 if ($CurrentState.Name -eq $Policyname) {

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
@@ -100,7 +100,8 @@ function Invoke-CIPPStandardSpamFilterPolicy {
                         ($CurrentState.EnableLanguageBlockList -eq $Settings.EnableLanguageBlockList) -and
                         ((-not $CurrentState.LanguageBlockList -and -not $Settings.LanguageBlockList.value) -or (!(Compare-Object -ReferenceObject $CurrentState.LanguageBlockList -DifferenceObject $Settings.LanguageBlockList.value))) -and
                         ($CurrentState.EnableRegionBlockList -eq $Settings.EnableRegionBlockList) -and
-                        ((-not $CurrentState.RegionBlockList -and -not $Settings.RegionBlockList.value) -or (!(Compare-Object -ReferenceObject $CurrentState.RegionBlockList -DifferenceObject $Settings.RegionBlockList.value)))
+                        ((-not $CurrentState.RegionBlockList -and -not $Settings.RegionBlockList.value) -or (!(Compare-Object -ReferenceObject $CurrentState.RegionBlockList -DifferenceObject $Settings.RegionBlockList.value))) -and
+                        (!(Compare-Object -ReferenceObject $CurrentState.AllowedSenderDomains -DifferenceObject ($Settings.AllowedSenderDomains.value ?? $Settings.AllowedSenderDomains)))
 
     $AcceptedDomains = New-ExoRequest -TenantId $Tenant -cmdlet 'Get-AcceptedDomain'
 
@@ -153,6 +154,7 @@ function Invoke-CIPPStandardSpamFilterPolicy {
                 LanguageBlockList                    = $Settings.LanguageBlockList.value
                 EnableRegionBlockList                = $Settings.EnableRegionBlockList
                 RegionBlockList                      = $Settings.RegionBlockList.value
+                AllowedSenderDomains                 = $Settings.AllowedSenderDomains.value ?? @{"@odata.type" = "#Exchange.GenericHashTable"}
             }
 
             if ($CurrentState.Name -eq $PolicyName) {


### PR DESCRIPTION
* API for https://github.com/KelvinTegelaar/CIPP/pull/3773

This is so the CIPP standard policy can do this
* [Allowlist Phishing Emails in Microsoft Office 365 Defender Basic and Advanced](https://support.huntress.io/hc/en-us/articles/10962584987795-Allowlist-Phishing-Emails-in-Microsoft-Office-365-Defender-Basic-and-Advanced)
* [Allowlist Phish Emails in Microsoft Active Threat Protection (Safelinks)](https://support.huntress.io/hc/en-us/articles/10962581248147-Allowlist-Phish-Emails-in-Microsoft-Active-Threat-Protection-Safelinks)