### PR TITLE
Feat: Enhance Set-CIPPNamedLocation functionality and fix variable casing issues

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-ListTenantDetails.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-ListTenantDetails.ps1
@@ -28,6 +28,7 @@ Function Invoke-ListTenantDetails {
 
         $Groups = (Get-TenantGroups -TenantFilter $TenantFilter) ?? @()
         $org | Add-Member -MemberType NoteProperty -Name 'Groups' -Value @($Groups)
+        $StatusCode = [HttpStatusCode]::OK
 
     } catch {
         $ErrorMessage = Get-CippException -Exception $_

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Conditional/Invoke-ExecNamedLocation.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Conditional/Invoke-ExecNamedLocation.ps1
@@ -15,26 +15,26 @@ function Invoke-ExecNamedLocation {
     Write-LogMessage -headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
 
 
+    # Interact with query parameters or the body of the request.
     $TenantFilter = $Request.Body.tenantFilter ?? $Request.Query.tenantFilter
-    $NamedLocationId = $Request.Body.NamedLocationId ?? $Request.Query.NamedLocationId
-    $change = $Request.Body.change ?? $Request.Query.change
-    $content = $Request.Body.input ?? $Request.Query.input
+    $NamedLocationId = $Request.Body.namedLocationId ?? $Request.Query.namedLocationId
+    $Change = $Request.Body.change ?? $Request.Query.change
+    $Content = $Request.Body.input ?? $Request.Query.input
 
     try {
-        $results = Set-CIPPNamedLocation -NamedLocationId $NamedLocationId -TenantFilter $TenantFilter -change $change -content $content -Headers $Request.Headers
+        $results = Set-CIPPNamedLocation -NamedLocationId $NamedLocationId -TenantFilter $TenantFilter -Change $Change -Content $Content -Headers $Headers
+        $StatusCode = [HttpStatusCode]::OK
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
-        Write-LogMessage -headers $Request.Headers -API $APIName -message "Failed to edit named location: $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
+        Write-LogMessage -headers $Headers -API $APIName -message "Failed to edit named location: $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
         $results = "Failed to edit named location. Error: $($ErrorMessage.NormalizedError)"
+        $StatusCode = [HttpStatusCode]::InternalServerError
     }
-
-
-    $body = [pscustomobject]@{'Results' = @($results) }
 
     # Associate values to output bindings by calling 'Push-OutputBinding'.
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
-            StatusCode = [HttpStatusCode]::OK
-            Body       = $body
+            StatusCode = $StatusCode
+            Body       = @{'Results' = @($results) }
         })
 
 }

