### PR TITLE
Add DesiredStartTime support for scheduled tasks

### DIFF
--- a/Modules/CIPPCore/Public/Add-CIPPScheduledTask.ps1
+++ b/Modules/CIPPCore/Public/Add-CIPPScheduledTask.ps1
@@ -20,6 +20,9 @@ function Add-CIPPScheduledTask {
         [string]$RowKey,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [string]$DesiredStartTime = $null,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'RunNow')]
         $Headers
     )
@@ -119,8 +122,25 @@ function Add-CIPPScheduledTask {
                 $task.Recurrence.value
             }
 
-            if ([int64]$task.ScheduledTime -eq 0 -or [string]::IsNullOrEmpty($task.ScheduledTime)) {
-                $task.ScheduledTime = [int64](([datetime]::UtcNow) - (Get-Date '1/1/1970')).TotalSeconds
+            if ($DesiredStartTime) {
+                try {
+                    # Parse the epoch time
+                    $epochSeconds = [int64]$DesiredStartTime
+                    # Set ScheduledTime to the desired time
+                    $task.ScheduledTime = $epochSeconds
+                }
+                catch {
+                    Write-Warning "Failed to parse DesiredStartTime: $DesiredStartTime. Using provided ScheduledTime."
+                    # Fall back to default
+                    if ([int64]$task.ScheduledTime -eq 0 -or [string]::IsNullOrEmpty($task.ScheduledTime)) {
+                        $task.ScheduledTime = [int64](([datetime]::UtcNow) - (Get-Date '1/1/1970')).TotalSeconds
+                    }
+                }
+            } else {
+                # No DesiredStartTime - use current behavior (immediate execution)
+                if ([int64]$task.ScheduledTime -eq 0 -or [string]::IsNullOrEmpty($task.ScheduledTime)) {
+                    $task.ScheduledTime = [int64](([datetime]::UtcNow) - (Get-Date '1/1/1970')).TotalSeconds
+                }
             }
             $excludedTenants = if ($task.excludedTenants.value) {
                 $task.excludedTenants.value -join ','
@@ -165,6 +185,10 @@ function Add-CIPPScheduledTask {
                 AdditionalProperties = [string]$AdditionalProperties
                 Hidden               = [bool]$Hidden
                 Results              = 'Planned'
+            }
+            # Always store DesiredStartTime if provided
+            if ($DesiredStartTime) {
+                $entity['DesiredStartTime'] = [string]$DesiredStartTime
             }
 
             # Store the original tenant filter for group expansion during execution

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Scheduler/Invoke-AddScheduledItem.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Scheduler/Invoke-AddScheduledItem.ps1
@@ -31,7 +31,7 @@ function Invoke-AddScheduledItem {
             $Result = "Error scheduling task: $($_.Exception.Message)"
         }
     } else {
-        $Result = Add-CIPPScheduledTask -Task $Request.Body -Headers $Request.Headers -hidden $hidden -DisallowDuplicateName $Request.Query.DisallowDuplicateName
+        $Result = Add-CIPPScheduledTask -Task $Request.Body -Headers $Request.Headers -hidden $hidden -DisallowDuplicateName $Request.Query.DisallowDuplicateName -DesiredStartTime $Request.Body.DesiredStartTime
         Write-LogMessage -headers $Request.Headers -API $APINAME -message $Result -Sev 'Info'
     }
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{


### PR DESCRIPTION
Introduces an optional DesiredStartTime parameter to allow specifying a custom start time for scheduled tasks. Updates both Add-CIPPScheduledTask and Invoke-AddScheduledItem to handle and persist this value if provided, improving scheduling flexibility.
UI PR: https://github.com/KelvinTegelaar/CIPP/pull/4499