### PR TITLE
Fix: Fix SharePoint site creation with UTF8 chars in it

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Teams-Sharepoint/Invoke-AddSite.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Teams-Sharepoint/Invoke-AddSite.ps1
@@ -1,6 +1,6 @@
 using namespace System.Net
 
-Function Invoke-AddSite {
+function Invoke-AddSite {
     <#
     .FUNCTIONALITY
         Entrypoint
@@ -24,7 +24,7 @@ Function Invoke-AddSite {
         $StatusCode = [HttpStatusCode]::OK
     } catch {
         $StatusCode = [HttpStatusCode]::InternalServerError
-        $Result = "Failed to create SharePoint Site: $($_.Exception.Message)"
+        $Result = $_.Exception.Message
     }
 
     # Associate values to output bindings by calling 'Push-OutputBinding'.


### PR DESCRIPTION
- add error handling
- Fix SharePoint site creation with UTF8 chars in it
- Resolves
https://github.com/KelvinTegelaar/CIPP/issues/4423