### PR TITLE
Fix: CIPPAlertInactiveLicensedUsers 

### DIFF
--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertInactiveLicensedUsers.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertInactiveLicensedUsers.ps1
@@ -8,8 +8,8 @@ function Get-CIPPAlertInactiveLicensedUsers {
         [Parameter(Mandatory = $false)]
         [Alias('input')]
         $InputValue,
-        [Parameter(Mandatory = $false)] #future use
-        [switch]$SkipNeverSignedIn, #future use
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeNeverSignedIn, # Include users who have never signed in (default is to skip them), future use would allow this to be set in an alert configuration
         $TenantFilter
     )
 
@@ -45,10 +45,8 @@ function Get-CIPPAlertInactiveLicensedUsers {
 
                 # Check if inactive
                 $isInactive = (-not $lastSignIn) -or ([DateTime]$lastSignIn -le $Lookup)
-
-                # Apply SkipNeverSignedIn filter #future use
-                if ($SkipNeverSignedIn -and -not $lastSignIn) { continue }
-
+                # Skip users who have never signed in by default (unless IncludeNeverSignedIn is specified)
+                if (-not $IncludeNeverSignedIn -and -not $lastSignIn) { continue }
                 # Only process inactive users
                 if ($isInactive) {
                     if (-not $lastSignIn) {

--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertInactiveLicensedUsers.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertInactiveLicensedUsers.ps1
@@ -8,28 +8,62 @@ function Get-CIPPAlertInactiveLicensedUsers {
         [Parameter(Mandatory = $false)]
         [Alias('input')]
         $InputValue,
+        [Parameter(Mandatory = $false)] #future use
+        [switch]$SkipNeverSignedIn, #future use
         $TenantFilter
     )
 
     try {
         try {
+            $Lookup = (Get-Date).AddDays(-90).ToUniversalTime()
 
-            $Lookup = (Get-Date).AddDays(-90).ToUniversalTime().ToString('o')
-            $GraphRequest = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users?`$filter=(signInActivity/lastNonInteractiveSignInDateTime le $Lookup)&`$select=id,UserPrincipalName,signInActivity,mail,userType,accountEnabled,assignedLicenses" -scope 'https://graph.microsoft.com/.default' -tenantid $TenantFilter |
-                Where-Object { $null -ne $_.assignedLicenses.skuId }
+            # Build base filter - cannot filter assignedLicenses server-side
+            $BaseFilter = if ($InputValue -eq $true) { "accountEnabled eq true" } else { "" }
 
-            # true = only active users
-            if ($InputValue -eq $true) { $GraphRequest = $GraphRequest | Where-Object { $_.accountEnabled -eq $true } }
-            $AlertData = foreach ($user in $GraphRequest) {
-                $Message = 'User {0} has been inactive for 90 days, but still has a license assigned.' -f $user.UserPrincipalName
-                $user | Select-Object -Property UserPrincipalName, signInActivity, @{Name = 'Message'; Expression = { $Message } }
-
+            $Uri = if ($BaseFilter) {
+                "https://graph.microsoft.com/beta/users?`$filter=$BaseFilter&`$select=id,UserPrincipalName,signInActivity,mail,userType,accountEnabled,assignedLicenses"
+            } else {
+                "https://graph.microsoft.com/beta/users?`$select=id,UserPrincipalName,signInActivity,mail,userType,accountEnabled,assignedLicenses"
             }
+
+            $GraphRequest = New-GraphGetRequest -uri $Uri -scope 'https://graph.microsoft.com/.default' -tenantid $TenantFilter |
+                Where-Object { $null -ne $_.assignedLicenses -and $_.assignedLicenses.Count -gt 0 }
+
+            $AlertData = foreach ($user in $GraphRequest) {
+                $lastInteractive = $user.signInActivity.lastSignInDateTime
+                $lastNonInteractive = $user.signInActivity.lastNonInteractiveSignInDateTime
+
+                # Find most recent sign-in
+                $lastSignIn = $null
+                if ($lastInteractive -and $lastNonInteractive) {
+                    $lastSignIn = if ([DateTime]$lastInteractive -gt [DateTime]$lastNonInteractive) { $lastInteractive } else { $lastNonInteractive }
+                } elseif ($lastInteractive) {
+                    $lastSignIn = $lastInteractive
+                } elseif ($lastNonInteractive) {
+                    $lastSignIn = $lastNonInteractive
+                }
+
+                # Check if inactive
+                $isInactive = (-not $lastSignIn) -or ([DateTime]$lastSignIn -le $Lookup)
+
+                # Apply SkipNeverSignedIn filter #future use
+                if ($SkipNeverSignedIn -and -not $lastSignIn) { continue }
+
+                # Only process inactive users
+                if ($isInactive) {
+                    if (-not $lastSignIn) {
+                        $Message = 'User {0} has never signed in but still has a license assigned.' -f $user.UserPrincipalName
+                    } else {
+                        $daysSinceSignIn = [Math]::Round(((Get-Date) - [DateTime]$lastSignIn).TotalDays)
+                        $Message = 'User {0} has been inactive for {1} days but still has a license assigned. Last sign-in: {2}' -f $user.UserPrincipalName, $daysSinceSignIn, $lastSignIn
+                    }
+
+                    $user | Select-Object -Property UserPrincipalName, signInActivity, @{Name = 'Message'; Expression = { $Message } }
+                }
+            }
+
             Write-AlertTrace -cmdletName $MyInvocation.MyCommand -tenantFilter $TenantFilter -data $AlertData
-
         } catch {}
-
-
     } catch {
         Write-AlertMessage -tenant $($TenantFilter) -message "Failed to check inactive users with licenses for $($TenantFilter): $(Get-NormalizedError -message $_.Exception.message)"
     }


### PR DESCRIPTION
This now checks against interactive sign-ins, something that it did not account for in the past.

A little bit of future use in there as well to make it possible to include never signed in accounts in the alert.

Seems to work for me but feel free to test in dev/prod env