### PR TITLE
Fix: Add ExternalAudience parameter to Set-CIPPOutOfOffice function

### DIFF
--- a/Modules/CIPPCore/Public/Set-CIPPOutOfoffice.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPOutOfoffice.ps1
@@ -18,8 +18,9 @@ function Set-CIPPOutOfOffice {
     try {
 
         $CmdParams = @{
-            Identity       = $UserID
-            AutoReplyState = $State
+            Identity         = $UserID
+            AutoReplyState   = $State
+            ExternalAudience = 'None'
         }
 
         if ($PSBoundParameters.ContainsKey('InternalMessage')) {
@@ -28,6 +29,7 @@ function Set-CIPPOutOfOffice {
 
         if ($PSBoundParameters.ContainsKey('ExternalMessage')) {
             $CmdParams.ExternalMessage = $ExternalMessage
+            $CmdParams.ExternalAudience = 'All'
         }
 
         if ($State -eq 'Scheduled') {


### PR DESCRIPTION
Introduce the ExternalAudience parameter to the Set-CIPPOutOfOffice function, ensuring correct function when setting external message
- Resolves https://github.com/KelvinTegelaar/CIPP/issues/4582