### PR TITLE
feat: Add mailbox recipient limits standardization script

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDeployMailContact.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDeployMailContact.ps1
@@ -69,26 +69,26 @@ function Invoke-CIPPStandardDeployMailContact {
     if ($Settings.remediate -eq $true) {
         if ($ExistingContact) {
             Write-LogMessage -API 'Standards' -tenant $Tenant -message "Mail contact with email $($Settings.ExternalEmailAddress) already exists" -sev Info
-            return
         }
+        else {
+            try {
+                $NewContactParams = @{
+                    ExternalEmailAddress = $Settings.ExternalEmailAddress
+                    DisplayName          = $Settings.DisplayName
+                    Name                 = $Settings.DisplayName
+                }
 
-        try {
-            $NewContactParams = @{
-                ExternalEmailAddress = $Settings.ExternalEmailAddress
-                DisplayName          = $Settings.DisplayName
-                Name                 = $Settings.DisplayName
+                # Add optional parameters if provided
+                if ($Settings.FirstName) { $NewContactParams.FirstName = $Settings.FirstName }
+                if ($Settings.LastName) { $NewContactParams.LastName = $Settings.LastName }
+
+                $null = New-ExoRequest -tenantid $Tenant -cmdlet 'New-MailContact' -cmdParams $NewContactParams
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Successfully created mail contact $($Settings.DisplayName) with email $($Settings.ExternalEmailAddress)" -sev Info
             }
-
-            # Add optional parameters if provided
-            if ($Settings.FirstName) { $NewContactParams.FirstName = $Settings.FirstName }
-            if ($Settings.LastName) { $NewContactParams.LastName = $Settings.LastName }
-
-            $null = New-ExoRequest -tenantid $Tenant -cmdlet 'New-MailContact' -cmdParams $NewContactParams
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Successfully created mail contact $($Settings.DisplayName) with email $($Settings.ExternalEmailAddress)" -sev Info
-        }
-        catch {
-            $ErrorMessage = Get-CippException -Exception $_
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Could not create mail contact. $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+            catch {
+                $ErrorMessage = Get-CippException -Exception $_
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Could not create mail contact. $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+            }
         }
     }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDeployMailContact.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDeployMailContact.ps1
@@ -65,13 +65,13 @@ function Invoke-CIPPStandardDeployMailContact {
         }
     }
 
-    if ($ExistingContact) {
-        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Mail contact with email $($Settings.ExternalEmailAddress) already exists" -sev Info
-        return
-    }
-
     # Remediation
     if ($Settings.remediate -eq $true) {
+        if ($ExistingContact) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Mail contact with email $($Settings.ExternalEmailAddress) already exists" -sev Info
+            return
+        }
+
         try {
             $NewContactParams = @{
                 ExternalEmailAddress = $Settings.ExternalEmailAddress

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDeployMailContact.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDeployMailContact.ps1
@@ -1,0 +1,130 @@
+function Invoke-CIPPStandardDeployMailContact {
+    <#
+    .FUNCTIONALITY
+        Internal
+    .COMPONENT
+        (APIName) DeployMailContact
+    .SYNOPSIS
+        (Label) Deploy Mail Contact
+    .DESCRIPTION
+        (Helptext) Creates a new mail contact in Exchange Online across all selected tenants. The contact will be visible in the Global Address List.
+        (DocsDescription) This standard creates a new mail contact in Exchange Online. Mail contacts are useful for adding external email addresses to your organization's address book. They can be used for distribution lists, shared mailboxes, and other collaboration scenarios.
+    .NOTES
+        CAT
+            Exchange Standards
+        TAG
+        ADDEDCOMPONENT
+            {"type":"textField","name":"standards.DeployMailContact.ExternalEmailAddress","label":"External Email Address","required":true}
+            {"type":"textField","name":"standards.DeployMailContact.DisplayName","label":"Display Name","required":true}
+            {"type":"textField","name":"standards.DeployMailContact.FirstName","label":"First Name","required":false}
+            {"type":"textField","name":"standards.DeployMailContact.LastName","label":"Last Name","required":false}
+        IMPACT
+            Low Impact
+        ADDEDDATE
+            2025-05-28
+        POWERSHELLEQUIVALENT
+            New-MailContact
+        RECOMMENDEDBY
+            "CIPP"
+    #>
+
+    param($Tenant, $Settings)
+
+    # Input validation
+    if (-not $Settings.ExternalEmailAddress -or -not $Settings.DisplayName) {
+        Write-LogMessage -API 'Standards' -tenant $Tenant -message 'DeployMailContact: ExternalEmailAddress and DisplayName are required parameters.' -sev Error
+        return
+    }
+
+    # Validate email address format
+    try {
+        $null = [System.Net.Mail.MailAddress]::new($Settings.ExternalEmailAddress)
+    }
+    catch {
+        Write-LogMessage -API 'Standards' -tenant $Tenant -message "DeployMailContact: Invalid email address format: $($Settings.ExternalEmailAddress)" -sev Error
+        return
+    }
+
+    # Check if contact already exists
+    try {
+        $ExistingContact = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MailContact' -cmdParams @{
+            Identity    = $Settings.ExternalEmailAddress
+            ErrorAction = 'Stop'
+        }
+    }
+    catch {
+        # If the error is that the contact wasn't found, that's expected and we can proceed
+        if ($_.Exception.Message -like "*couldn't be found*") {
+            $ExistingContact = $null
+        }
+        else {
+            # For any other error, we should log it and return
+            $ErrorMessage = Get-CippException -Exception $_
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Error checking for existing mail contact: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+            return
+        }
+    }
+
+    if ($ExistingContact) {
+        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Mail contact with email $($Settings.ExternalEmailAddress) already exists" -sev Info
+        return
+    }
+
+    # Remediation
+    if ($Settings.remediate -eq $true) {
+        try {
+            $NewContactParams = @{
+                ExternalEmailAddress = $Settings.ExternalEmailAddress
+                DisplayName          = $Settings.DisplayName
+                Name                 = $Settings.DisplayName
+            }
+
+            # Add optional parameters if provided
+            if ($Settings.FirstName) { $NewContactParams.FirstName = $Settings.FirstName }
+            if ($Settings.LastName) { $NewContactParams.LastName = $Settings.LastName }
+
+            $null = New-ExoRequest -tenantid $Tenant -cmdlet 'New-MailContact' -cmdParams $NewContactParams
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Successfully created mail contact $($Settings.DisplayName) with email $($Settings.ExternalEmailAddress)" -sev Info
+        }
+        catch {
+            $ErrorMessage = Get-CippException -Exception $_
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Could not create mail contact. $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+        }
+    }
+
+    # Alert
+    if ($Settings.alert -eq $true) {
+        if ($ExistingContact) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Mail contact $($Settings.DisplayName) already exists" -sev Info
+        }
+        else {
+            Write-StandardsAlert -message "Mail contact $($Settings.DisplayName) needs to be created" -object @{
+                DisplayName          = $Settings.DisplayName
+                ExternalEmailAddress = $Settings.ExternalEmailAddress
+                FirstName            = $Settings.FirstName
+                LastName             = $Settings.LastName
+            } -tenant $Tenant -standardName 'DeployMailContact' -standardId $Settings.standardId
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Mail contact $($Settings.DisplayName) needs to be created" -sev Info
+        }
+    }
+
+    # Report
+    if ($Settings.report -eq $true) {
+        $ReportData = @{
+            DisplayName          = $Settings.DisplayName
+            ExternalEmailAddress = $Settings.ExternalEmailAddress
+            FirstName            = $Settings.FirstName
+            LastName             = $Settings.LastName
+            Exists               = [bool]$ExistingContact
+        }
+        Add-CIPPBPAField -FieldName 'DeployMailContact' -FieldValue $ReportData -StoreAs json -Tenant $Tenant
+
+        if ($ExistingContact) {
+            $FieldValue = $true
+        }
+        else {
+            $FieldValue = $ReportData
+        }
+        Set-CIPPStandardsCompareField -FieldName 'standards.DeployMailContact' -FieldValue $FieldValue -Tenant $Tenant
+    }
+} 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardMailboxRecipientLimits.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardMailboxRecipientLimits.ps1
@@ -1,0 +1,87 @@
+function Invoke-CIPPStandardMailboxRecipientLimits {
+    <#
+    .FUNCTIONALITY
+        Internal
+    .COMPONENT
+        (APIName) MailboxRecipientLimits
+    .SYNOPSIS
+        (Label) Set Mailbox Recipient Limits
+    .DESCRIPTION
+        (Helptext) Sets the maximum number of recipients that can be specified in the To, Cc, and Bcc fields of a message for all mailboxes in the tenant.
+        (DocsDescription) This standard configures the recipient limits for all mailboxes in the tenant. The recipient limit determines the maximum number of recipients that can be specified in the To, Cc, and Bcc fields of a message. This helps prevent spam and manage email flow.
+    .NOTES
+        CAT
+            Exchange Standards
+        TAG
+        ADDEDCOMPONENT
+            {"type":"number","name":"standards.MailboxRecipientLimits.RecipientLimit","label":"Recipient Limit","defaultValue":500}
+        IMPACT
+            Low Impact
+        ADDEDDATE
+            2025-05-28
+        POWERSHELLEQUIVALENT
+            Set-Mailbox -RecipientLimits
+        RECOMMENDEDBY
+            "CIPP"
+    #>
+
+    param($Tenant, $Settings)
+
+    # Input validation
+    if ([Int32]$Settings.RecipientLimit -lt 0 -or [Int32]$Settings.RecipientLimit -gt 10000) {
+        Write-LogMessage -API 'Standards' -tenant $Tenant -message 'MailboxRecipientLimits: Invalid RecipientLimit parameter set. Must be between 0 and 10000.' -sev Error
+        return
+    }
+
+    # Get all mailboxes in the tenant
+    $Mailboxes = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-Mailbox' -cmdParams @{ResultSize = 'Unlimited' }
+
+    # Check which mailboxes need to be updated
+    $MailboxesToUpdate = $Mailboxes | Where-Object { $_.RecipientLimits -ne $Settings.RecipientLimit }
+
+    # Remediation
+    if ($Settings.remediate -eq $true) {
+        if ($MailboxesToUpdate.Count -gt 0) {
+            try {
+                foreach ($Mailbox in $MailboxesToUpdate) {
+                    $null = New-ExoRequest -tenantid $Tenant -cmdlet 'Set-Mailbox' -cmdParams @{
+                        Identity        = $Mailbox.Identity
+                        RecipientLimits = $Settings.RecipientLimit
+                    }
+                }
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Successfully set recipient limits to $($Settings.RecipientLimit) for $($MailboxesToUpdate.Count) mailboxes" -sev Info
+            }
+            catch {
+                $ErrorMessage = Get-CippException -Exception $_
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Could not set recipient limits. $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+            }
+        }
+        else {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "All mailboxes already have the correct recipient limit of $($Settings.RecipientLimit)" -sev Info
+        }
+    }
+
+    # Alert
+    if ($Settings.alert -eq $true) {
+        if ($MailboxesToUpdate.Count -eq 0) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "All mailboxes have the correct recipient limit of $($Settings.RecipientLimit)" -sev Info
+        }
+        else {
+            Write-StandardsAlert -message "Found $($MailboxesToUpdate.Count) mailboxes with incorrect recipient limits" -object $MailboxesToUpdate -tenant $Tenant -standardName 'MailboxRecipientLimits' -standardId $Settings.standardId
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Found $($MailboxesToUpdate.Count) mailboxes with incorrect recipient limits" -sev Info
+        }
+    }
+
+    # Report
+    if ($Settings.report -eq $true) {
+        Add-CIPPBPAField -FieldName 'MailboxRecipientLimits' -FieldValue $MailboxesToUpdate -StoreAs json -Tenant $Tenant
+
+        if ($MailboxesToUpdate.Count -eq 0) {
+            $FieldValue = $true
+        }
+        else {
+            $FieldValue = $MailboxesToUpdate
+        }
+        Set-CIPPStandardsCompareField -FieldName 'standards.MailboxRecipientLimits' -FieldValue $FieldValue -Tenant $Tenant
+    }
+} 


### PR DESCRIPTION
Add new PowerShell script to standardize mailbox recipient limits across tenants. This script will help enforce consistent recipient limits for mailboxes in the CIPP platform.