### PR TITLE
Add the ID of the consent request to output to enable deduplication

### DIFF
--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertNewAppApproval.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertNewAppApproval.ps1
@@ -29,6 +29,7 @@ function Get-CIPPAlertNewAppApproval {
                     }
 
                     $Message = [PSCustomObject]@{
+                        RequestId   = $_.id
                         AppName     = $App.appDisplayName
                         RequestUser = $_.createdBy.user.userPrincipalName
                         Reason      = $_.reason


### PR DESCRIPTION
Helps to resolve https://github.com/KelvinTegelaar/CIPP/issues/4472
Adds Request ID of the consent request to the alert output, in order to allow deduplication of repeated alerts that have not yet been resolved if processed consent IDs already exist in at whatever the client is (deduplication would be done client-side, this just provides the unique identifier to enable it).

Does not duplicate the changes already made in https://github.com/KelvinTegelaar/CIPP-API/pull/1569, just adds an additional field.