### PR TITLE
Fix for Set send/receive size limits

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Transport/Invoke-AddTransportRule.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Transport/Invoke-AddTransportRule.ps1
@@ -1,9 +1,9 @@
 using namespace System.Net
 
-Function Invoke-AddTransportRule {
+function Invoke-AddTransportRule {
     <#
     .FUNCTIONALITY
-        Entrypoint
+        Entrypoint,AnyTenant
     .ROLE
         Exchange.TransportRule.ReadWrite
     #>
@@ -17,6 +17,15 @@ Function Invoke-AddTransportRule {
     $RequestParams = $Request.Body.PowerShellCommand | ConvertFrom-Json | Select-Object -Property * -ExcludeProperty GUID, HasSenderOverride, ExceptIfHasSenderOverride, ExceptIfMessageContainsDataClassifications, MessageContainsDataClassifications
 
     $Tenants = ($Request.body.selectedTenants).value
+
+    $AllowedTenants = Test-CippAccess -Request $Request -TenantList
+
+    if ($AllowedTenants -ne 'AllTenants') {
+        $AllTenants = Get-Tenants -IncludeErrors
+        $AllowedTenantList = $AllTenants | Where-Object { $_.customerId -in $AllowedTenants }
+        $Tenants = $Tenants | Where-Object { $_ -in $AllowedTenantList.defaultDomainName }
+    }
+
     $Result = foreach ($tenantFilter in $tenants) {
         $Existing = New-ExoRequest -ErrorAction SilentlyContinue -tenantid $tenantFilter -cmdlet 'Get-TransportRule' -useSystemMailbox $true | Where-Object -Property Identity -EQ $RequestParams.name
         try {

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-AddStandardsTemplate.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-AddStandardsTemplate.ps1
@@ -29,9 +29,8 @@ function Invoke-AddStandardsTemplate {
         RowKey       = "$GUID"
         PartitionKey = 'StandardsTemplateV2'
         GUID         = "$GUID"
-
     }
-    Write-LogMessage -headers $Request.Headers -API $APINAME -message "Created CA Template $($Request.body.name) with GUID $GUID" -Sev 'Debug'
+    Write-LogMessage -headers $Request.Headers -API $APINAME -message "Standards Template $($Request.body.templateName) with GUID $GUID added/edited." -Sev 'Info'
     $body = [pscustomobject]@{'Results' = 'Successfully added template'; Metadata = @{id = $GUID } }
 
     # Associate values to output bindings by calling 'Push-OutputBinding'.

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-listStandardTemplates.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-listStandardTemplates.ps1
@@ -1,6 +1,6 @@
 using namespace System.Net
 
-Function Invoke-listStandardTemplates {
+function Invoke-listStandardTemplates {
     <#
     .FUNCTIONALITY
         Entrypoint,AnyTenant
@@ -29,7 +29,11 @@ Function Invoke-listStandardTemplates {
             return
         }
         $Data | Add-Member -NotePropertyName 'GUID' -NotePropertyValue $_.GUID -Force
-        if ($Data.excludedTenants) { $Data.excludedTenants = @($Data.excludedTenants) }
+        if ($Data.excludedTenants -and $Data.excludedTenants -ne 'excludedTenants') {
+            $Data.excludedTenants = @($Data.excludedTenants)
+        } else {
+            $Data.excludedTenants = @()
+        }
         $Data
     } | Sort-Object -Property templateName
 

--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-ListLogs.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-ListLogs.ps1
@@ -3,7 +3,7 @@ using namespace System.Net
 function Invoke-ListLogs {
     <#
     .FUNCTIONALITY
-        Entrypoint
+        Entrypoint,AnyTenant
     .ROLE
         CIPP.Core.Read
     #>

--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-ListLogs.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-ListLogs.ps1
@@ -54,34 +54,33 @@ function Invoke-ListLogs {
         Write-Host "Getting logs for filter: $Filter, LogLevel: $LogLevel, Username: $username"
 
         $Rows = Get-AzDataTableEntity @Table -Filter $Filter | Where-Object { $_.Severity -in $LogLevel -and $_.Username -like $username }
+
+        if ($AllowedTenants -notcontains 'AllTenants') {
+            $TenantList = Get-Tenants -IncludeErrors | Where-Object { $_.customerId -in $AllowedTenants }
+        }
+
         foreach ($Row in $Rows) {
-            if ($AllowedTenants -notcontains 'AllTenants') {
-                $TenantList = Get-Tenants -IncludeErrors
-                if ($Row.Tenant -ne 'None' -and $Row.Tenant) {
-                    $Tenant = $TenantList | Where-Object -Property defaultDomainName -EQ $Row.Tenant
-                    if ($Tenant -and $Tenant.customerId -notin $AllowedTenants) {
-                        continue
+            if ($AllowedTenants -contains 'AllTenants' -or ($AllowedTenants -notcontains 'AllTenants' -and ($TenantList.defaultDomainName -contains $Row.Tenant -or $Row.Tenant -eq 'CIPP' -or $TenantList.customerId -contains $Row.TenantId)) ) {
+
+                $LogData = if ($Row.LogData -and (Test-Json -Json $Row.LogData -ErrorAction SilentlyContinue)) {
+                    $Row.LogData | ConvertFrom-Json
+                } else { $Row.LogData }
+                [PSCustomObject]@{
+                    DateTime = $Row.Timestamp
+                    Tenant   = $Row.Tenant
+                    API      = $Row.API
+                    Message  = $Row.Message
+                    User     = $Row.Username
+                    Severity = $Row.Severity
+                    LogData  = $LogData
+                    TenantID = if ($Row.TenantID -ne $null) {
+                        $Row.TenantID
+                    } else {
+                        'None'
                     }
+                    AppId    = $Row.AppId
+                    IP       = $Row.IP
                 }
-            }
-            $LogData = if ($Row.LogData -and (Test-Json -Json $Row.LogData -ErrorAction SilentlyContinue)) {
-                $Row.LogData | ConvertFrom-Json
-            } else { $Row.LogData }
-            [PSCustomObject]@{
-                DateTime = $Row.Timestamp
-                Tenant   = $Row.Tenant
-                API      = $Row.API
-                Message  = $Row.Message
-                User     = $Row.Username
-                Severity = $Row.Severity
-                LogData  = $LogData
-                TenantID = if ($Row.TenantID -ne $null) {
-                    $Row.TenantID
-                } else {
-                    'None'
-                }
-                AppId    = $Row.AppId
-                IP       = $Row.IP
             }
         }
     }

--- a/Modules/CIPPCore/Public/Set-CIPPCopyGroupMembers.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPCopyGroupMembers.ps1
@@ -46,7 +46,7 @@ function Set-CIPPCopyGroupMembers {
         try {
             if ($PSCmdlet.ShouldProcess($MailGroup.displayName, "Add $UserId to group")) {
                 if ($MailGroup.MailEnabled -and $Mailgroup.ResourceProvisioningOptions -notcontains 'Team' -and $MailGroup.groupTypes -notcontains 'Unified') {
-                    $Params = @{ Identity = $MailGroup.mailNickname; Member = $UserId; BypassSecurityGroupManagerCheck = $true }
+                    $Params = @{ Identity = $MailGroup.id; Member = $UserId; BypassSecurityGroupManagerCheck = $true }
                     try {
                         $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Add-DistributionGroupMember' -cmdParams $params -UseSystemMailbox $true
                     } catch {

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardEXODisableAutoForwarding.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardEXODisableAutoForwarding.ps1
@@ -38,8 +38,7 @@ function Invoke-CIPPStandardEXODisableAutoForwarding {
     $CurrentInfo = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-HostedOutboundSpamFilterPolicy' -cmdParams @{Identity = 'Default' } -useSystemMailbox $true
     $StateIsCorrect = $CurrentInfo.AutoForwardingMode -eq 'Off'
 
-    If ($Settings.remediate -eq $true) {
-
+    if ($Settings.remediate -eq $true) {
         try {
             New-ExoRequest -tenantid $tenant -cmdlet 'Set-HostedOutboundSpamFilterPolicy' -cmdParams @{ Identity = 'Default'; AutoForwardingMode = 'Off' } -useSystemMailbox $true
             Write-LogMessage -API 'Standards' -tenant $tenant -message 'Disabled auto forwarding' -sev Info
@@ -50,7 +49,6 @@ function Invoke-CIPPStandardEXODisableAutoForwarding {
     }
 
     if ($Settings.alert -eq $true) {
-
         if ($StateIsCorrect -eq $true) {
             Write-LogMessage -API 'Standards' -tenant $tenant -message 'Auto forwarding is disabled.' -sev Info
         } else {
@@ -60,9 +58,8 @@ function Invoke-CIPPStandardEXODisableAutoForwarding {
     }
 
     if ($Settings.report -eq $true) {
-        $state = $StateIsCorrect ? $true : $CurrentInfo | Select-Object autoForwardingMode
+        $state = $StateIsCorrect ?? ($CurrentInfo | Select-Object AutoForwardingMode)
         Set-CIPPStandardsCompareField -FieldName 'standards.EXODisableAutoForwarding' -FieldValue $state -TenantFilter $Tenant
         Add-CIPPBPAField -FieldName 'AutoForwardingDisabled' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $tenant
     }
-
 }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
@@ -241,9 +241,7 @@ function Invoke-CIPPStandardSpamFilterPolicy {
         if ($StateIsCorrect) {
             $FieldValue = $true
         } else {
-            $CurrentState = $CurrentState | Select-Object -Property Name, SpamAction, SpamQuarantineTag, HighConfidenceSpamAction, HighConfidenceSpamQuarantineTag, BulkSpamAction, BulkQuarantineTag, PhishSpamAction, PhishQuarantineTag, HighConfidencePhishAction, HighConfidencePhishQuarantineTag, BulkThreshold, QuarantineRetentionPeriod, IncreaseScoreWithImageLinks, IncreaseScoreWithNumericIps, IncreaseScoreWithRedirectToOtherPort, IncreaseScoreWithBizOrInfoUrls, MarkAsSpamEmptyMessages, MarkAsSpamJavaScriptInHtml, MarkAsSpamFramesInHtml, MarkAsSpamObjectTagsInHtml, MarkAsSpamEmbedTagsInHtml, MarkAsSpamFormTagsInHtml, MarkAsSpamWebBugsInHtml, MarkAsSpamSensitiveWordList, MarkAsSpamSpfRecordHardFail, MarkAsSpamFromAddressAuthFail, MarkAsSpamNdrBackscatter, MarkAsSpamBulkMail, InlineSafetyTipsEnabled, PhishZapEnabled, SpamZapEnabled
-
-            $FieldValue = $StateIsCorrect ?? $CurrentState ?? @{ state = 'Spam filter policy not found' }
+            $FieldValue = $StateIsCorrect -eq $true ? $true : ($CurrentState ?? @{ state = 'Spam filter policy not found' })
         }
         Set-CIPPStandardsCompareField -FieldName 'standards.SpamFilterPolicy' -FieldValue $FieldValue -Tenant $Tenant
     }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
@@ -241,7 +241,9 @@ function Invoke-CIPPStandardSpamFilterPolicy {
         if ($StateIsCorrect) {
             $FieldValue = $true
         } else {
-            $FieldValue = $CurrentState ? $CurrentState : @{ state = 'Spam filter policy not found' }
+            $CurrentState = $CurrentState | Select-Object -Property Name, SpamAction, SpamQuarantineTag, HighConfidenceSpamAction, HighConfidenceSpamQuarantineTag, BulkSpamAction, BulkQuarantineTag, PhishSpamAction, PhishQuarantineTag, HighConfidencePhishAction, HighConfidencePhishQuarantineTag, BulkThreshold, QuarantineRetentionPeriod, IncreaseScoreWithImageLinks, IncreaseScoreWithNumericIps, IncreaseScoreWithRedirectToOtherPort, IncreaseScoreWithBizOrInfoUrls, MarkAsSpamEmptyMessages, MarkAsSpamJavaScriptInHtml, MarkAsSpamFramesInHtml, MarkAsSpamObjectTagsInHtml, MarkAsSpamEmbedTagsInHtml, MarkAsSpamFormTagsInHtml, MarkAsSpamWebBugsInHtml, MarkAsSpamSensitiveWordList, MarkAsSpamSpfRecordHardFail, MarkAsSpamFromAddressAuthFail, MarkAsSpamNdrBackscatter, MarkAsSpamBulkMail, InlineSafetyTipsEnabled, PhishZapEnabled, SpamZapEnabled
+
+            $FieldValue = $StateIsCorrect ?? $CurrentState ?? @{ state = 'Spam filter policy not found' }
         }
         Set-CIPPStandardsCompareField -FieldName 'standards.SpamFilterPolicy' -FieldValue $FieldValue -Tenant $Tenant
     }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardUserSubmissions.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardUserSubmissions.ps1
@@ -196,6 +196,8 @@ function Invoke-CIPPStandardUserSubmissions {
         if ($StateIsCorrect) {
             $FieldValue = $true
         } else {
+            $PolicyState = $PolicyState | Select-Object EnableReportToMicrosoft, ReportJunkToCustomizedAddress, ReportNotJunkToCustomizedAddress, ReportPhishToCustomizedAddress, ReportJunkAddresses, ReportNotJunkAddresses, ReportPhishAddresses
+            $RuleState = $RuleState | Select-Object State, SentTo
             $FieldValue = @{ PolicyState = $PolicyState; RuleState = $RuleState }
         }
 


### PR DESCRIPTION
Handle mailbox plan size values set to "Unlimited" to prevent conversion errors when comparing or updating send/receive limits in Exchange Online.
Prevent error: "Error running standard SendReceiveLimitTenant for tenant xxx.xx - Cannot convert value "Unlimited" to type "System.Int64". Error: "The input string 'Unlimited' was not in a correct format.""