### PR TITLE
Filter out OOF and junk inbox rules in Push-BECRun function

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/BEC/Push-BECRun.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/BEC/Push-BECRun.ps1
@@ -96,7 +96,8 @@ function Push-BECRun {
         Write-Information 'Getting rules'
 
         try {
-            $RulesLog = New-ExoRequest -cmdlet 'Get-InboxRule' -tenantid $TenantFilter -cmdParams @{ Mailbox = $Username; IncludeHidden = $true } -Anchor $Username
+            $RulesLog = New-ExoRequest -cmdlet 'Get-InboxRule' -tenantid $TenantFilter -cmdParams @{ Mailbox = $Username; IncludeHidden = $true } -Anchor $Username |
+                Where-Object { $_.Name -ne 'Junk E-Mail Rule' -and $_.Name -notlike 'Microsoft.Exchange.OOF.*' }
         } catch {
             Write-Host 'Failed to get rules: ' + $_.Exception.Message
             $RulesLog = @()


### PR DESCRIPTION
Exclude 'Junk E-Mail Rule' and out-of-office rules from the rules retrieved in the Push-BECRun function.
Like they are in the normal shown inbox rules