### PR TITLE
Add Power Platform and Power BI portal links

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListUserSettings.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListUserSettings.ps1
@@ -36,6 +36,15 @@ function Invoke-ListUserSettings {
                 }
             }
         }
+
+        try {
+            $UserSpecificSettings = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'UserSettings' and RowKey eq '$Username'"
+            $UserSpecificSettings = $UserSpecificSettings.JSON | ConvertFrom-Json -Depth 10 -ErrorAction SilentlyContinue
+        }
+        catch {
+            Write-Warning "Failed to convert UserSpecificSettings JSON: $($_.Exception.Message)"
+        }
+
         #Get branding settings
         if ($UserSettings) {
             $brandingTable = Get-CippTable -tablename 'Config'
@@ -44,6 +53,11 @@ function Invoke-ListUserSettings {
                 $UserSettings | Add-Member -MemberType NoteProperty -Name 'customBranding' -Value $BrandingSettings -Force | Out-Null
             }
         }
+
+        if ($UserSpecificSettings) {
+            $UserSettings | Add-Member -MemberType NoteProperty -Name 'UserSpecificSettings' -Value $UserSpecificSettings -Force | Out-Null
+        }
+
         $StatusCode = [HttpStatusCode]::OK
         $Results = $UserSettings
     } catch {

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-ListTenants.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-ListTenants.ps1
@@ -105,7 +105,9 @@ function Invoke-ListTenants {
                 @{Name = 'portal_intune'; Expression = { "https://intune.microsoft.com/$($_.defaultDomainName)" } },
                 @{Name = 'portal_security'; Expression = { "https://security.microsoft.com/?tid=$($_.customerId)" } },
                 @{Name = 'portal_compliance'; Expression = { "https://purview.microsoft.com/?tid=$($_.customerId)" } },
-                @{Name = 'portal_sharepoint'; Expression = { "/api/ListSharePointAdminUrl?tenantFilter=$($_.defaultDomainName)" } }
+                @{Name = 'portal_sharepoint'; Expression = { "/api/ListSharePointAdminUrl?tenantFilter=$($_.defaultDomainName)" } },
+                @{Name = 'portal_platform'; Expression = { "https://admin.powerplatform.microsoft.com/account/login/$($_.customerId)" } },
+                @{Name = 'portal_bi'; Expression = { "https://app.powerbi.com/admin-portal?ctid=$($_.customerId)" } }
             }
 
         } else {

--- a/Modules/CippExtensions/Public/NinjaOne/Invoke-NinjaOneTenantSync.ps1
+++ b/Modules/CippExtensions/Public/NinjaOne/Invoke-NinjaOneTenantSync.ps1
@@ -1565,6 +1565,16 @@ function Invoke-NinjaOneTenantSync {
                     Name = 'Azure Portal'
                     Link = "https://portal.azure.com/$($customer.defaultDomainName)"
                     Icon = 'fas fa-server'
+                },
+                @{
+                    Name = 'Power Platform Portal'
+                    Link = "https://admin.powerplatform.microsoft.com/account/login/$($Customer.customerId)"
+                    Icon = 'fa-solid fa-robot'
+                },
+                @{
+                    Name = 'Power BI Portal'
+                    Link = "https://app.powerbi.com/admin-portal?ctid=$($Customer.customerId)"
+                    Icon = 'fas fa-bar-chart'
                 }
 
             )


### PR DESCRIPTION
Added Power Platform and Power BI portal URLs to tenant and user settings endpoints, and included them in NinjaOne tenant sync output. Also improved user-specific settings retrieval and error handling in Invoke-ListUserSettings.ps1.

UI PR: https://github.com/KelvinTegelaar/CIPP/pull/4539
Resolves: https://github.com/KelvinTegelaar/CIPP/issues/4518