### PR TITLE
Fix 90 Day Guest Filter

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
@@ -32,11 +32,12 @@ function Invoke-CIPPStandardDisableGuests {
     param($Tenant, $Settings)
     ##$Rerun -Type Standard -Tenant $Tenant -Settings $Settings 'DisableGuests'
 
-    $Lookup = (Get-Date).AddDays(-90).ToUniversalTime().ToString('o')
+    $90Days = (Get-Date).AddDays(-90).ToUniversalTime()
+    $Lookup = $90Days.ToString('o')
     $AuditLookup = (Get-Date).AddDays(-7).ToUniversalTime().ToString('o')
 
-    $GraphRequest = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users?`$filter=(signInActivity/lastSuccessfulSignInDateTime le $Lookup)&`$select=id,UserPrincipalName,signInActivity,mail,userType,accountEnabled" -scope 'https://graph.microsoft.com/.default' -tenantid $Tenant |
-        Where-Object { $_.userType -eq 'Guest' -and $_.AccountEnabled -eq $true }
+    $GraphRequest = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users?`$filter=createdDateTime le $Lookup and userType eq 'Guest' and accountEnabled eq true &`$select=id,UserPrincipalName,signInActivity,mail,userType,accountEnabled,createdDateTime,externalUserState" -scope 'https://graph.microsoft.com/.default' -tenantid $Tenant |
+        Where-Object { $_.signInActivity.lastSuccessfulSignInDateTime -le $90Days }
 
     $RecentlyReactivatedUsers = (New-GraphGetRequest -uri "https://graph.microsoft.com/beta/auditLogs/directoryAudits?`$filter=activityDisplayName eq 'Enable account' and activityDateTime ge $AuditLookup" -scope 'https://graph.microsoft.com/.default' -tenantid $Tenant |
         ForEach-Object { $_.targetResources[0].id } | Select-Object -Unique)


### PR DESCRIPTION
The current logic does not return Guest accounts without a lastSuccessfulSignInDateTime. If a guest is invited but never accepts the invite, they are never returned to be disabled. This PR will return all enabled Guest accounts created over 90 days ago and then filter down to guest accounts with a lastSuccessfulSignInDateTime older than 90 days, which includes Guests without a lastSuccessfulSignInDateTime.