### PR TITLE
Feat: Enable and disable mailbox rules

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecSetMailboxRule.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecSetMailboxRule.ps1
@@ -1,0 +1,58 @@
+﻿using namespace System.Net
+
+Function Invoke-ExecSetMailboxRule {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Mailbox.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message 'Accessed this API' -Sev 'Debug'
+
+    # Interact with the query or body of the request
+    $TenantFilter = $Request.Body.TenantFilter
+    $RuleName = $Request.Body.ruleName
+    $RuleId = $Request.Body.ruleId
+    $Username = $Request.Body.userPrincipalName
+    $Enable = $Request.Body.Enable -as [bool]
+    $Disable = $Request.Body.Disable -as [bool]
+
+
+    # Set the rule
+    $SetCIPPMailboxRuleParams = @{
+        Username     = $Username
+        TenantFilter = $TenantFilter
+        APIName      = $APIName
+        Headers      = $Headers
+        RuleId       = $RuleId
+        RuleName     = $RuleName
+    }
+    if ($Enable -eq $true) {
+        $SetCIPPMailboxRuleParams.Add('Enable', $true)
+    } elseif ($Disable -eq $true) {
+        $SetCIPPMailboxRuleParams.Add('Disable', $true)
+    } else {
+        Write-LogMessage -headers $Headers -API $APIName -message 'No state provided for mailbox rule' -Sev 'Error' -tenant $TenantFilter
+        throw 'No state provided for mailbox rule'
+    }
+
+    $Results = Set-CIPPMailboxRule @SetCIPPMailboxRuleParams
+
+    if ($Results -like '*Could not set*') {
+        $StatusCode = [HttpStatusCode]::InternalServerError
+    } else {
+        $StatusCode = [HttpStatusCode]::OK
+    }
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{ Results = $Results }
+        })
+
+}

