### PR TITLE
Feat: Add tenant offboarding defaults API and listing support

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-EditTenantOffboardingDefaults.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-EditTenantOffboardingDefaults.ps1
@@ -1,0 +1,81 @@
+using namespace System.Net
+
+function Invoke-EditTenantOffboardingDefaults {
+    <#
+    .FUNCTIONALITY
+        Entrypoint,AnyTenant
+    .ROLE
+        Tenant.Config.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+
+    # Interact with query parameters or the body of the request.
+    $customerId = $Request.Body.customerId
+    $offboardingDefaults = $Request.Body.offboardingDefaults
+
+    if (!$customerId) {
+        $response = @{
+            state      = 'error'
+            resultText = 'Customer ID is required'
+        }
+        Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::BadRequest
+                Body       = $response
+            })
+        return
+    }
+
+    $PropertiesTable = Get-CippTable -TableName 'TenantProperties'
+
+    try {
+        # Convert the offboarding defaults to JSON string and ensure it's treated as a string
+        $jsonValue = [string]($offboardingDefaults | ConvertTo-Json -Compress)
+
+        if ($jsonValue -and $jsonValue -ne '{}' -and $jsonValue -ne 'null' -and $jsonValue -ne '') {
+            # Save offboarding defaults
+            $offboardingEntity = @{
+                PartitionKey = [string]$customerId
+                RowKey       = [string]'OffboardingDefaults'
+                Value        = [string]$jsonValue
+            }
+            $null = Add-CIPPAzDataTableEntity @PropertiesTable -Entity $offboardingEntity -Force
+            Write-LogMessage -headers $Headers -tenant $customerId -API $APIName -message "Updated tenant offboarding defaults" -Sev 'Info'
+
+            $resultText = 'Tenant offboarding defaults updated successfully'
+        } else {
+            # Remove offboarding defaults if empty or null
+            $Existing = Get-CIPPAzDataTableEntity @PropertiesTable -Filter "PartitionKey eq '$customerId' and RowKey eq 'OffboardingDefaults'"
+            if ($Existing) {
+                Remove-AzDataTableEntity @PropertiesTable -Entity $Existing
+                Write-LogMessage -headers $Headers -tenant $customerId -API $APIName -message "Removed tenant offboarding defaults" -Sev 'Info'
+            }
+
+            $resultText = 'Tenant offboarding defaults cleared successfully'
+        }
+
+        $response = @{
+            state      = 'success'
+            resultText = $resultText
+        }
+
+        Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::OK
+                Body       = $response
+            })
+    } catch {
+        Write-LogMessage -headers $Headers -tenant $customerId -API $APINAME -message "Edit Tenant Offboarding Defaults failed. The error is: $($_.Exception.Message)" -Sev 'Error'
+        $response = @{
+            state      = 'error'
+            resultText = $_.Exception.Message
+        }
+        Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::InternalServerError
+                Body       = $response
+            })
+    }
+}


### PR DESCRIPTION
Introduces Invoke-EditTenantOffboardingDefaults.ps1 to allow editing or clearing tenant offboarding defaults. Updates Invoke-ListTenants.ps1 to optionally include offboarding defaults in tenant listings when requested.

UI PR: github.com/KelvinTegelaar/CIPP/pull/4525