### PR TITLE
Add Exchange Recipient Limits Management

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecSetRecipientLimits.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecSetRecipientLimits.ps1
@@ -1,0 +1,50 @@
+function Invoke-ExecSetRecipientLimits {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Mailbox.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message 'Accessed this API' -Sev 'Debug'
+
+    # Interact with the query or body of the request
+    $TenantFilter = $Request.Body.tenantFilter
+    $recipientLimit = $Request.Body.recipientLimit
+    $Identity = $Request.Body.Identity
+    $UserPrincipalName = $Request.Body.userid
+
+    # Set the parameters for the EXO request
+    $ExoRequest = @{
+        tenantid  = $TenantFilter
+        cmdlet    = 'Set-Mailbox'
+        cmdParams = @{
+            Identity              = $Identity
+            RecipientLimits       = $recipientLimit
+        }
+    }
+
+    # Execute the EXO request
+    try {
+        $null = New-ExoRequest @ExoRequest
+        $Results = "Recipient limit for $UserPrincipalName has been set to $recipientLimit"
+        
+        Write-LogMessage -API $APIName -tenant $TenantFilter -message $Results -sev Info
+        $StatusCode = [HttpStatusCode]::OK
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        $Results = "Could not set recipient limit for $UserPrincipalName to $recipientLimit. Error: $($ErrorMessage.NormalizedError)"
+        Write-LogMessage -API $APIName -tenant $TenantFilter -message $Results -sev Error -LogData $ErrorMessage
+        $StatusCode = [HttpStatusCode]::InternalServerError
+    }
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{ Results = $Results }
+        })
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUser.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUser.ps1
@@ -38,15 +38,20 @@ Function Invoke-AddUser {
     } else {
         $CreationResults = New-CIPPUserTask -userobj $UserObj -APIName $APINAME -Headers $Request.Headers
         $body = [pscustomobject] @{
-            'Results'  = $CreationResults.Results
-            'Username' = $CreationResults.username
-            'Password' = $CreationResults.password
+            'Results'  = @(
+                $CreationResults.Results[0],
+                $CreationResults.Results[1],
+                @{
+                    'resultText' = $CreationResults.Results[2]
+                    'copyField' = $CreationResults.password
+                    'state' = 'success'
+                }
+            )
             'CopyFrom' = @{
                 'Success' = $CreationResults.CopyFrom.Success
                 'Error'   = $CreationResults.CopyFrom.Error
             }
         }
-
     }
     # Associate values to output bindings by calling 'Push-OutputBinding'.
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{

--- a/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
@@ -13,7 +13,6 @@ function New-CIPPUserTask {
         $Results.Add('Created New User.')
         $Results.Add("Username: $($CreationResults.Username)")
         $Results.Add("Password: $($CreationResults.Password)")
-        $Results.Add("$($CreationResults.Password)")
     } catch {
         $Results.Add("Failed to create user. $($_.Exception.Message)" )
         return @{'Results' = $Results }


### PR DESCRIPTION
Adds new HTTP function `Invoke-ExecSetRecipientLimits` to manage Exchange mailbox recipient limits through the CIPP API. The function allows setting recipient limits for specific mailboxes with proper error handling and logging.