### PR TITLE
Fix: Re-add Set-CIPPCalendarPermission refactor and clean up logging

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyCalPerms.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyCalPerms.ps1
@@ -11,16 +11,17 @@ Function Invoke-ExecModifyCalPerms {
     param($Request, $TriggerMetadata)
 
     $APIName = $Request.Params.CIPPEndpoint
-    Write-LogMessage -headers $Request.Headers -API $APINAME-message 'Accessed this API' -Sev 'Debug'
-    
-    $Username = $request.body.userID
-    $Tenantfilter = $request.body.tenantfilter
-    $Permissions = $request.body.permissions
+    $Headers = $Request.Headers
+    Write-LogMessage -headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
 
-    Write-LogMessage -headers $Request.Headers -API $APINAME-message "Processing request for user: $Username, tenant: $Tenantfilter" -Sev 'Debug'
+    $Username = $Request.Body.userID
+    $TenantFilter = $Request.Body.tenantFilter
+    $Permissions = $Request.Body.permissions
 
-    if ($username -eq $null) { 
-        Write-LogMessage -headers $Request.Headers -API $APINAME-message 'Username is null' -Sev 'Error'
+    Write-LogMessage -headers $Headers -API $APIName -message "Processing request for user: $Username, tenant: $TenantFilter" -Sev 'Debug'
+
+    if ($null -eq $Username) {
+        Write-LogMessage -headers $Headers -API $APIName -message 'Username is null' -Sev 'Error'
         $body = [pscustomobject]@{'Results' = @('Username is required') }
         Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
                 StatusCode = [HttpStatusCode]::BadRequest
@@ -28,13 +29,12 @@ Function Invoke-ExecModifyCalPerms {
             })
         return
     }
-    
+
     try {
-        $userid = (New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users/$($username)" -tenantid $Tenantfilter).id
-        Write-LogMessage -headers $Request.Headers -API $APINAME-message "Retrieved user ID: $userid" -Sev 'Debug'
-    }
-    catch {
-        Write-LogMessage -headers $Request.Headers -API $APINAME-message "Failed to get user ID: $($_.Exception.Message)" -Sev 'Error'
+        $UserId = (New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users/$($Username)" -tenantid $TenantFilter).id
+        Write-LogMessage -headers $Headers -API $APIName -message "Retrieved user ID: $UserId" -Sev 'Debug'
+    } catch {
+        Write-LogMessage -headers $Headers -API $APIName -message "Failed to get user ID: $($_.Exception.Message)" -Sev 'Error'
         $body = [pscustomobject]@{'Results' = @("Failed to get user ID: $($_.Exception.Message)") }
         Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
                 StatusCode = [HttpStatusCode]::NotFound
@@ -43,98 +43,73 @@ Function Invoke-ExecModifyCalPerms {
         return
     }
 
-    $Results = [System.Collections.ArrayList]::new()
+    $Results = [System.Collections.Generic.List[string]]::new()
     $HasErrors = $false
 
     # Convert permissions to array format if it's an object with numeric keys
     if ($Permissions -is [PSCustomObject]) {
         if ($Permissions.PSObject.Properties.Name -match '^\d+$') {
             $Permissions = $Permissions.PSObject.Properties.Value
-        }
-        else {
+        } else {
             $Permissions = @($Permissions)
         }
     }
 
-    Write-LogMessage -headers $Request.Headers -API $APINAME-message "Processing $($Permissions.Count) permission entries" -Sev 'Debug'
+    Write-LogMessage -headers $Headers -API $APIName -message "Processing $($Permissions.Count) permission entries" -Sev 'Debug'
 
     foreach ($Permission in $Permissions) {
-        Write-LogMessage -headers $Request.Headers -API $APINAME-message "Processing permission: $($Permission | ConvertTo-Json)" -Sev 'Debug'
-        
+        Write-LogMessage -headers $Headers -API $APIName -message "Processing permission: $($Permission | ConvertTo-Json)" -Sev 'Debug'
+
         $PermissionLevel = $Permission.PermissionLevel.value ?? $Permission.PermissionLevel
         $Modification = $Permission.Modification
         $CanViewPrivateItems = $Permission.CanViewPrivateItems ?? $false
-        
-        Write-LogMessage -headers $Request.Headers -API $APINAME-message "Permission Level: $PermissionLevel, Modification: $Modification, CanViewPrivateItems: $CanViewPrivateItems" -Sev 'Debug'
-        
+        $FolderName = $Permission.FolderName ?? 'Calendar'
+
+        Write-LogMessage -headers $Headers -API $APIName -message "Permission Level: $PermissionLevel, Modification: $Modification, CanViewPrivateItems: $CanViewPrivateItems, FolderName: $FolderName" -Sev 'Debug'
+
         # Handle UserID as array or single value
         $TargetUsers = @($Permission.UserID | ForEach-Object { $_.value ?? $_ })
 
-        Write-LogMessage -headers $Request.Headers -API $APINAME-message "Target Users: $($TargetUsers -join ', ')" -Sev 'Debug'
+        Write-LogMessage -headers $Headers -API $APIName -message "Target Users: $($TargetUsers -join ', ')" -Sev 'Debug'
 
         foreach ($TargetUser in $TargetUsers) {
             try {
-                Write-LogMessage -headers $Request.Headers -API $APINAME-message "Processing target user: $TargetUser" -Sev 'Debug'
-                
-                if ($Modification -eq 'Remove') {
-                    try {
-                        $CalPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Remove-MailboxFolderPermission' -cmdParams @{
-                            Identity = "$($userid):\Calendar"
-                            User     = $TargetUser
-                            Confirm  = $false
-                        }
-                        $null = $results.Add("Removed $($TargetUser) from $($username) Calendar permissions")
-                    }
-                    catch {
-                        $null = $results.Add("No existing permissions to remove for $($TargetUser)")
-                    }
+                Write-LogMessage -headers $Headers -API $APIName -message "Processing target user: $TargetUser" -Sev 'Debug'
+                $Params = @{
+                    APIName              = $APIName
+                    Headers              = $Headers
+                    RemoveAccess         = if ($Modification -eq 'Remove') { $TargetUser } else { $null }
+                    TenantFilter         = $TenantFilter
+                    UserID               = $UserId
+                    folderName           = $FolderName
+                    UserToGetPermissions = $TargetUser
+                    LoggingName          = $TargetUser
+                    Permissions          = $PermissionLevel
+                    CanViewPrivateItems  = $CanViewPrivateItems
                 }
-                else {
-                    Write-LogMessage -headers $Request.Headers -API $APINAME-message "Setting permissions with AccessRights: $PermissionLevel" -Sev 'Debug'
 
-                    $cmdParams = @{
-                        Identity     = "$($userid):\Calendar"
-                        User         = $TargetUser
-                        AccessRights = $PermissionLevel
-                        Confirm      = $false
-                    }
+                # Write-Host "Request params: $($Params | ConvertTo-Json)"
+                $Result = Set-CIPPCalendarPermission @Params
 
-                    if ($CanViewPrivateItems) {
-                        $cmdParams['SharingPermissionFlags'] = 'Delegate,CanViewPrivateItems'
-                    }
-
-                    try {
-                        # Try Add first
-                        $CalPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Add-MailboxFolderPermission' -cmdParams $cmdParams
-                        $null = $results.Add("Granted $($TargetUser) $($PermissionLevel) access to $($username) Calendar$($CanViewPrivateItems ? ' with access to private items' : '')")
-                    }
-                    catch {
-                        # If Add fails, try Set
-                        $CalPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Set-MailboxFolderPermission' -cmdParams $cmdParams
-                        $null = $results.Add("Updated $($TargetUser) $($PermissionLevel) access to $($username) Calendar$($CanViewPrivateItems ? ' with access to private items' : '')")
-                    }
-                }
-                Write-LogMessage -headers $Request.Headers -API $APINAME-message "Successfully executed $($PermissionLevel) permission modification for $($TargetUser) on $($username)" -Sev 'Info' -tenant $TenantFilter
-            }
-            catch {
+                $null = $Results.Add($Result)
+            } catch {
                 $HasErrors = $true
-                Write-LogMessage -headers $Request.Headers -API $APINAME-message "Could not execute $($PermissionLevel) permission modification for $($TargetUser) on $($username). Error: $($_.Exception.Message)" -Sev 'Error' -tenant $TenantFilter
-                $null = $results.Add("Could not execute $($PermissionLevel) permission modification for $($TargetUser) on $($username). Error: $($_.Exception.Message)")
+                $null = $Results.Add("$($_.Exception.Message)")
             }
         }
     }
 
-    if ($results.Count -eq 0) {
-        Write-LogMessage -headers $Request.Headers -API $APINAME-message 'No results were generated from the operation' -Sev 'Warning'
-        $null = $results.Add('No results were generated from the operation. Please check the logs for more details.')
+    if ($Results.Count -eq 0) {
+        Write-LogMessage -headers $Headers -API $APIName -message 'No results were generated from the operation' -Sev 'Warning'
+        $null = $Results.Add('No results were generated from the operation. Please check the logs for more details.')
         $HasErrors = $true
     }
 
-    $body = [pscustomobject]@{'Results' = @($results) }
+    $Body = [pscustomobject]@{'Results' = @($Results) }
 
     # Associate values to output bindings by calling 'Push-OutputBinding'.
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
             StatusCode = if ($HasErrors) { [HttpStatusCode]::InternalServerError } else { [HttpStatusCode]::OK }
             Body       = $Body
         })
-} 
+}


### PR DESCRIPTION
Restore the refactored code for Set-CIPPCalendarPermission that was mistakenly removed, streamline logging, and correct casing issues.