### PR TITLE
Domain Analyser and DKIM exclusions

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Domain Analyser/Push-DomainAnalyserTenant.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Domain Analyser/Push-DomainAnalyserTenant.ps1
@@ -30,6 +30,8 @@ function Push-DomainAnalyserTenant {
                 '*.signature365.net'
                 '*.myteamsconnect.io'
                 '*.teams.dstny.com'
+                '*.msteams.8x8.com'
+                '*.ucconnect.co.uk'
             )
             $Domains = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/domains' -tenantid $Tenant.customerId | Where-Object { $_.isVerified -eq $true } | ForEach-Object {
                 $Domain = $_

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAddDKIM.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAddDKIM.ps1
@@ -76,6 +76,8 @@ function Invoke-CIPPStandardAddDKIM {
         '*.signature365.net'
         '*.myteamsconnect.io'
         '*.teams.dstny.com'
+        '*.msteams.8x8.com'
+        '*.ucconnect.co.uk'
     )
 
     $AllDomains = ($BatchResults | Where-Object { $_.DomainName }).DomainName | ForEach-Object {


### PR DESCRIPTION
8x8 and Gamma both appear on the tenant as added domains for their teams integration, like the other excluded domains I have added them to this list as no DKIM or domain analyser actions should be performed on them