### PR TITLE
fix logic for checking existing group membership

### DIFF
--- a/host.json
+++ b/host.json
@@ -10,8 +10,8 @@
   "functionTimeout": "00:10:00",
   "extensions": {
     "durableTask": {
-      "maxConcurrentActivityFunctions": 1,
-      "maxConcurrentOrchestratorFunctions": 1
+      "maxConcurrentActivityFunctions": 5,
+      "maxConcurrentOrchestratorFunctions": 2
     }
   }
 }


### PR DESCRIPTION
Without this change, when you call this endpoint any existing entities in the group memberships table for the selected tenant get removed.