### PR TITLE
Fix: Variable casing and improve logging in Invoke-RemoveStandardTemplate function

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-RemoveStandardTemplate.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-RemoveStandardTemplate.ps1
@@ -12,22 +12,23 @@ Function Invoke-RemoveStandardTemplate {
 
     $APIName = $Request.Params.CIPPEndpoint
     $Headers = $Request.Headers
-    Write-LogMessage -Headers $Headers -API $APINAME -message 'Accessed this API' -Sev 'Debug'
+    Write-LogMessage -Headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
 
     # Interact with query parameters or the body of the request.
     $ID = $Request.Body.ID ?? $Request.Query.ID
     try {
         $Table = Get-CippTable -tablename 'templates'
-        $Filter = "PartitionKey eq 'StandardsTemplateV2' and RowKey eq '$id'"
-        $ClearRow = Get-CIPPAzDataTableEntity @Table -Filter $Filter -Property PartitionKey, RowKey
-        Remove-AzDataTableEntity -Force @Table -Entity $clearRow
-        $Result = "Removed Standards Template named $($ClearRow.name) and id $($id)"
-        Write-LogMessage -Headers $Headers -API $APINAME -message $Result -Sev 'Info'
+        $Filter = "PartitionKey eq 'StandardsTemplateV2' and RowKey eq '$ID'"
+        $ClearRow = Get-CIPPAzDataTableEntity @Table -Filter $Filter -Property PartitionKey, RowKey, JSON
+        $TemplateName = (ConvertFrom-Json -InputObject $ClearRow.JSON).templateName
+        Remove-AzDataTableEntity -Force @Table -Entity $ClearRow
+        $Result = "Removed Standards Template named: '$($TemplateName)' with id: $($ID)"
+        Write-LogMessage -Headers $Headers -API $APIName -message $Result -Sev Info
         $StatusCode = [HttpStatusCode]::OK
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
-        $Result = "Failed to remove Standards template $ID. $($ErrorMessage.NormalizedError)"
-        Write-LogMessage -Headers $Headers -API $APINAME -message $Result -Sev 'Error' -LogData $ErrorMessage
+        $Result = "Failed to remove Standards template: $TemplateName with id: $ID. Error: $($ErrorMessage.NormalizedError)"
+        Write-LogMessage -Headers $Headers -API $APIName -message $Result -Sev Error -LogData $ErrorMessage
         $StatusCode = [HttpStatusCode]::InternalServerError
     }
 


### PR DESCRIPTION
Correct variable casing for consistency and enhance logging messages for better clarity and debugging.

- Resolves https://github.com/KelvinTegelaar/CIPP/issues/4005