### PR TITLE
Invoke-CIPPStandardBranding: Create default branding localization if doesn't exist

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardBranding.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardBranding.ps1
@@ -38,29 +38,62 @@ function Invoke-CIPPStandardBranding {
 
     $TenantId = Get-Tenants | Where-Object -Property defaultDomainName -EQ $Tenant
 
-    try {
-        $CurrentState = New-GraphGetRequest -Uri "https://graph.microsoft.com/beta/organization/$($TenantId.customerId)/branding/localizations/0" -tenantID $Tenant -AsApp $true
-    }
-    catch {
-        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the Branding state for $Tenant. Error: $ErrorMessage" -Sev Error
-        return
-    }
-
+    $Localizations = New-GraphGetRequest -Uri "https://graph.microsoft.com/beta/organization/$($TenantId.customerId)/branding/localizations" -tenantID $Tenant -AsApp $true
     # Get layoutTemplateType value using null-coalescing operator
     $layoutTemplateType = $Settings.layoutTemplateType.value ?? $Settings.layoutTemplateType
+    # If default localization (id "0") exists, use that to get the currentState. Otherwise we have to create it first.
+    if ($Localizations | Where-Object { $_.id -eq '0' }) {
+        try {
+            $CurrentState = New-GraphGetRequest -Uri "https://graph.microsoft.com/beta/organization/$($TenantId.customerId)/branding/localizations/0" -tenantID $Tenant -AsApp $true
+        }
+        catch {
+            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the Branding state for $Tenant. Error: $ErrorMessage" -Sev Error
+            return
+        }
+    }
+    else {
+        try {
+            $GraphRequest = @{
+                tenantID    = $Tenant
+                uri         = "https://graph.microsoft.com/beta/organization/$($TenantId.customerId)/branding/localizations"
+                AsApp       = $true
+                Type        = 'POST'
+                ContentType = 'application/json; charset=utf-8'
+                Body        = [pscustomobject]@{
+                    signInPageText                  = $Settings.signInPageText
+                    usernameHintText                = $Settings.usernameHintText
+                    loginPageTextVisibilitySettings = [pscustomobject]@{
+                        hideAccountResetCredentials = $Settings.hideAccountResetCredentials
+                    }
+                    loginPageLayoutConfiguration    = [pscustomobject]@{
+                        layoutTemplateType = $layoutTemplateType
+                        isHeaderShown      = $Settings.isHeaderShown
+                        isFooterShown      = $Settings.isFooterShown
+                    }
+                } | ConvertTo-Json -Compress
+            }
+            $CurrentState = New-GraphPostRequest @GraphRequest
+        }
+        catch {
+            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not create the default Branding localization for $Tenant. Error: $ErrorMessage" -Sev Error
+            return
+        }
+    }
 
     $StateIsCorrect = ($CurrentState.signInPageText -eq $Settings.signInPageText) -and
-                        ($CurrentState.usernameHintText -eq $Settings.usernameHintText) -and
-                        ($CurrentState.loginPageTextVisibilitySettings.hideAccountResetCredentials -eq $Settings.hideAccountResetCredentials) -and
-                        ($CurrentState.loginPageLayoutConfiguration.layoutTemplateType -eq $layoutTemplateType) -and
-                        ($CurrentState.loginPageLayoutConfiguration.isHeaderShown -eq $Settings.isHeaderShown) -and
-                        ($CurrentState.loginPageLayoutConfiguration.isFooterShown -eq $Settings.isFooterShown)
+    ($CurrentState.usernameHintText -eq $Settings.usernameHintText) -and
+    ($CurrentState.loginPageTextVisibilitySettings.hideAccountResetCredentials -eq $Settings.hideAccountResetCredentials) -and
+    ($CurrentState.loginPageLayoutConfiguration.layoutTemplateType -eq $layoutTemplateType) -and
+    ($CurrentState.loginPageLayoutConfiguration.isHeaderShown -eq $Settings.isHeaderShown) -and
+    ($CurrentState.loginPageLayoutConfiguration.isFooterShown -eq $Settings.isFooterShown)
 
     If ($Settings.remediate -eq $true) {
         if ($StateIsCorrect -eq $true) {
             Write-LogMessage -API 'Standards' -Tenant $Tenant -Message 'Branding is already applied correctly.' -Sev Info
-        } else {
+        }
+        else {
             try {
                 $GraphRequest = @{
                     tenantID    = $Tenant
@@ -83,7 +116,8 @@ function Invoke-CIPPStandardBranding {
                 }
                 $null = New-GraphPostRequest @GraphRequest
                 Write-LogMessage -API 'Standards' -Tenant $Tenant -Message 'Successfully updated branding.' -Sev Info
-            } catch {
+            }
+            catch {
                 $ErrorMessage = Get-CippException -Exception $_
                 Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Failed to update branding. Error: $($ErrorMessage.NormalizedError)" -Sev Error -LogData $ErrorMessage
             }
@@ -95,7 +129,8 @@ function Invoke-CIPPStandardBranding {
 
         if ($StateIsCorrect -eq $true) {
             Write-LogMessage -API 'Standards' -Tenant $Tenant -Message 'Branding is correctly set.' -Sev Info
-        } else {
+        }
+        else {
             Write-StandardsAlert -message 'Branding is incorrectly set.' -object ($CurrentState | Select-Object -Property signInPageText, usernameHintText, loginPageTextVisibilitySettings, loginPageLayoutConfiguration) -tenant $Tenant -standardName 'Branding' -standardId $Settings.standardId
             Write-LogMessage -API 'Standards' -Tenant $Tenant -Message 'Branding is incorrectly set.' -Sev Info
         }


### PR DESCRIPTION
This is done to prevent errors when getting/setting state, allowing brand new tenants that have never had branding set to have the standard applied.