### PR TITLE
Fix: Mailboxes page not loading and sync ListMailboxes select statements

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1
@@ -56,15 +56,15 @@ Function Invoke-ListMailboxes {
             }
         }
 
-        $GraphRequest = (New-ExoRequest @ExoRequest) | Select-Object id, ExchangeGuid, ArchiveGuid, WhenSoftDeleted, @{ Name = 'UPN'; Expression = { $_.'UserPrincipalName' } },
-
+        $GraphRequest = (New-ExoRequest @ExoRequest) | Select-Object id, ExchangeGuid, ArchiveGuid, WhenSoftDeleted,
+        @{ Name = 'UPN'; Expression = { $_.'UserPrincipalName' } },
         @{ Name = 'displayName'; Expression = { $_.'DisplayName' } },
         @{ Name = 'primarySmtpAddress'; Expression = { $_.'PrimarySMTPAddress' } },
         @{ Name = 'recipientType'; Expression = { $_.'RecipientType' } },
         @{ Name = 'recipientTypeDetails'; Expression = { $_.'RecipientTypeDetails' } },
         @{ Name = 'AdditionalEmailAddresses'; Expression = { ($_.'EmailAddresses' | Where-Object { $_ -clike 'smtp:*' }).Replace('smtp:', '') -join ', ' } },
-        @{Name = 'ForwardingSmtpAddress'; Expression = { $_.'ForwardingSmtpAddress' -replace 'smtp:', '' } },
-        @{Name = 'InternalForwardingAddress'; Expression = { $_.'ForwardingAddress' } },
+        @{ Name = 'ForwardingSmtpAddress'; Expression = { $_.'ForwardingSmtpAddress' -replace 'smtp:', '' } },
+        @{ Name = 'InternalForwardingAddress'; Expression = { $_.'ForwardingAddress' } },
         DeliverToMailboxAndForward,
         HiddenFromAddressListsEnabled,
         ExternalDirectoryObjectId,
@@ -75,7 +75,7 @@ Function Invoke-ListMailboxes {
         LitigationHoldDuration,
         @{ Name = 'LicensedForLitigationHold'; Expression = { ($_.PersistedCapabilities -contains 'BPOS_S_DlpAddOn' -or $_.PersistedCapabilities -contains 'BPOS_S_Enterprise') } },
         ComplianceTagHoldApplied,
-        RetentionHoldEnabled,
+        RetentionHoldEnabled
 
         $StatusCode = [HttpStatusCode]::OK
     } catch {

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1
@@ -77,6 +77,7 @@ Function Invoke-ListMailboxes {
         ComplianceTagHoldApplied,
         RetentionHoldEnabled,
         InPlaceHolds
+        # This select also exists in ListUserMailboxDetails and should be updated if this is changed here
 
         $StatusCode = [HttpStatusCode]::OK
     } catch {


### PR DESCRIPTION
Change a bit of formatting, and remove a trailing comma in the GraphRequest select statement, breaking the page