### PR TITLE
Fix: AuthMethodsPolicyMigration for newer tenants

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAuthMethodsPolicyMigration.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAuthMethodsPolicyMigration.ps1
@@ -30,8 +30,12 @@ function Invoke-CIPPStandardAuthMethodsPolicyMigration {
     param($Tenant, $Settings)
     $CurrentInfo = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy' -tenantid $Tenant
 
+    if ($null -eq $CurrentInfo) {
+        throw
+    }
+
     if ($Settings.remediate -eq $true) {
-        if ($CurrentInfo.policyMigrationState -eq 'migrationComplete') {
+        if ($CurrentInfo.policyMigrationState -eq 'migrationComplete' -or $null -eq $CurrentInfo.policyMigrationState) {
             Write-LogMessage -API 'Standards' -tenant $tenant -message 'Authentication methods policy migration is already complete.' -sev Info
         } else {
             try {
@@ -44,14 +48,14 @@ function Invoke-CIPPStandardAuthMethodsPolicyMigration {
     }
 
     if ($Settings.alert -eq $true) {
-        if ($CurrentInfo.policyMigrationState -ne 'migrationComplete') {
+        if ($CurrentInfo.policyMigrationState -ne 'migrationComplete' -and $null -ne $CurrentInfo.policyMigrationState) {
             Write-StandardsAlert -message 'Authentication methods policy migration is not complete. Please check if you have legacy SSPR settings or MFA settings set: https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-authentication-methods-manage' -object $CurrentInfo -tenant $tenant -standardName 'AuthMethodsPolicyMigration' -standardId $Settings.standardId
             Write-LogMessage -API 'Standards' -tenant $tenant -message 'Authentication methods policy migration is not complete' -sev Alert
         }
     }
 
     if ($Settings.report -eq $true) {
-        $migrationComplete = $CurrentInfo.policyMigrationState -eq 'migrationComplete'
+        $migrationComplete = $CurrentInfo.policyMigrationState -eq 'migrationComplete' -or $null -eq $CurrentInfo.policyMigrationState
         Set-CIPPStandardsCompareField -FieldName 'standards.AuthMethodsPolicyMigration' -FieldValue $migrationComplete -TenantFilter $tenant
         Add-CIPPBPAField -FieldName 'AuthMethodsPolicyMigration' -FieldValue $migrationComplete -StoreAs bool -Tenant $tenant
     }

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAuthMethodsPolicyMigration.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAuthMethodsPolicyMigration.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardAuthMethodsPolicyMigration {
     $CurrentInfo = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy' -tenantid $Tenant
 
     if ($null -eq $CurrentInfo) {
-        throw
+        throw "Failed to retrieve current authentication methods policy information"
     }
 
     if ($Settings.remediate -eq $true) {


### PR DESCRIPTION
Tenants which are newly created have the policy migration 'completed' by default. On these tenants, the property policyMigrationState from graph endpoint /beta/policies/authenticationMethodsPolicy is always NULL. Even if you set policyMigrationState to migrationComplete with a PATCH request, the value will remain NULL. In the Entra portal for these tenants, the migration option is also not shown since they are already using the new authentication methods policy.

I have a few tenants where this is the case, causing the alerts and report to show incorrectly.

This PR updates the logic to treat null values as "migration complete" to align with Microsoft's behavior for newly created tenants.