### PR TITLE
Feat: Add Custom Quarantine Policies (Additional PR)

### DIFF
--- a/Modules/CIPPCore/Private/Convert-QuarantinePermissionsValue.ps1
+++ b/Modules/CIPPCore/Private/Convert-QuarantinePermissionsValue.ps1
@@ -1,16 +1,30 @@
 function Convert-QuarantinePermissionsValue {
+    [CmdletBinding(DefaultParameterSetName = 'DecimalValue')]
     param (
-        [Parameter(Mandatory = $true, Position=0)]
+        [Parameter(Mandatory, Position = 0, ParameterSetName = "StringValue")]
         [ValidateNotNullOrEmpty()]
-        [ValidateScript(
-            {$_ -is [String] ? $true : $_ -is [Hashtable] ? $true : $false},
-            ErrorMessage = "Input must be a string or hashtable."
-            )]
-        $InputObject
+        [string]$InputObject,
+
+        [Parameter(Position = 0, ParameterSetName = "DecimalValue")]
+        [int]$PermissionToViewHeader = 0,
+        [Parameter(Position = 1, ParameterSetName = "DecimalValue")]
+        [int]$PermissionToDownload = 0,
+        [Parameter(Mandatory, Position = 2, ParameterSetName = "DecimalValue")]
+        [int]$PermissionToAllowSender,
+        [Parameter(Mandatory, Position = 3, ParameterSetName = "DecimalValue")]
+        [int]$PermissionToBlockSender,
+        [Parameter(Mandatory, Position = 4, ParameterSetName = "DecimalValue")]
+        [int]$PermissionToRequestRelease,
+        [Parameter(Mandatory, Position = 5, ParameterSetName = "DecimalValue")]
+        [int]$PermissionToRelease,
+        [Parameter(Mandatory, Position = 6, ParameterSetName = "DecimalValue")]
+        [int]$PermissionToPreview,
+        [Parameter(Mandatory, Position = 7, ParameterSetName = "DecimalValue")]
+        [int]$PermissionToDelete
     )
 
     #Converts string value with EndUserQuarantinePermissions received from Get-QuarantinePolicy
-    if ($InputObject -is [String]) {
+    if (($PSCmdlet.ParameterSetName) -eq "StringValue") {
         try {
             # Remove square brackets and split into lines
             $InputObject = $InputObject.Trim('[', ']')
@@ -22,28 +36,36 @@ function Convert-QuarantinePermissionsValue {
             return $hashtable
         }
         catch {
-            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-            throw "Convert-QuarantinePermissionsValue: Failed to convert string to hashtable. Error: $ErrorMessage"
+            throw "Convert-QuarantinePermissionsValue: Failed to convert string to hashtable."
         }
     }
 
-    #Converts hashtable with selected end user quarantine permissions to decimal value used by EndUserQuarantinePermissionsValue property in New-QuarantinePolicy and Set-QuarantinePolicy
-    elseif ($InputObject -is [Hashtable]) {
+    #Converts selected end user quarantine permissions to decimal value used by EndUserQuarantinePermissionsValue property in New-QuarantinePolicy and Set-QuarantinePolicy
+    elseif (($PSCmdlet.ParameterSetName) -eq "DecimalValue") {
         try {
-            $EndUserQuarantinePermissionsValue = 0
-            $EndUserQuarantinePermissionsValue += ([int]$InputObject.PermissionToViewHeader ?? 0 ) * 128
-            $EndUserQuarantinePermissionsValue += ([int]$InputObject.PermissionToDownload ?? 0 ) * 64
-            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToAllowSender * 32
-            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToBlockSender * 16
-            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToRequestRelease * 8
-            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToRelease * 4
-            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToPreview * 2
-            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToDelete * 1
-            return $EndUserQuarantinePermissionsValue
+            # both PermissionToRequestRelease and PermissionToRelease cannot be set to true at the same time
+            if($PermissionToRequestRelease -eq 1 -and $PermissionToRelease -eq 1) {
+                throw "PermissionToRequestRelease and PermissionToRelease cannot both be set to true."
+            }
+
+            # Convert each permission to a binary string
+            $BinaryValue = [string]@(
+                $PermissionToViewHeader,
+                $PermissionToDownload,
+                $PermissionToAllowSender,
+                $PermissionToBlockSender,
+                $PermissionToRequestRelease,
+                $PermissionToRelease,
+                $PermissionToPreview,
+                $PermissionToDelete
+            ) -replace '\s',''
+
+            # Convert the binary string to an Decimal value
+            return [convert]::ToInt32($BinaryValue,2)
         }
         catch {
             $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-            throw "Convert-QuarantinePermissionsValue: Failed to convert hashtable to QuarantinePermissionsValue. Error: $ErrorMessage"
+            throw "Convert-QuarantinePermissionsValue: Failed to convert QuarantinePermissions to QuarantinePermissionsValue. Error: $ErrorMessage"
         }
     }
 }

--- a/Modules/CIPPCore/Private/Convert-QuarantinePermissionsValue.ps1
+++ b/Modules/CIPPCore/Private/Convert-QuarantinePermissionsValue.ps1
@@ -1,0 +1,49 @@
+function Convert-QuarantinePermissionsValue {
+    param (
+        [Parameter(Mandatory = $true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript(
+            {$_ -is [String] ? $true : $_ -is [Hashtable] ? $true : $false},
+            ErrorMessage = "Input must be a string or hashtable."
+            )]
+        $InputObject
+    )
+
+    #Converts string value with EndUserQuarantinePermissions received from Get-QuarantinePolicy
+    if ($InputObject -is [String]) {
+        try {
+            # Remove square brackets and split into lines
+            $InputObject = $InputObject.Trim('[', ']')
+            $hashtable = @{}
+            $InputObject -split "`n" | ForEach-Object {
+                $key, $value = $_ -split ":\s*"
+                $hashtable[$key.Trim()] = [System.Convert]::ToBoolean($value.Trim())
+            }
+            return $hashtable
+        }
+        catch {
+            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+            throw "Convert-QuarantinePermissionsValue: Failed to convert string to hashtable. Error: $ErrorMessage"
+        }
+    }
+
+    #Converts hashtable with selected end user quarantine permissions to decimal value used by EndUserQuarantinePermissionsValue property in New-QuarantinePolicy and Set-QuarantinePolicy
+    elseif ($InputObject -is [Hashtable]) {
+        try {
+            $EndUserQuarantinePermissionsValue = 0
+            $EndUserQuarantinePermissionsValue += ([int]$InputObject.PermissionToViewHeader ?? 0 ) * 128
+            $EndUserQuarantinePermissionsValue += ([int]$InputObject.PermissionToDownload ?? 0 ) * 64
+            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToAllowSender * 32
+            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToBlockSender * 16
+            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToRequestRelease * 8
+            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToRelease * 4
+            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToPreview * 2
+            $EndUserQuarantinePermissionsValue += [int]$InputObject.PermissionToDelete * 1
+            return $EndUserQuarantinePermissionsValue
+        }
+        catch {
+            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+            throw "Convert-QuarantinePermissionsValue: Failed to convert hashtable to QuarantinePermissionsValue. Error: $ErrorMessage"
+        }
+    }
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-AddQuarantinePolicy.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-AddQuarantinePolicy.ps1
@@ -16,10 +16,9 @@ Function Invoke-AddQuarantinePolicy {
 
     $Tenants = ($Request.body.selectedTenants).value
 
-    # If allTenants is selected, get all tenants from table and overwrite any other tenant selection
+    # If allTenants is selected, get all tenants and overwrite any other tenant selection
     if ("AllTenants" -in $Tenants) {
-        $TenantTable = Get-CIPPTable -tablename 'Tenants'
-        $tenants = (Get-CIPPAzDataTableEntity @TenantTable -Filter "PartitionKey eq 'Tenants'").defaultDomainName
+        $tenants = (Get-Tenants).defaultDomainName
     }
 
     $Result = foreach ($TenantFilter in $tenants) {

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-AddQuarantinePolicy.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-AddQuarantinePolicy.ps1
@@ -1,0 +1,68 @@
+using namespace System.Net
+
+Function Invoke-AddQuarantinePolicy {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Spamfilter.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -Headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+
+    $Tenants = ($Request.body.selectedTenants).value
+
+    # If allTenants is selected, get all tenants from table and overwrite any other tenant selection
+    if ("AllTenants" -in $Tenants) {
+        $TenantTable = Get-CIPPTable -tablename 'Tenants'
+        $tenants = (Get-CIPPAzDataTableEntity @TenantTable -Filter "PartitionKey eq 'Tenants'").defaultDomainName
+    }
+
+    $Result = foreach ($TenantFilter in $tenants) {
+        try {
+            $ReleaseActionPreference = $Request.Body.ReleaseActionPreference.value ?? $Request.Body.ReleaseActionPreference
+
+            $EndUserQuarantinePermissions   = @{
+                PermissionToBlockSender = $Request.Body.BlockSender
+                PermissionToDelete  = $Request.Body.Delete
+                PermissionToPreview = $Request.Body.Preview
+                PermissionToRelease = $ReleaseActionPreference -eq "Release" ? $true : $false
+                PermissionToRequestRelease  = $ReleaseActionPreference -eq "RequestRelease" ? $true : $false
+                PermissionToAllowSender = $Request.Body.AllowSender
+            }
+
+            $Params = @{
+                Identity = $Request.Body.Name
+                EndUserQuarantinePermissions = $EndUserQuarantinePermissions
+                ESNEnabled = $Request.Body.QuarantineNotification
+                IncludeMessagesFromBlockedSenderAddress = $Request.Body.IncludeMessagesFromBlockedSenderAddress
+                action = "New"
+                tenantFilter = $TenantFilter
+                APIName = $APIName
+            }
+
+            Set-CIPPQuarantinePolicy @Params
+            $Message = "Created Quarantine policy '$($Request.Body.Name)' for tenant '$($TenantFilter)'"
+            Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message $Message -Sev Info
+            $Message
+
+        }
+        catch {
+            $ErrorMessage = Get-CippException -Exception $_
+            $Message = "Failed to create Quarantine policy '$($Request.Body.Name)' for tenant '$($TenantFilter)' - $($ErrorMessage.NormalizedError)"
+            Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message $Message -Sev Error -LogData $ErrorMessage
+            $Message
+        }
+    }
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = [HttpStatusCode]::OK
+            Body       = @{Results = @($Result) }
+        })
+
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-EditQuarantinePolicy.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-EditQuarantinePolicy.ps1
@@ -1,0 +1,79 @@
+using namespace System.Net
+
+Function Invoke-EditQuarantinePolicy {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Spamfilter.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -Headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+
+    $TenantFilter = $Request.Query.TenantFilter ?? $Request.Body.TenantFilter
+
+    if ($Request.Query.Type -eq "GlobalQuarantinePolicy") {
+
+        $Frequency = $Request.Body.EndUserSpamNotificationFrequency.value ?? $Request.Body.EndUserSpamNotificationFrequency
+        # If request EndUserSpamNotificationFrequency it not set to a ISO 8601 timeformat, convert it to one.
+        # This happens if the user doesn't change the Notification Frequency value in the UI. Because of a "bug" with setDefaultValue function with the cippApiDialog, where "label" is set to both label and value.
+        $EndUserSpamNotificationFrequency = switch ($Frequency) {
+            "4 Hours" { "PT4H" }
+            "Daily" { "P1D" }
+            "Weekly" { "P7D" }
+            Default { $Frequency }
+        }
+
+        $Params = @{
+            Identity = $Request.Body.Identity
+            # Convert the requested frequency from ISO 8601 to a TimeSpan object
+            EndUserSpamNotificationFrequency = [System.Xml.XmlConvert]::ToTimeSpan($EndUserSpamNotificationFrequency)
+            EndUserSpamNotificationCustomFromAddress = $Request.Body.EndUserSpamNotificationCustomFromAddress
+            OrganizationBrandingEnabled = $Request.Body.OrganizationBrandingEnabled
+        }
+    }
+    else {
+        $ReleaseActionPreference = $Request.Body.ReleaseActionPreference.value ?? $Request.Body.ReleaseActionPreference
+
+        $EndUserQuarantinePermissions   = @{
+            PermissionToBlockSender = $Request.Body.BlockSender
+            PermissionToDelete  = $Request.Body.Delete
+            PermissionToPreview = $Request.Body.Preview
+            PermissionToRelease = $ReleaseActionPreference -eq "Release" ? $true : $false
+            PermissionToRequestRelease  = $ReleaseActionPreference -eq "RequestRelease" ? $true : $false
+            PermissionToAllowSender = $Request.Body.AllowSender
+        }
+
+        $Params = @{
+            Identity = $Request.Body.Identity
+            EndUserQuarantinePermissions = $EndUserQuarantinePermissions
+            ESNEnabled = $Request.Body.QuarantineNotification
+            IncludeMessagesFromBlockedSenderAddress = $Request.Body.IncludeMessagesFromBlockedSenderAddress
+            action = $Request.Body.Action ?? "Set"
+        }
+    }
+
+    try {
+        Set-CIPPQuarantinePolicy @Params -tenantFilter $TenantFilter -APIName $APIName
+
+        $Result = "Updated Quarantine policy '$($Request.Body.Name)'"
+        $StatusCode = [HttpStatusCode]::OK
+        Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message $Result -Sev Info
+    }
+    catch {
+        $Result = "Failed to update Quarantine policy '$($Request.Body.Name)' - $($_)"
+        $StatusCode = [HttpStatusCode]::Forbidden
+        Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message $Result -Sev Error -LogData $ErrorMessage
+    }
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{Results = $Result }
+        })
+
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-ListQuarantinePolicy.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-ListQuarantinePolicy.ps1
@@ -1,0 +1,45 @@
+function Invoke-ListQuarantinePolicy {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.SpamFilter.Read
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+
+    # Interact with query parameters or the body of the request.
+    $TenantFilter = $Request.Query.TenantFilter ?? $Request.body.TenantFilter
+    $QuarantinePolicyType = $Request.Query.Type ?? 'QuarantinePolicy'
+
+    $Policies = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-QuarantinePolicy' -cmdParams @{QuarantinePolicyType=$QuarantinePolicyType} | Select-Object -Property * -ExcludeProperty *odata*, *data.type*
+
+    write-host $($Request | ConvertTo-Json -Depth 10)
+
+    if ($QuarantinePolicyType -eq 'QuarantinePolicy') {
+        # Convert the string EndUserQuarantinePermissions to individual properties
+        $Policies | ForEach-Object {
+            $Permissions = Convert-QuarantinePermissionsValue -InputObject $_.EndUserQuarantinePermissions
+            foreach ($Perm in $Permissions.GetEnumerator()) {
+                $_ | Add-Member -MemberType NoteProperty -Name ($Perm.Key -replace "PermissionTo", "" ) -Value $Perm.Value
+            }
+        }
+
+        # "convert" to values display in the UI and Builtin used for filtering
+        $Policies = $Policies | Select-Object -Property *,
+        @{ Name = 'QuarantineNotification'; Expression = { $_.ESNEnabled -eq $true ? $true : $false} },
+        @{ Name = 'ReleaseActionPreference'; Expression = { $_.Release -eq $true ? "Release" : "RequestRelease"} },
+        @{ Name = 'Builtin'; Expression = { $_.Guid -eq "00000000-0000-0000-0000-000000000000" ? $true : $false} }
+    }
+
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = [HttpStatusCode]::OK
+            Body       = @($Policies)
+        })
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-RemoveQuarantinePolicy.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-RemoveQuarantinePolicy.ps1
@@ -1,0 +1,45 @@
+using namespace System.Net
+
+Function Invoke-RemoveQuarantinePolicy {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Spamfilter.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -Headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+    $TenantFilter = $Request.Query.TenantFilter ?? $Request.Body.TenantFilter
+    $PolicyName = $Request.Query.Name ?? $Request.Body.Name
+    $Identity = $Request.Query.Identity ?? $Request.Body.Identity
+
+    try {
+        $Params = @{
+            Identity = ($Identity -eq "00000000-0000-0000-0000-000000000000" ? $PolicyName : $Identity)
+        }
+
+        $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Remove-QuarantinePolicy' -cmdParams $Params -useSystemMailbox $true
+
+        $Result = "Deleted Quarantine policy '$($PolicyName)'"
+        Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message $Result -Sev Info
+        $StatusCode = [HttpStatusCode]::OK
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        $Result = "Failed to remove Quarantine policy '$($PolicyName)' - $($ErrorMessage.NormalizedError -replace '\|Microsoft.Exchange.Management.Tasks.ValidationException\|', '')"
+        Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message $Result -Sev Error -LogData $ErrorMessage
+        $StatusCode = [HttpStatusCode]::Forbidden
+    }
+
+    $StatusCode = [HttpStatusCode]::OK
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{Results = $Result }
+        })
+
+}

--- a/Modules/CIPPCore/Public/Set-CIPPQuarantinePolicy.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPQuarantinePolicy.ps1
@@ -85,7 +85,7 @@ function Set-CIPPQuarantinePolicy {
              }
             "QuarantinePolicy" {
                 $cmdParams = @{
-                    EndUserQuarantinePermissionsValue = Convert-QuarantinePermissionsValue -InputObject $EndUserQuarantinePermissions
+                    EndUserQuarantinePermissionsValue = Convert-QuarantinePermissionsValue @EndUserQuarantinePermissions -ErrorAction Stop
                     ESNEnabled = $ESNEnabled
                     IncludeMessagesFromBlockedSenderAddress = $IncludeMessagesFromBlockedSenderAddress
                 }

--- a/Modules/CIPPCore/Public/Set-CIPPQuarantinePolicy.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPQuarantinePolicy.ps1
@@ -1,0 +1,109 @@
+function Set-CIPPQuarantinePolicy {
+    <#
+    .SYNOPSIS
+    Set/Add Quarantine policy, supports both custom and global Quarantine Policy
+
+    .DESCRIPTION
+    Set/Add Quarantine policy, supports both custom and global Quarantine Policy
+
+    .PARAMETER identity
+    Identity of the Quarantine policy to set, Name or GUID.
+
+    .PARAMETER action
+    Which action to perform Create or Update. Valid values are Add, New, Create, Edit, Set, Update.
+
+    .PARAMETER tenantFilter
+    Tenant to manage quarantine policy for.
+
+    .PARAMETER EndUserQuarantinePermissions
+    End user quarantine permissions to set. This is a hashtable with the following keys:
+    PermissionToBlockSender
+    PermissionToDelete
+    PermissionToPreview
+    PermissionToRelease
+    PermissionToRequestRelease
+    PermissionToAllowSender
+    PermissionToViewHeader
+    PermissionToDownload
+
+    .PARAMETER APIName
+    Name of the API executing the command.
+
+    .PARAMETER ESNEnabled
+    Whether the quarantine notification is enabled or not.
+
+    .PARAMETER IncludeMessagesFromBlockedSenderAddress
+    Whether to include messages from blocked sender address or not.
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'QuarantinePolicy')]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'QuarantinePolicy')]
+        [Parameter(Mandatory, ParameterSetName = 'GlobalQuarantinePolicy')]
+        [ValidateNotNullOrEmpty()]
+        [string]$identity,
+
+        [Parameter(Mandatory, ParameterSetName = 'QuarantinePolicy')]
+        [ValidateSet("Add", "New", "Create", "Edit", "Set", "Update")]
+        [string]$action,
+
+        [Parameter(Mandatory, ParameterSetName = 'QuarantinePolicy')]
+        [Hashtable]$EndUserQuarantinePermissions,
+
+        [Parameter(Mandatory, ParameterSetName = 'QuarantinePolicy')]
+        [bool]$ESNEnabled,
+
+        [Parameter(ParameterSetName = 'QuarantinePolicy')]
+        [bool]$IncludeMessagesFromBlockedSenderAddress = $false,
+
+        [Parameter(Mandatory, ParameterSetName = 'GlobalQuarantinePolicy')]
+        [TimeSpan]$EndUserSpamNotificationFrequency,
+
+        [Parameter(ParameterSetName = 'GlobalQuarantinePolicy')]
+        [string]$EndUserSpamNotificationCustomFromAddress = "",
+
+        [Parameter(ParameterSetName = 'GlobalQuarantinePolicy')]
+        [bool]$OrganizationBrandingEnabled = $false,
+
+        [Parameter(Mandatory)]
+        [string]$tenantFilter,
+        [string]$APIName = 'QuarantinePolicy'
+    )
+
+    try {
+
+        switch ($PSCmdlet.ParameterSetName) {
+            "GlobalQuarantinePolicy" {
+                $cmdParams = @{
+                    Identity = $identity
+                    EndUserSpamNotificationFrequency = $EndUserSpamNotificationFrequency.ToString()
+                    EndUserSpamNotificationCustomFromAddress = $EndUserSpamNotificationCustomFromAddress
+                    OrganizationBrandingEnabled = $OrganizationBrandingEnabled
+                    # QuarantinePolicyType = 'GlobalQuarantinePolicy'
+                }
+                $cmdLet = 'Set-QuarantinePolicy'
+             }
+            "QuarantinePolicy" {
+                $cmdParams = @{
+                    EndUserQuarantinePermissionsValue = Convert-QuarantinePermissionsValue -InputObject $EndUserQuarantinePermissions
+                    ESNEnabled = $ESNEnabled
+                    IncludeMessagesFromBlockedSenderAddress = $IncludeMessagesFromBlockedSenderAddress
+                }
+
+                switch ($action) {
+                    {$_ -in @("Add", "New", "Create")} { $cmdParams.Add("Name", $identity) ; $cmdLet = 'New-QuarantinePolicy' }
+                    {$_ -in @("Edit", "Set", "Update")} { $cmdParams.Add("Identity", $identity) ; $cmdLet = 'Set-QuarantinePolicy' }
+                    Default {
+                        throw "Invalid action specified. Valid actions are: Add, New, Edit, Set, Update."
+                    }
+                }
+            }
+        }
+
+        $null = New-ExoRequest -tenantid $tenantFilter -cmdlet $cmdLet -cmdParams $cmdParams -useSystemMailbox $true
+
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        throw ($ErrorMessage.NormalizedError -replace '\|Microsoft.Exchange.Management.Tasks.ValidationException\|', '')
+    }
+}

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
@@ -64,7 +64,7 @@ function Invoke-CIPPStandardQuarantineTemplate {
                 if ($Policy.displayName.value -in $CurrentPolicies.Name) {
                     #Get the current policy and convert EndUserQuarantinePermissions from string to hashtable for compare
                     $ExistingPolicy = $CurrentPolicies | Where-Object -Property Name -eq $Policy.displayName.value
-                    $ExistingPolicyEndUserQuarantinePermissions = Convert-QuarantinePermissionsValue -InputObject $ExistingPolicy.EndUserQuarantinePermissions -ErrorAction Stop
+                    $ExistingPolicyEndUserQuarantinePermissions = Convert-QuarantinePermissionsValue @EndUserQuarantinePermissions -ErrorAction Stop
 
                     #Compare the current policy
                     $StateIsCorrect = ($ExistingPolicy.Name -eq $Policy.displayName.value) -and

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
@@ -41,50 +41,7 @@ function Invoke-CIPPStandardQuarantineTemplate {
 
     param($Tenant, $Settings)
 
-
-    function Convert-HashtableToEndUserQuarantinePermissionsValue {
-        param (
-            [hashtable]$InputHashtable
-        )
-        #Converts hashtable with selected end user quarantine permissions to decimal value used by EndUserQuarantinePermissionsValue property in New-QuarantinePolicy and Set-QuarantinePolicy
-        try {
-            $EndUserQuarantinePermissionsValue = 0
-            $EndUserQuarantinePermissionsValue += [int]$InputHashtable.PermissionToViewHeader * 128
-            $EndUserQuarantinePermissionsValue += [int]$InputHashtable.PermissionToDownload * 64
-            $EndUserQuarantinePermissionsValue += [int]$InputHashtable.PermissionToAllowSender * 32
-            $EndUserQuarantinePermissionsValue += [int]$InputHashtable.PermissionToBlockSender * 16
-            $EndUserQuarantinePermissionsValue += [int]$InputHashtable.PermissionToRequestRelease * 8
-            $EndUserQuarantinePermissionsValue += [int]$InputHashtable.PermissionToRelease * 4
-            $EndUserQuarantinePermissionsValue += [int]$InputHashtable.PermissionToPreview * 2
-            $EndUserQuarantinePermissionsValue += [int]$InputHashtable.PermissionToDelete * 1
-            return $EndUserQuarantinePermissionsValue
-        }
-        catch {
-            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-            throw "Convert-HashtableToEndUserQuarantinePermissionsValue: Failed to hashtable QuarantinePermissionsValue. Error: $ErrorMessage"
-        }
-    }
-
-    function Convert-StringToHashtable {
-        param (
-            [string]$InputString
-        )
-        #Converts string value with EndUserQuarantinePermissions received from Get-QuarantinePolicy
-        try {
-            # Remove square brackets and split into lines
-            $InputString = $InputString.Trim('[', ']')
-            $hashtable = @{}
-            $InputString -split "`n" | ForEach-Object {
-                $key, $value = $_ -split ":\s*"
-                $hashtable[$key.Trim()] = [System.Convert]::ToBoolean($value.Trim())
-            }
-            return $hashtable
-        }
-        catch {
-            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-            throw "Convert-StringToHashtable: Failed to convert string to hashtable. Error: $ErrorMessage"
-        }
-    }
+    $APIName = 'Standards'
 
     try {
         # Get the current custom quarantine policies
@@ -93,21 +50,13 @@ function Invoke-CIPPStandardQuarantineTemplate {
         # Compare the settings from standard with the current policies
         $CompareList = foreach ($Policy in $Settings) {
             try {
-                # prepare the cmdParams used in New-ExoRequest
-                $cmdParams = @{
-                    ESNEnabled                              = $Policy.ESNEnabled
-                    IncludeMessagesFromBlockedSenderAddress = $Policy.IncludeMessagesFromBlockedSenderAddress
-                }
-
-                # Create hashtable with desired EndUserQuarantinePermissions
+                # Create hashtable with desired Quarantine Setting
                 $EndUserQuarantinePermissions   = @{
                     PermissionToBlockSender = $Policy.PermissionToBlockSender
                     PermissionToDelete  = $Policy.PermissionToDelete
-                    PermissionToDownload    = $false
                     PermissionToPreview = $Policy.PermissionToPreview
-                    PermissionToRelease = if ($Policy.ReleaseAction -eq "PermissionToRelease") { $true } else { $false }
-                    PermissionToRequestRelease  = if ($Policy.ReleaseAction -eq "PermissionToRequestRelease") { $true } else { $false }
-                    PermissionToViewHeader  = $true
+                    PermissionToRelease = $Policy.ReleaseAction -eq "PermissionToRelease" ? $true : $false
+                    PermissionToRequestRelease  = $Policy.ReleaseAction -eq "PermissionToRequestRelease" ? $true : $false
                     PermissionToAllowSender = $Policy.PermissionToAllowSender
                 }
 
@@ -115,7 +64,7 @@ function Invoke-CIPPStandardQuarantineTemplate {
                 if ($Policy.displayName.value -in $CurrentPolicies.Name) {
                     #Get the current policy and convert EndUserQuarantinePermissions from string to hashtable for compare
                     $ExistingPolicy = $CurrentPolicies | Where-Object -Property Name -eq $Policy.displayName.value
-                    $ExistingPolicyEndUserQuarantinePermissions = Convert-StringToHashtable -InputString $ExistingPolicy.EndUserQuarantinePermissions -ErrorAction Stop
+                    $ExistingPolicyEndUserQuarantinePermissions = Convert-QuarantinePermissionsValue -InputObject $ExistingPolicy.EndUserQuarantinePermissions -ErrorAction Stop
 
                     #Compare the current policy
                     $StateIsCorrect = ($ExistingPolicy.Name -eq $Policy.displayName.value) -and
@@ -128,9 +77,11 @@ function Invoke-CIPPStandardQuarantineTemplate {
                         [PSCustomObject]@{
                             missing         = $false
                             StateIsCorrect  = $StateIsCorrect
+                            Action          = "None"
                             displayName     = $Policy.displayName.value
                             EndUserQuarantinePermissions = $EndUserQuarantinePermissions
-                            cmdParams       = $cmdParams
+                            ESNEnabled      = $Policy.ESNEnabled
+                            IncludeMessagesFromBlockedSenderAddress = $Policy.IncludeMessagesFromBlockedSenderAddress
                             remediate       = $Policy.remediate
                             alert           = $Policy.alert
                             report          = $Policy.report
@@ -141,9 +92,11 @@ function Invoke-CIPPStandardQuarantineTemplate {
                         [PSCustomObject]@{
                             missing         = $false
                             StateIsCorrect  = $StateIsCorrect
+                            Action          = "Update"
                             displayName     = $Policy.displayName.value
                             EndUserQuarantinePermissions = $EndUserQuarantinePermissions
-                            cmdParams       = $cmdParams
+                            ESNEnabled      = $Policy.ESNEnabled
+                            IncludeMessagesFromBlockedSenderAddress = $Policy.IncludeMessagesFromBlockedSenderAddress
                             remediate       = $Policy.remediate
                             alert           = $Policy.alert
                             report          = $Policy.report
@@ -155,9 +108,11 @@ function Invoke-CIPPStandardQuarantineTemplate {
                     [PSCustomObject]@{
                         missing         = $true
                         StateIsCorrect  = $false
+                        Action          = "Create"
                         displayName     = $Policy.displayName.value
                         EndUserQuarantinePermissions = $EndUserQuarantinePermissions
-                        cmdParams       = $cmdParams
+                        ESNEnabled      = $Policy.ESNEnabled
+                        IncludeMessagesFromBlockedSenderAddress = $Policy.IncludeMessagesFromBlockedSenderAddress
                         remediate       = $Policy.remediate
                         alert           = $Policy.alert
                         report          = $Policy.report
@@ -166,7 +121,9 @@ function Invoke-CIPPStandardQuarantineTemplate {
             }
             catch {
                 $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-                Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to compare Quarantine policy $($Policy.displayName.value), Error: $ErrorMessage" -sev 'Error'
+                $Message = "Failed to compare Quarantine policy $($Policy.displayName.value), Error: $ErrorMessage"
+                Write-LogMessage -API $APIName -tenant $tenant -message $Message -sev 'Error'
+                Return $Message
             }
         }
 
@@ -175,43 +132,29 @@ function Invoke-CIPPStandardQuarantineTemplate {
             # Remediate each policy which is incorrect or missing
             foreach ($Policy in $CompareList | Where-Object { $_.remediate -EQ $true -and $_.StateIsCorrect -eq $false }) {
                 try {
-                    # Convert desired EndUserQuarantinePermissions to decimal value
-                    $EndUserQuarantinePermissionsValue = Convert-HashtableToEndUserQuarantinePermissionsValue -InputHashtable $Policy.EndUserQuarantinePermissions -ErrorAction Stop
-                    $cmdParams = $Policy.cmdParams
-
-                    # Create policy if missing
-                    if ($Policy.missing) {
-                        try {
-                            #Add the rest of the desired settings to cmdParams
-                            $cmdParams.Add('Name', $Policy.displayName)
-                            $cmdParams.Add('EndUserQuarantinePermissionsValue', $EndUserQuarantinePermissionsValue)
-
-                            New-ExoRequest -tenantid $Tenant -cmdlet 'New-QuarantinePolicy' -cmdParams $cmdParams -UseSystemMailbox $true -ErrorAction Stop
-                            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created Custom Quarantine Policy $($Policy.displayName)" -sev Info
-                        }
-                        catch {
-                            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-                            Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to create Quarantine policy $($Policy.displayName), Error: $ErrorMessage" -sev 'Error'
-                        }
+                    # Parameters for splatting to Set-CIPPQuarantinePolicy
+                    $Params = @{
+                        Action = $Policy.Action
+                        Identity = $Policy.displayName
+                        EndUserQuarantinePermissions = $Policy.EndUserQuarantinePermissions
+                        ESNEnabled = $Policy.ESNEnabled
+                        IncludeMessagesFromBlockedSenderAddress = $Policy.IncludeMessagesFromBlockedSenderAddress
+                        tenantFilter = $Tenant
+                        APIName = $APIName
                     }
-                    # Update policy if incorrect
-                    else {
-                        try {
-                            #Add the rest of the desired settings to cmdParams
-                            $cmdParams.Add('Identity', $Policy.displayName)
-                            $cmdParams.Add('EndUserQuarantinePermissionsValue', $EndUserQuarantinePermissionsValue)
 
-                            New-ExoRequest -tenantid $Tenant -cmdlet 'Set-QuarantinePolicy' -cmdParams $cmdParams -UseSystemMailbox $true -ErrorAction Stop
-                            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated Custom Quarantine Policy $($Policy.displayName)" -sev Info
-                        }
-                        catch {
-                            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update Custom Quarantine Policy $($Policy.displayName)" -sev Error -LogData $_
-                        }
+                    try {
+                        Set-CIPPQuarantinePolicy @Params
+                        Write-LogMessage -API $APIName -tenant $Tenant -message "$($Policy.Action)d Custom Quarantine Policy '$($Policy.displayName)'" -sev Info
+                    }
+                    catch {
+                        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+                        Write-LogMessage -API $APIName -tenant $tenant -message "Failed to $($Policy.Action) Quarantine policy $($Policy.displayName), Error: $ErrorMessage" -sev 'Error'
                     }
                 }
                 catch {
                     $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-                    Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to create or update Quarantine policy $($Policy.displayName), Error: $ErrorMessage" -sev 'Error'
+                    Write-LogMessage -API $APIName -tenant $tenant -message "Failed to create or update Quarantine policy $($Policy.displayName), Error: $ErrorMessage" -sev 'Error'
                 }
             }
         }
@@ -219,18 +162,18 @@ function Invoke-CIPPStandardQuarantineTemplate {
         if ($true -in $Settings.alert) {
             foreach ($Policy in $CompareList | Where-Object -Property alert -EQ $true) {
                 if ($Policy.StateIsCorrect) {
-                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Quarantine policy $($Policy.displayName) has the correct configuration." -sev Info
+                    Write-LogMessage -API $APIName -tenant $Tenant -message "Quarantine policy $($Policy.displayName) has the correct configuration." -sev Info
                 }
                 else {
                     if ($Policy.missing) {
                         $CurrentInfo = $Policy | Select-Object -Property displayName, missing
                         Write-StandardsAlert -message "Quarantine policy $($Policy.displayName) is missing." -object $CurrentInfo -tenant $Tenant -standardName 'QuarantineTemplate' -standardId $Settings.templateId
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Quarantine policy $($Policy.displayName) is missing." -sev info
+                        Write-LogMessage -API $APIName -tenant $Tenant -message "Quarantine policy $($Policy.displayName) is missing." -sev info
                     }
                     else {
                         $CurrentInfo = $CurrentPolicies | Where-Object -Property Name -eq $Policy.displayName | Select-Object -Property Name, ESNEnabled, IncludeMessagesFromBlockedSenderAddress, EndUserQuarantinePermissions
                         Write-StandardsAlert -message "Quarantine policy $($Policy.displayName) does not match the expected configuration." -object $CurrentInfo -tenant $Tenant -standardName 'QuarantineTemplate' -standardId $Settings.templateId
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Quarantine policy $($Policy.displayName) does not match the expected configuration. We've generated an alert" -sev info
+                        Write-LogMessage -API $APIName -tenant $Tenant -message "Quarantine policy $($Policy.displayName) does not match the expected configuration. We've generated an alert" -sev info
                     }
                 }
             }
@@ -245,6 +188,6 @@ function Invoke-CIPPStandardQuarantineTemplate {
     }
     catch {
         $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-        Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to create or update Quarantine policy/policies, Error: $ErrorMessage" -sev 'Error'
+        Write-LogMessage -API $APIName -tenant $tenant -message "Failed to create or update Quarantine policy/policies, Error: $ErrorMessage" -sev 'Error'
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -8537,6 +8537,270 @@
         }
       }
     },
+    "/ListQuarantinePolicy": {
+      "get": {
+        "description": "ListQuarantinePolicy",
+        "summary": "ListQuarantinePolicy",
+        "tags": [
+          "GET"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "tenantfilter",
+            "in": "query"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "Type",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        }
+      }
+    },
+    "/AddQuarantinePolicy": {
+      "post": {
+        "description": "AddQuarantinePolicy",
+        "summary": "AddQuarantinePolicy",
+        "tags": [
+          "POST"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "tenantfilter",
+            "in": "query"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "Name",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "BlockSender",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "Delete",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "Preview",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "ReleaseActionPreference",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "AllowSender",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "QuarantineNotification",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "IncludeMessagesFromBlockedSenderAddress",
+            "in": "body"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        }
+      }
+    },
+    "/EditQuarantinePolicy": {
+      "post": {
+        "description": "EditQuarantinePolicy",
+        "summary": "EditQuarantinePolicy",
+        "tags": [
+          "POST"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "tenantfilter",
+            "in": "query"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "Type",
+            "in": "query"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "Identity",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "EndUserSpamNotificationFrequency",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "EndUserSpamNotificationCustomFromAddress",
+            "in": "body"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "OrganizationBrandingEnabled",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "BlockSender",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "Delete",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "Preview",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "ReleaseActionPreference",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "AllowSender",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "QuarantineNotification",
+            "in": "body"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "IncludeMessagesFromBlockedSenderAddress",
+            "in": "body"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        }
+      }
+    },
     "/RemoveExConnector": {
       "get": {
         "description": "RemoveExConnector",
@@ -8568,6 +8832,54 @@
             },
             "name": "Type",
             "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        }
+      }
+    },
+    "/RemoveQuarantinePolicy": {
+      "get": {
+        "description": "RemoveQuarantinePolicy",
+        "summary": "RemoveQuarantinePolicy",
+        "tags": [
+          "GET"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "tenantfilter",
+            "in": "query"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "name": "Identity",
+            "in": "body"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "name": "Name",
+            "in": "body"
           }
         ],
         "responses": {


### PR DESCRIPTION
New endpoints and functions for managing custom quarantine policies and global quarantine policy, from quarantine policies pages. Updated standard from previous PR to use new Quarantine Policy add/edit function, also used by the new endpoints.
https://github.com/KelvinTegelaar/CIPP-API/pull/1438