### PR TITLE
Fix deleting app config and protection policies

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-RemovePolicy.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-RemovePolicy.ps1
@@ -18,13 +18,13 @@ function Invoke-RemovePolicy {
     $TenantFilter = $Request.Query.tenantFilter ?? $Request.body.tenantFilter
     $PolicyId = $Request.Query.ID ?? $Request.body.ID
     $UrlName = $Request.Query.URLName ?? $Request.body.URLName
-
+    $BaseEndpoint = $UrlName -eq 'managedAppPolicies' ? 'deviceAppManagement' : 'deviceManagement'
     if (!$PolicyId) { exit }
-    try {
 
-        # $unAssignRequest = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies('$($PolicyId)')/assign" -type POST -Body '{"assignments":[]}' -tenant $TenantFilter
-        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/deviceManagement/$($UrlName)('$($PolicyId)')" -type DELETE -tenant $TenantFilter
-        $Results = "Successfully deleted the policy with ID: $($PolicyId)"
+    try {
+        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/$($BaseEndpoint)/$($UrlName)('$($PolicyId)')" -type DELETE -tenant $TenantFilter
+
+        $Results = "Successfully deleted the $UrlName policy with ID: $($PolicyId)"
         Write-LogMessage -headers $Headers -API $APINAME -message $Results -Sev Info -tenant $TenantFilter
         $StatusCode = [HttpStatusCode]::OK
 


### PR DESCRIPTION
The changes ensure that the deletion of app protection and configuration policies functions correctly by adjusting the endpoint used for the delete request. This resolves the issue where policies could not be deleted due to a "Resource not found" error.

Fixes KelvinTegelaar/CIPP#4498