### PR TITLE
feat:Add functions for AP device renaming and editing group tag

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/Autopilot/Invoke-ExecRenameAPDevice.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/Autopilot/Invoke-ExecRenameAPDevice.ps1
@@ -1,0 +1,61 @@
+using namespace System.Net
+
+Function Invoke-ExecRenameAPDevice {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Endpoint.Autopilot.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -Headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+    $TenantFilter = $Request.Body.tenantFilter
+
+
+    try {
+        $DeviceId = $Request.Body.deviceId
+        $SerialNumber = $Request.Body.serialNumber
+        $DisplayName = $Request.Body.displayName
+
+        # Validation
+        if ($DisplayName.Length -gt 15) {
+            $ValidationError = 'Display name cannot exceed 15 characters.'
+        } elseif ($DisplayName -notmatch '^[a-zA-Z0-9-]+$') {
+            # This regex also implicitly checks for spaces
+            $ValidationError = 'Display name can only contain letters (a-z, A-Z), numbers (0-9), and hyphens (-).'
+        } elseif ($DisplayName -match '^\d+$') {
+            $ValidationError = 'Display name cannot consist solely of numbers.'
+        }
+
+        if ($null -ne $ValidationError) {
+            $Result = "Validation failed: $ValidationError"
+            $StatusCode = [HttpStatusCode]::BadRequest
+        } else {
+            # Validation passed, proceed with Graph API call
+            $body = @{
+                displayName = $DisplayName
+            } | ConvertTo-Json
+
+            New-GraphPOSTRequest -uri "https://graph.microsoft.com/beta/deviceManagement/windowsAutopilotDeviceIdentities/$($DeviceId)/UpdateDeviceProperties" -tenantid $TenantFilter -body $body -method POST | Out-Null
+            $Result = "Successfully renamed device '$($DeviceId)' with serial number '$($SerialNumber)' to '$($DisplayName)'"
+            Write-LogMessage -Headers $User -API $APINAME -message $Result -Sev Info
+            $StatusCode = [HttpStatusCode]::OK
+        }
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        $Result = "Could not rename device '$($DeviceId)' with serial number '$($SerialNumber)' to '$($DisplayName)'. Error: $($ErrorMessage.NormalizedError)"
+        Write-LogMessage -Headers $User -API $APINAME -message $Result -Sev Error -LogData $ErrorMessage
+        $StatusCode = [HttpStatusCode]::BadRequest
+    }
+
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{ Results = $Result }
+        })
+
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/Autopilot/Invoke-ExecSetAPDeviceGroupTag.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/Autopilot/Invoke-ExecSetAPDeviceGroupTag.ps1
@@ -1,0 +1,53 @@
+using namespace System.Net
+
+Function Invoke-ExecSetAPDeviceGroupTag {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Endpoint.Autopilot.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -Headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+    $TenantFilter = $Request.Body.tenantFilter
+
+    try {
+        $DeviceId = $Request.Body.deviceId
+        $SerialNumber = $Request.Body.serialNumber
+        $GroupTag = $Request.Body.groupTag
+
+        # Validation - GroupTag can be empty, but if provided, validate it
+        if ($null -ne $GroupTag -and $GroupTag -ne '' -and $GroupTag.Length -gt 128) {
+            $ValidationError = 'Group tag cannot exceed 128 characters.'
+        }
+
+        if ($null -ne $ValidationError) {
+            $Result = "Validation failed: $ValidationError"
+            $StatusCode = [HttpStatusCode]::BadRequest
+        } else {
+            # Validation passed, proceed with Graph API call
+            $body = @{
+                groupTag = $GroupTag
+            } | ConvertTo-Json
+
+            New-GraphPOSTRequest -uri "https://graph.microsoft.com/beta/deviceManagement/windowsAutopilotDeviceIdentities/$($DeviceId)/UpdateDeviceProperties" -tenantid $TenantFilter -body $body -method POST | Out-Null
+            $Result = "Successfully updated group tag for device '$($DeviceId)' with serial number '$($SerialNumber)' to '$($GroupTag)'"
+            Write-LogMessage -Headers $Headers -API $APIName -message $Result -Sev Info
+            $StatusCode = [HttpStatusCode]::OK
+        }
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        $Result = "Could not update group tag for device '$($DeviceId)' with serial number '$($SerialNumber)' to '$($GroupTag)'. Error: $($ErrorMessage.NormalizedError)"
+        Write-LogMessage -Headers $Headers -API $APIName -message $Result -Sev Error -LogData $ErrorMessage
+        $StatusCode = [HttpStatusCode]::BadRequest
+    }
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{ Results = $Result }
+        })
+}


### PR DESCRIPTION
Implement a new function to rename Autopilot devices, including validation for display names and integration with the Microsoft Graph API for updating device properties.
Resolves https://github.com/KelvinTegelaar/CIPP/issues/3909