--- a/Modules/CIPPCore/Public/Set-CIPPNamedLocation.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPNamedLocation.ps1
@@ -3,8 +3,8 @@ function Set-CIPPNamedLocation {
     param(
         $NamedLocationId,
         $TenantFilter,
-        #$Change should be one of 'addIp','addLocation','removeIp','removeLocation','rename','setTrusted','setUntrusted'
-        [ValidateSet('addIp', 'addLocation', 'removeIp', 'removeLocation', 'rename', 'setTrusted', 'setUntrusted')]
+        #$Change should be one of 'addIp','addLocation','removeIp','removeLocation','rename','setTrusted','setUntrusted','delete'
+        [ValidateSet('addIp', 'addLocation', 'removeIp', 'removeLocation', 'rename', 'setTrusted', 'setUntrusted', 'delete')]
         $Change,
         $Content,
         $APIName = 'Set Named Location',
@@ -13,40 +13,58 @@ function Set-CIPPNamedLocation {
 
     try {
         $NamedLocations = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/identity/conditionalAccess/namedLocations/$NamedLocationId" -Tenantid $TenantFilter
+
         switch ($Change) {
             'addIp' {
                 $NamedLocations.ipRanges = @($NamedLocations.ipRanges + @{ cidrAddress = $Content; '@odata.type' = '#microsoft.graph.iPv4CidrRange' })
+                $ActionDescription = "Adding IP $Content to named location"
             }
             'addLocation' {
                 $NamedLocations.countriesAndRegions = $NamedLocations.countriesAndRegions + $Content
+                $ActionDescription = "Adding location $Content to named location"
             }
             'removeIp' {
                 $NamedLocations.ipRanges = @($NamedLocations.ipRanges | Where-Object -Property cidrAddress -NE $Content)
+                $ActionDescription = "Removing IP $Content from named location"
             }
             'removeLocation' {
                 $NamedLocations.countriesAndRegions = @($NamedLocations.countriesAndRegions | Where-Object { $_ -NE $Content })
+                $ActionDescription = "Removing location $Content from named location"
             }
             'rename' {
                 $NamedLocations.displayName = $Content
+                $ActionDescription = "Renaming named location to: $Content"
             }
             'setTrusted' {
                 $NamedLocations.isTrusted = $true
+                $ActionDescription = 'Setting named location as trusted'
             }
             'setUntrusted' {
                 $NamedLocations.isTrusted = $false
+                $ActionDescription = 'Setting named location as untrusted'
+            }
+            'delete' {
+                $ActionDescription = 'Deleting named location'
             }
         }
-        if ($PSCmdlet.ShouldProcess($NamedLocations.displayName, "Editing named location: $($NamedLocations.displayName). Change: $Change with content $($Content)")) {
-            #Remove unneeded properties
-            if ($NamedLocations.'@odata.type' -eq '#microsoft.graph.countryNamedLocation') {
-                $NamedLocations = $NamedLocations | Select-Object '@odata.type', 'displayName', 'countriesAndRegions', 'includeUnknownCountriesAndRegions'
-            } elseif ($NamedLocations.'@odata.type' -eq '#microsoft.graph.ipNamedLocation') {
-                $NamedLocations = $NamedLocations | Select-Object '@odata.type', 'displayName', 'ipRanges', 'isTrusted'
+
+        if ($PSCmdlet.ShouldProcess($NamedLocations.displayName, $ActionDescription)) {
+            if ($Change -eq 'delete') {
+                $null = New-GraphPOSTRequest -uri "https://graph.microsoft.com/beta/identity/conditionalAccess/namedLocations/$NamedLocationId" -tenantid $TenantFilter -type DELETE
+                $Result = "Deleted named location: $($NamedLocations.displayName)"
+            } else {
+                # PATCH operations - remove unneeded properties
+                if ($NamedLocations.'@odata.type' -eq '#microsoft.graph.countryNamedLocation') {
+                    $NamedLocations = $NamedLocations | Select-Object '@odata.type', 'displayName', 'countriesAndRegions', 'includeUnknownCountriesAndRegions'
+                } elseif ($NamedLocations.'@odata.type' -eq '#microsoft.graph.ipNamedLocation') {
+                    $NamedLocations = $NamedLocations | Select-Object '@odata.type', 'displayName', 'ipRanges', 'isTrusted'
+                }
+
+                $JsonBody = ConvertTo-Json -InputObject $NamedLocations -Compress -Depth 10
+                $null = New-GraphPOSTRequest -uri "https://graph.microsoft.com/beta/identity/conditionalAccess/namedLocations/$NamedLocationId" -tenantid $TenantFilter -type PATCH -body $JsonBody
+                $Result = "Edited named location: $($NamedLocations.displayName). Change: $Change$(if ($Content) { " with content $Content" })"
             }
 
-            $JsonBody = ConvertTo-Json -InputObject $NamedLocations -Compress -Depth 10
-            $null = New-GraphPOSTRequest -uri "https://graph.microsoft.com/beta/identity/conditionalAccess/namedLocations/$NamedLocationId" -tenantid $TenantFilter -type PATCH -body $JsonBody
-            $Result = "Edited named location: $($NamedLocations.displayName). Change: $Change with content $($Content)"
             Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message $Result -Sev 'Info'
         }
         return $Result

--- a/Modules/CIPPCore/Public/Set-CIPPNamedLocation.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPNamedLocation.ps1
@@ -3,8 +3,8 @@ function Set-CIPPNamedLocation {
     param(
         $NamedLocationId,
         $TenantFilter,
-        #$Change should be one of 'addIp','addLocation','removeIp','removeLocation','rename'
-        [ValidateSet('addIp', 'addLocation', 'removeIp', 'removeLocation', 'rename')]
+        #$Change should be one of 'addIp','addLocation','removeIp','removeLocation','rename','setTrusted','setUntrusted'
+        [ValidateSet('addIp', 'addLocation', 'removeIp', 'removeLocation', 'rename', 'setTrusted', 'setUntrusted')]
         $Change,
         $Content,
         $APIName = 'Set Named Location',
@@ -29,12 +29,18 @@ function Set-CIPPNamedLocation {
             'rename' {
                 $NamedLocations.displayName = $Content
             }
+            'setTrusted' {
+                $NamedLocations.isTrusted = $true
+            }
+            'setUntrusted' {
+                $NamedLocations.isTrusted = $false
+            }
         }
         if ($PSCmdlet.ShouldProcess($NamedLocations.displayName, "Editing named location: $($NamedLocations.displayName). Change: $Change with content $($Content)")) {
             #Remove unneeded properties
             if ($NamedLocations.'@odata.type' -eq '#microsoft.graph.countryNamedLocation') {
                 $NamedLocations = $NamedLocations | Select-Object '@odata.type', 'displayName', 'countriesAndRegions', 'includeUnknownCountriesAndRegions'
-            } else {
+            } elseif ($NamedLocations.'@odata.type' -eq '#microsoft.graph.ipNamedLocation') {
                 $NamedLocations = $NamedLocations | Select-Object '@odata.type', 'displayName', 'ipRanges', 'isTrusted'
             }
 


### PR DESCRIPTION
Introduce support for renaming named locations and additional actions like setting trusted/untrusted states and deleting locations. Standardize variable casing and improve error handling in the Set-CIPPNamedLocation function
Also fix dumb tenant info bug.