### PR TITLE
Fix: EXO object matches multiple entries

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableBasicAuthSMTP.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableBasicAuthSMTP.ps1
@@ -59,7 +59,7 @@ function Invoke-CIPPStandardDisableBasicAuthSMTP {
             # Disable SMTP Basic Authentication for all users
             $SMTPusers | ForEach-Object {
                 try {
-                    New-ExoRequest -tenantid $Tenant -cmdlet 'Set-CASMailbox' -cmdParams @{ Identity = $_.Identity; SmtpClientAuthenticationDisabled = $null } -UseSystemMailbox $true
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'Set-CASMailbox' -cmdParams @{ Identity = $_.Guid; SmtpClientAuthenticationDisabled = $null } -UseSystemMailbox $true
                     Write-LogMessage -API 'Standards' -tenant $tenant -message "Disabled SMTP Basic Authentication for $($_.DisplayName), $($_.PrimarySmtpAddress)" -sev Info
                 } catch {
                     $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableExchangeOnlinePowerShell.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableExchangeOnlinePowerShell.ps1
@@ -44,7 +44,7 @@ function Invoke-CIPPStandardDisableExchangeOnlinePowerShell {
     try {
 
         $AdminUsers = (New-GraphGetRequest -uri 'https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments?$expand=principal' -tenantid $Tenant).principal.userPrincipalName
-        $UsersWithPowerShell = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-User' -Select 'userPrincipalName, identity, remotePowerShellEnabled' | Where-Object { $_.RemotePowerShellEnabled -eq $true -and $_.userPrincipalName -notin $AdminUsers }
+        $UsersWithPowerShell = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-User' -Select 'userPrincipalName, identity, guid, remotePowerShellEnabled' | Where-Object { $_.RemotePowerShellEnabled -eq $true -and $_.userPrincipalName -notin $AdminUsers }
         $PowerShellEnabledCount = ($UsersWithPowerShell | Measure-Object).Count
         $StateIsCorrect = $PowerShellEnabledCount -eq 0
     } catch {
@@ -61,7 +61,7 @@ function Invoke-CIPPStandardDisableExchangeOnlinePowerShell {
                 @{
                     CmdletInput = @{
                         CmdletName = 'Set-User'
-                        Parameters = @{Identity = $_.Identity; RemotePowerShellEnabled = $false }
+                        Parameters = @{Identity = $_.Guid; RemotePowerShellEnabled = $false }
                     }
                 }
             }


### PR DESCRIPTION
Fix issue in rare cases where Exchange identity matches multiple entries for DisableBasicAuthSMTP and DisableExoPowershell standards.

This causes the command to fail with EXO returning the following error:
`Error: Ex9E65A2|Microsoft.Exchange.Configuration.Tasks.ManagementObjectAmbiguousException|The operation couldn't be performed because object: '****' matches multiple entries.`

Changed the request parameter identity to use the Guid property, which is always unique and accepted as a valid identity by Exchange Online.