--- a/Modules/CIPPCore/Public/Remove-CIPPMailboxRule.ps1
+++ b/Modules/CIPPCore/Public/Remove-CIPPMailboxRule.ps1
@@ -1,8 +1,8 @@
 function Remove-CIPPMailboxRule {
     [CmdletBinding()]
     param (
-        $userid,
-        $username,
+        $UserId,
+        $Username,
         $TenantFilter,
         $APIName = 'Mailbox Rules Removal',
         $Headers,
@@ -14,35 +14,34 @@ function Remove-CIPPMailboxRule {
     if ($RemoveAllRules.IsPresent -eq $true) {
         # Delete all rules
         try {
-            Write-Host "Checking rules for $username"
-            $rules = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-InboxRule' -cmdParams @{Mailbox = $username; IncludeHidden = $true } | Where-Object { $_.Name -ne 'Junk E-Mail Rule' -and $_.Name -notlike 'Microsoft.Exchange.OOF.*' }
-            Write-Host "$($rules.count) rules found"
-            if ($null -eq $rules) {
-                Write-LogMessage -headers $Headers -API $APIName -message "No Rules for $($username) to delete" -Sev 'Info' -tenant $TenantFilter
-                return "No rules for $($username) to delete"
+            Write-Host "Checking rules for $Username"
+            $Rules = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-InboxRule' -cmdParams @{Mailbox = $Username; IncludeHidden = $true } | Where-Object { $_.Name -ne 'Junk E-Mail Rule' -and $_.Name -notlike 'Microsoft.Exchange.OOF.*' }
+            Write-Host "$($Rules.count) rules found"
+            if ($null -eq $Rules) {
+                Write-LogMessage -headers $Headers -API $APIName -message "No Rules for $($Username) to delete" -Sev 'Info' -tenant $TenantFilter
+                return "No rules for $($Username) to delete"
             } else {
-                ForEach ($rule in $rules) {
-                    $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Remove-InboxRule' -Anchor $username -cmdParams @{Identity = $rule.Identity }
+                ForEach ($rule in $Rules) {
+                    $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Remove-InboxRule' -Anchor $Username -cmdParams @{Identity = $rule.Identity }
                 }
-                Write-LogMessage -headers $Headers -API $APIName -message "Deleted Rules for $($username)" -Sev 'Info' -tenant $TenantFilter
-                return "Deleted Rules for $($username)"
+                Write-LogMessage -headers $Headers -API $APIName -message "Deleted rules for $($Username)" -Sev 'Info' -tenant $TenantFilter
+                return "Deleted rules for $($Username)"
             }
         } catch {
             $ErrorMessage = Get-CippException -Exception $_
-            Write-LogMessage -headers $Headers -API $APIName -message "Could not delete rules for $($username): $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
-            return "Could not delete rules for $($username). Error: $($ErrorMessage.NormalizedError)"
+            Write-LogMessage -headers $Headers -API $APIName -message "Could not delete rules for $($Username): $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
+            return "Could not delete rules for $($Username). Error: $($ErrorMessage.NormalizedError)"
         }
     } else {
         # Only delete 1 rule
         try {
-            $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Remove-InboxRule' -Anchor $username -cmdParams @{Identity = $RuleId }
-            Write-LogMessage -headers $Headers -API $APIName -message "Deleted mailbox rule $($RuleName) for $($username)" -Sev 'Info' -tenant $TenantFilter
-            return "Deleted mailbox rule $($RuleName) for $($username)"
+            $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Remove-InboxRule' -Anchor $Username -cmdParams @{Identity = $RuleId }
+            Write-LogMessage -headers $Headers -API $APIName -message "Deleted mailbox rule $($RuleName) for $($Username)" -Sev 'Info' -tenant $TenantFilter
+            return "Deleted mailbox rule $($RuleName) for $($Username)"
         } catch {
             $ErrorMessage = Get-CippException -Exception $_
-            Write-LogMessage -headers $Headers -API $APIName -message "Could not delete rule for $($username): $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
-            return "Could not delete rule for $($username). Error: $($ErrorMessage.NormalizedError)"
+            Write-LogMessage -headers $Headers -API $APIName -message "Could not delete rule for $($Username): $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
+            return "Could not delete rule for $($Username). Error: $($ErrorMessage.NormalizedError)"
         }
     }
 }
-

--- a/Modules/CIPPCore/Public/Set-CIPPMailboxRule.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPMailboxRule.ps1
@@ -1,0 +1,34 @@
+﻿function Set-CIPPMailboxRule {
+    [CmdletBinding()]
+    param (
+        $UserId,
+        $Username,
+        $TenantFilter,
+        $APIName = 'Set mailbox rules',
+        $Headers,
+        $RuleId,
+        $RuleName,
+        [switch]$Enable,
+        [switch]$Disable
+    )
+
+    if ($Enable.IsPresent -eq $true) {
+        $State = 'Enable'
+    } elseif ($Disable.IsPresent -eq $true) {
+        $State = 'Disable'
+    } else {
+        Write-LogMessage -headers $Headers -API $APIName -message 'No state provided for mailbox rule' -Sev 'Error' -tenant $TenantFilter
+        throw 'No state provided for mailbox rule'
+    }
+
+    try {
+        $null = New-ExoRequest -tenantid $TenantFilter -cmdlet "$State-InboxRule" -Anchor $Username -cmdParams @{Identity = $RuleId }
+        Write-LogMessage -headers $Headers -API $APIName -message "Successfully set mailbox rule $($RuleName) for $($Username) to $($State)d" -Sev 'Info' -tenant $TenantFilter
+        return "Successfully set mailbox rule $($RuleName) for $($Username) to $($State)d"
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -headers $Headers -API $APIName -message "Could not set mailbox rule $($RuleName) for $($Username) to $($State)d. Error: $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
+        throw "Could not set mailbox rule $($RuleName) for $($Username) to $($State)d. Error: $($ErrorMessage.NormalizedError)"
+    }
+
+}


### PR DESCRIPTION
Refactor the `Remove-CIPPMailboxRule` function for consistent parameter casing and introduce `Invoke-ExecSetMailboxRule` and `Set-CIPPMailboxRule` functions to enhance mailbox rule management capabilities.