### PR TITLE
Add log message endpoint for Transport Standards and clearing up inconsistant use of APINAME for logs

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardConditionalAccessTemplate.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardConditionalAccessTemplate.ps1
@@ -33,8 +33,6 @@ function Invoke-CIPPStandardConditionalAccessTemplate {
 
     If ($Settings.remediate -eq $true) {
 
-        $APINAME = 'Standards'
-
         foreach ($Setting in $Settings) {
             try {
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardExConnector.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardExConnector.ps1
@@ -8,7 +8,6 @@ function Invoke-CIPPStandardExConnector {
 
     If ($Settings.remediate -eq $true) {
 
-        $APINAME = 'Standards'
         foreach ($Template in $Settings.TemplateList) {
             try {
                 $Table = Get-CippTable -tablename 'templates'
@@ -20,10 +19,10 @@ function Invoke-CIPPStandardExConnector {
                 if ($Existing) {
                     $RequestParams | Add-Member -NotePropertyValue $Existing.Identity -NotePropertyName Identity -Force
                     $null = New-ExoRequest -tenantid $Tenant -cmdlet "Set-$($ConnectorType)connector" -cmdParams $RequestParams -useSystemMailbox $true
-                    Write-LogMessage -API $APINAME -tenant $Tenant -message "Updated transport rule for $($Tenant, $Settings)" -sev info
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated transport rule for $($Tenant, $Settings)" -sev info
                 } else {
                     $null = New-ExoRequest -tenantid $Tenant -cmdlet "New-$($ConnectorType)connector" -cmdParams $RequestParams -useSystemMailbox $true
-                    Write-LogMessage -API $APINAME -tenant $Tenant -message "Created transport rule for $($Tenant, $Settings)" -sev info
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created transport rule for $($Tenant, $Settings)" -sev info
                 }
             } catch {
                 $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTransportRuleTemplate.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardTransportRuleTemplate.ps1
@@ -51,7 +51,7 @@ function Invoke-CIPPStandardTransportRuleTemplate {
                     Write-LogMessage -API 'Standards' -tenant $tenant -message "Successfully created transport rule for $tenant" -sev 'Info'
                 }
 
-                Write-LogMessage -API $APINAME -tenant $Tenant -message "Created transport rule for $($tenantFilter)" -sev 'Debug'
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created transport rule for $($tenantFilter)" -sev 'Debug'
             } catch {
                 $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
                 Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not create transport rule for $($tenantFilter): $ErrorMessage" -sev 'Error'


### PR DESCRIPTION
The variable was missing for $APIName in the transport rule standard, and upon reviewing other standards, I found that they were no longer using the variable to define the log message location.

I have changed two other standards that had an inconsistent usage of $APINAME.

I haven't adjusted https://github.com/KelvinTegelaar/CIPP-API/blob/master/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1 because it used $APIName throughout