### PR TITLE
Fixed: Quarantine Policy Standards failed on compare

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-ListQuarantinePolicy.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Spamfilter/Invoke-ListQuarantinePolicy.ps1
@@ -18,8 +18,6 @@ function Invoke-ListQuarantinePolicy {
 
     $Policies = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-QuarantinePolicy' -cmdParams @{QuarantinePolicyType=$QuarantinePolicyType} | Select-Object -Property * -ExcludeProperty *odata*, *data.type*
 
-    write-host $($Request | ConvertTo-Json -Depth 10)
-
     if ($QuarantinePolicyType -eq 'QuarantinePolicy') {
         # Convert the string EndUserQuarantinePermissions to individual properties
         $Policies | ForEach-Object {

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
@@ -52,6 +52,9 @@ function Invoke-CIPPStandardQuarantineTemplate {
             try {
                 # Create hashtable with desired Quarantine Setting
                 $EndUserQuarantinePermissions   = @{
+                    # ViewHeader and Download are set to false because the value 0 or 1 does nothing per Microsoft documentation
+                    PermissionToViewHeader = $false
+                    PermissionToDownload  = $false
                     PermissionToBlockSender = $Policy.PermissionToBlockSender
                     PermissionToDelete  = $Policy.PermissionToDelete
                     PermissionToPreview = $Policy.PermissionToPreview
@@ -64,7 +67,7 @@ function Invoke-CIPPStandardQuarantineTemplate {
                 if ($Policy.displayName.value -in $CurrentPolicies.Name) {
                     #Get the current policy and convert EndUserQuarantinePermissions from string to hashtable for compare
                     $ExistingPolicy = $CurrentPolicies | Where-Object -Property Name -eq $Policy.displayName.value
-                    $ExistingPolicyEndUserQuarantinePermissions = Convert-QuarantinePermissionsValue @EndUserQuarantinePermissions -ErrorAction Stop
+                    $ExistingPolicyEndUserQuarantinePermissions = Convert-QuarantinePermissionsValue -InputObject $ExistingPolicy.EndUserQuarantinePermissions -ErrorAction Stop
 
                     #Compare the current policy
                     $StateIsCorrect = ($ExistingPolicy.Name -eq $Policy.displayName.value) -and


### PR DESCRIPTION
- Fixed issue where Quarantine Policy standard failed in compare section. Causing existing quarantine policies to fail before remediate, alert, report. New policies was successful but standard would fail no next run 
- Logbook would show error `Failed to compare Quarantine policy <policyName>, Error: Cannot bind argument to parameter 'ReferenceObject' because it is null.`
- Removed write-host that was used for debug under development