### PR TITLE
Fix: Script Edit not working

### DIFF
--- a/CIPPHttpTrigger/function.json
+++ b/CIPPHttpTrigger/function.json
@@ -7,7 +7,7 @@
       "type": "httpTrigger",
       "direction": "in",
       "name": "Request",
-      "methods": ["get", "post", "patch"],
+      "methods": ["get", "post"],
       "route": "{CIPPEndpoint}"
     },
     {

--- a/CIPPHttpTrigger/function.json
+++ b/CIPPHttpTrigger/function.json
@@ -7,7 +7,7 @@
       "type": "httpTrigger",
       "direction": "in",
       "name": "Request",
-      "methods": ["get", "post"],
+      "methods": ["get", "post", "patch"],
       "route": "{CIPPEndpoint}"
     },
     {

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-EditIntuneScript.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-EditIntuneScript.ps1
@@ -72,6 +72,12 @@ function Invoke-EditIntuneScript {
             }
         }
         'PATCH' {
+            Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::BadRequest
+                Body       = "Method $($Request.Method) is not supported."
+            })
+        }
+        'POST' {
             # Parse the script data to determine type
             $scriptData = $Request.Body.IntuneScript | ConvertFrom-Json
             $scriptType = $Request.Body.ScriptType
@@ -115,9 +121,6 @@ function Invoke-EditIntuneScript {
                         Body       = "Failed to update script: $($ErrorMessage.NormalizedError)"
                     })
             }
-        }
-        'POST' {
-            Write-Output 'Adding script'
         }
     }
 }


### PR DESCRIPTION
Function Invoke-EditIntuneScript uses method PATCH to update intune script. Method PACTH was not allowed by CIPPHttpTrigger.
If it's not preferred to allow method PATCH. EditIntuneScript could be changed to use method POST instead of PATCH, but i'm not the author of Invoke-EditIntuneScript so would not change the logic behind the function.

- Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/4375