### PR TITLE
Fix tenant filter fallback in Invoke-ExecOffboardUser function

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecOffboardUser.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecOffboardUser.ps1
@@ -10,7 +10,7 @@ Function Invoke-ExecOffboardUser {
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
     $AllUsers = $Request.Body.user.value
-    $TenantFilter = $request.Body.tenantFilter.value
+    $TenantFilter = $request.Body.tenantFilter.value ?? $Request.Body.tenantFilter
     $Results = foreach ($username in $AllUsers) {
         try {
             $APIName = 'ExecOffboardUser'


### PR DESCRIPTION
Enhance the handling of tenant filters to support both v6 format and CIPPAPIModule.