### PR TITLE
Fix: Fix mailbox rules orchestrator to handle multiple starts gracefully

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-ListMailboxRulesQueue.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-ListMailboxRulesQueue.ps1
@@ -26,7 +26,7 @@ function Push-ListMailboxRulesQueue {
                     Rules        = [string]($Rule | ConvertTo-Json)
                     RowKey       = [string](New-Guid).guid
                     Tenant       = [string]$domainName
-                    PartitionKey = 'mailboxrules'
+                    PartitionKey = 'MailboxRules'
                 }
 
             }
@@ -38,7 +38,7 @@ function Push-ListMailboxRulesQueue {
                 Rules        = [string]$Rules
                 RowKey       = [string]$domainName
                 Tenant       = [string]$domainName
-                PartitionKey = 'mailboxrules'
+                PartitionKey = 'MailboxRules'
             }
         }
     } catch {
@@ -49,7 +49,7 @@ function Push-ListMailboxRulesQueue {
             Rules        = [string]$Rules
             RowKey       = [string]$domainName
             Tenant       = [string]$domainName
-            PartitionKey = 'mailboxrules'
+            PartitionKey = 'MailboxRules'
         }
     }
     Add-CIPPAzDataTableEntity @Table -Entity $GraphRequest -Force | Out-Null


### PR DESCRIPTION
Prevent the mailbox rules orchestrator from starting multiple times if the user refreshes before the previous operation completes. Adjustments ensure consistent partition key naming and improve user feedback during loading states.