### PR TITLE
Fix: Remove 'Device' type from Invoke-ListDeletedItems function

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListDeletedItems.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListDeletedItems.ps1
@@ -16,7 +16,7 @@ Function Invoke-ListDeletedItems {
     Write-LogMessage -Headers $Headers -API $APINAME -message 'Accessed this API' -Sev 'Debug'
 
     # Interact with query parameters or the body of the request.
-    $Types = 'Application', 'User', 'Device', 'Group'
+    $Types = 'Application', 'User', 'Group'
     $GraphRequest = foreach ($Type in $Types) {
     (New-GraphGetRequest -uri "https://graph.microsoft.com/beta/directory/deletedItems/microsoft.graph.$($Type)" -tenantid $TenantFilter) |
             Where-Object -Property '@odata.context' -NotLike '*graph.microsoft.com*' |


### PR DESCRIPTION
Remove the "Device" type since it always returns null anyway. Saves us an API call