### PR TITLE
Fix: Manger and sponsor functions, fix casing, and add missing options when creating new users

### DIFF
--- a/Modules/CIPPCore/Public/Add-CIPPAlias.ps1
+++ b/Modules/CIPPCore/Public/Add-CIPPAlias.ps1
@@ -1,9 +1,9 @@
 function Add-CIPPAlias {
     [CmdletBinding()]
     param (
-        $user,
+        $User,
         $Aliases,
-        $UserprincipalName,
+        $UserPrincipalName,
         $TenantFilter,
         $APIName = 'Add Alias',
         $Headers
@@ -11,16 +11,17 @@ function Add-CIPPAlias {
 
     try {
         foreach ($Alias in $Aliases) {
-            Write-Host "Adding alias $Alias to $user"
-            New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$user" -tenantid $TenantFilter -type 'patch' -body "{`"mail`": `"$Alias`"}" -verbose
+            Write-Host "Adding alias $Alias to $User"
+            New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$User" -tenantid $TenantFilter -type 'patch' -body "{`"mail`": `"$Alias`"}" -verbose
         }
         Write-Host "Resetting primary alias to $User"
-        New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($user)" -tenantid $TenantFilter -type 'patch' -body "{`"mail`": `"$User`"}" -verbose
-        Write-LogMessage -headers $Headers -API $APINAME -tenant $($TenantFilter) -message "Added alias $($Alias) to $($UserprincipalName)" -Sev 'Info'
+        New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$User" -tenantid $TenantFilter -type 'patch' -body "{`"mail`": `"$User`"}" -verbose
+        Write-LogMessage -headers $Headers -API $APIName -tenant $($TenantFilter) -message "Added alias $($Alias) to $($UserPrincipalName)" -Sev 'Info'
         return ("Added Aliases: $($Aliases -join ',')")
     } catch {
-        Write-LogMessage -headers $Headers -API $APINAME -tenant $($TenantFilter) -message "Failed to set alias. Error:$($_.Exception.Message)" -Sev 'Error'
-        throw "Failed to set alias: $($_.Exception.Message)"
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -headers $Headers -API $APIName -tenant $($TenantFilter) -message "Failed to set alias. Error:$($ErrorMessage.NormalizedError)" -Sev 'Error' -LogData $ErrorMessage
+        throw "Failed to set alias: $($ErrorMessage.NormalizedError)"
     }
 }
 

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
@@ -224,19 +224,13 @@ function Invoke-EditUser {
     }
 
     if ($Request.body.setManager.value) {
-        $ManagerBody = [PSCustomObject]@{'@odata.id' = "https://graph.microsoft.com/beta/users/$($Request.body.setManager.value)" }
-        $ManagerBodyJSON = ConvertTo-Json -Compress -Depth 10 -InputObject $ManagerBody
-        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($UserObj.id)/manager/`$ref" -tenantid $UserObj.tenantFilter -type PUT -body $ManagerBodyJSON -Verbose
-        Write-LogMessage -headers $Headers -API $APIName -tenant $UserObj.tenantFilter -message "Set $($UserObj.DisplayName)'s manager to $($Request.body.setManager.label)" -Sev Info
-        $Results.Add("Success. Set $($UserObj.DisplayName)'s manager to $($Request.body.setManager.label)")
+        $ManagerResult = Set-CIPPManager -User $UserPrincipalName -Manager $Request.body.setManager.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
+        $Results.Add($ManagerResult)
     }
 
     if ($Request.body.setSponsor.value) {
-        $SponsorBody = [PSCustomObject]@{'@odata.id' = "https://graph.microsoft.com/beta/users/$($Request.body.setSponsor.value)" }
-        $SponsorBodyJSON = ConvertTo-Json -Compress -Depth 10 -InputObject $SponsorBody
-        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($UserObj.id)/sponsors/`$ref" -tenantid $UserObj.tenantFilter -type POST -body $SponsorBodyJSON -Verbose
-        Write-LogMessage -headers $Headers -API $APIName -tenant $UserObj.tenantFilter -message "Set $($UserObj.DisplayName)'s sponsor to $($Request.body.setSponsor.label)" -Sev Info
-        $Results.Add("Success. Set $($UserObj.DisplayName)'s sponsor to $($Request.body.setSponsor.label)")
+        $SponsorResult = Set-CIPPSponsor -User $UserPrincipalName -Sponsor $Request.body.setSponsor.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
+        $Results.Add($SponsorResult)
     }
 
     # Associate values to output bindings by calling 'Push-OutputBinding'.

--- a/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
@@ -54,7 +54,7 @@ function New-CIPPUserTask {
 
     try {
         if ($UserObj.AddedAliases) {
-            $AliasResults = Add-CIPPAlias -user $CreationResults.Username -Aliases ($UserObj.AddedAliases -split '\s') -UserprincipalName $CreationResults.Username -TenantFilter $UserObj.tenantFilter -APIName $APIName -Headers $Headers
+            $AliasResults = Add-CIPPAlias -User $CreationResults.Username -Aliases ($UserObj.AddedAliases -split '\s') -UserPrincipalName $CreationResults.Username -TenantFilter $UserObj.tenantFilter -APIName $APIName -Headers $Headers
             $Results.Add($AliasResults)
         }
     } catch {
@@ -69,12 +69,12 @@ function New-CIPPUserTask {
     }
 
     if ($UserObj.setManager) {
-        $ManagerResult = Set-CIPPManager -user $CreationResults.Username -Manager $UserObj.setManager.value -TenantFilter $UserObj.tenantFilter -APIName 'Set Manager' -Headers $Headers
+        $ManagerResult = Set-CIPPManager -User $CreationResults.Username -Manager $UserObj.setManager.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
         $Results.Add($ManagerResult)
     }
 
     if ($UserObj.setSponsor) {
-        $SponsorResult = Set-CIPPManager -user $CreationResults.Username -Manager $UserObj.setSponsor.value -TenantFilter $UserObj.tenantFilter -APIName 'Set Sponsor' -Headers $Headers
+        $SponsorResult = Set-CIPPSponsor -User $CreationResults.Username -Sponsor $UserObj.setSponsor.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
         $Results.Add($SponsorResult)
     }
 

--- a/Modules/CIPPCore/Public/New-CippUser.ps1
+++ b/Modules/CIPPCore/Public/New-CippUser.ps1
@@ -26,12 +26,14 @@ function New-CIPPUser {
             'userPrincipalName' = $UserPrincipalName
             'usageLocation'     = $UserObj.usageLocation.value ? $UserObj.usageLocation.value : $UserObj.usageLocation
             'city'              = $UserObj.City
+            'state'             = $UserObj.state
             'country'           = $UserObj.Country
             'jobtitle'          = $UserObj.Jobtitle
             'mobilePhone'       = $UserObj.MobilePhone
             'streetAddress'     = $UserObj.streetAddress
             'postalCode'        = $UserObj.PostalCode
             'companyName'       = $UserObj.CompanyName
+            'otherMails'        = $UserObj.otherMails ? @($UserObj.otherMails) : @()
             'passwordProfile'   = @{
                 'forceChangePasswordNextSignIn' = [bool]$UserObj.MustChangePass
                 'password'                      = $password

--- a/Modules/CIPPCore/Public/Set-CIPPManager.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPManager.ps1
@@ -1,7 +1,7 @@
 function Set-CIPPManager {
     [CmdletBinding()]
     param (
-        $user,
+        $User,
         $Manager,
         $TenantFilter,
         $APIName = 'Set Manager',
@@ -11,12 +11,13 @@ function Set-CIPPManager {
     try {
         $ManagerBody = [PSCustomObject]@{'@odata.id' = "https://graph.microsoft.com/beta/users/$($Manager)" }
         $ManagerBodyJSON = ConvertTo-Json -Compress -Depth 10 -InputObject $ManagerBody
-        New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($User)/manager/`$ref" -tenantid $TenantFilter -type PUT -body $ManagerBodyJSON -Verbose
-        Write-LogMessage -headers $Headers -API $APINAME -tenant $UserObj.tenantID -message "Set $user's manager to $Manager" -Sev 'Info'
+        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($User)/manager/`$ref" -tenantid $TenantFilter -type PUT -body $ManagerBodyJSON
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Set $User's manager to $Manager" -Sev 'Info'
     } catch {
-        Write-LogMessage -headers $Headers -API $APINAME -tenant $($UserObj.tenantID) -message "Failed to Set Manager. Error:$($_.Exception.Message)" -Sev 'Error'
-        throw "Failed to set manager: $($_.Exception.Message)"
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to Set Manager. Error:$($ErrorMessage.NormalizedError)" -Sev 'Error' -LogData $_
+        throw "Failed to set manager: $($ErrorMessage.NormalizedError)"
     }
-    return "Set $user's manager to $Manager"
+    return "Set $User's manager to $Manager"
 }
 

--- a/Modules/CIPPCore/Public/Set-CIPPSponsor.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPSponsor.ps1
@@ -1,0 +1,22 @@
+function Set-CIPPSponsor {
+    [CmdletBinding()]
+    param (
+        $User,
+        $Sponsor,
+        $TenantFilter,
+        $APIName = 'Set Sponsor',
+        $Headers
+    )
+
+    try {
+        $SponsorBody = [PSCustomObject]@{'@odata.id' = "https://graph.microsoft.com/beta/users/$($Sponsor)" }
+        $SponsorBodyJSON = ConvertTo-Json -Compress -Depth 10 -InputObject $SponsorBody
+        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($User)/sponsors/`$ref" -tenantid $TenantFilter -type PUT -body $SponsorBodyJSON
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Set $User's sponsor to $Sponsor" -Sev 'Info'
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to Set Sponsor. Error:$($ErrorMessage.NormalizedError)" -Sev 'Error' -LogData $_
+        throw "Failed to set sponsor: $($_.Exception.Message)"
+    }
+    return "Set $user's sponsor to $Sponsor"
+}


### PR DESCRIPTION
This is missing the handling for state in EditUser, but I couldnt figure out a good way of handling it. @JohnDuprey

Invoke-EditUser.ps1: Refactored to use new Set-CIPPManager and Set-CIPPSponsor functions for setting manager and sponsor, improving maintainability.
New-CIPPUserTask.ps1: Fixed casing for parameters, switched to new sponsor logic, and improved function calls.
New-CippUser.ps1: Added missing state and otherMails properties to user creation.
Set-CIPPManager.ps1: Improved error handling and parameter naming.
Set-CIPPSponsor.ps1: New function for setting a user's sponsor.
Add-CIPPAlias.ps1: Fixed variable casing and improved error handling in alias management.