### PR TITLE
Fix: Quaratine Policy standard report

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ListStandardsCompare.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ListStandardsCompare.ps1
@@ -50,6 +50,18 @@ function Invoke-ListStandardsCompare {
         $FieldName = $Standard.RowKey
         $FieldValue = $Standard.Value
         $Tenant = $Standard.PartitionKey
+
+        # decode field names that are hex encoded (e.g. QuarantineTemplates)
+        if ($FieldName -match '^(standards\.QuarantineTemplate\.)(.+)$') {
+            $Prefix = $Matches[1]
+            $HexEncodedName = $Matches[2]
+            $Chars = [System.Collections.Generic.List[char]]::new()
+            for ($i = 0; $i -lt $HexEncodedName.Length; $i += 2) {
+                $Chars.Add([char][Convert]::ToInt32($HexEncodedName.Substring($i,2),16))
+            }
+            $FieldName = "$Prefix$(-join $Chars)"
+        }
+
         if ($FieldValue -is [System.Boolean]) {
             $FieldValue = [bool]$FieldValue
         } elseif ($FieldValue -like '*{*') {

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
@@ -183,9 +183,10 @@ function Invoke-CIPPStandardQuarantineTemplate {
         }
 
         if ($true -in $Settings.report) {
-            # This could do with an improvement. But will work for now or else reporting could be disabled for now
             foreach ($Policy in $CompareList | Where-Object -Property report -EQ $true) {
-                Set-CIPPStandardsCompareField -FieldName "standards.QuarantineTemplate" -FieldValue $Policy.StateIsCorrect -TenantFilter $Tenant
+                # Convert displayName to hex to avoid invalid characters "/, \, #, ?" which are not allowed in RowKey, but "\, #, ?" can be used in quarantine displayName
+                $HexName = -join ($Policy.displayName.ToCharArray() | ForEach-Object { '{0:X2}' -f [int][char]$_ })
+                Set-CIPPStandardsCompareField -FieldName "standards.QuarantineTemplate.$HexName" -FieldValue $Policy.StateIsCorrect -TenantFilter $Tenant
             }
         }
     }


### PR DESCRIPTION
The compare/report result was not saved properly. Because an identificer for the template as missing. Only available identificer is the name of the Quarantine Policy.

There was just one issue with using name as identificer. Because fieldname is saved as rowkey, characters "/, \, #, ?" are not allowed. Quarantine policy name allows 3 of those characters in the name.

To prevent invalid characters trying to be saved as rowkey I convert the policy name to hex.

- Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/4303