### PR TITLE
Prevent dropping last record when no real nextLink is present

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ListGraphRequest.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ListGraphRequest.ps1
@@ -120,13 +120,15 @@ function Invoke-ListGraphRequest {
 
     try {
         $Results = Get-GraphRequestList @GraphRequestParams
-        if ($Results.nextLink) {
-            Write-Host "NextLink: $($Results.nextLink | Select-Object -Last 1)"
+        if ($Results | Where-Object { $_.nextLink }) {
+            Write-Host "NextLink: $($Results.nextLink | Where-Object { $_ } | Select-Object -Last 1)"
             if ($Request.Query.TenantFilter -ne 'AllTenants') {
-                $Metadata['nextLink'] = $Results.nextLink | Select-Object -Last 1
+                $Metadata['nextLink'] = $Results.nextLink | Where-Object { $_ } | Select-Object -Last 1
             }
-            #Results is an array of objects, so we need to remove the last object before returning
-            $Results = $Results | Select-Object -First ($Results.Count - 1)
+            # Remove nextLink trailing object only if it’s the last item
+            if ($Results[-1].PSObject.Properties.Name -contains 'nextLink') {
+                $Results = $Results | Select-Object -First ($Results.Count - 1)
+            }
         }
         if ($Request.Query.ListProperties) {
             $Columns = ($Results | Select-Object -First 1).PSObject.Properties.Name


### PR DESCRIPTION
Resolves [#4517](https://github.com/KelvinTegelaar/CIPP/issues/4517)

In PowerShell, `$Results.nextLink` on an array returns an array of the `nextLink` values from each object. Even if every value is `$null`, the result is still a non-empty array, which evaluates as truthy in an `if` statement. This caused the final record in small datasets to be dropped even when no `nextLink` existed.

This change ensures the drop logic only runs when at least one object in `$Results` has a non-null, non-empty `nextLink` property. 
