### PR TITLE
Add proper null checks to handle "0" values not being evaluated as false.

### DIFF
--- a/Modules/CIPPCore/Public/Compare-CIPPIntuneObject.ps1
+++ b/Modules/CIPPCore/Public/Compare-CIPPIntuneObject.ps1
@@ -244,6 +244,9 @@ function Compare-CIPPIntuneObject {
                                             $child.choiceSettingValue.value
                                         }
                                     }
+                                    if (!$childValue -and $null -ne $child.simpleSettingValue -and $null -ne $child.simpleSettingValue.value) {
+                                        $childValue = $child.simpleSettingValue.value
+                                    }
 
                                     # Add object to our temporary list
                                     [PSCustomObject]@{
@@ -337,9 +340,9 @@ function Compare-CIPPIntuneObject {
                                         } else {
                                             $child.choiceSettingValue.value
                                         }
-                                        if (!$childValue -and $child.simpleSettingValue.value) {
-                                            $childValue = $child.simpleSettingValue.value
-                                        }
+                                    }
+                                    if (!$childValue -and $null -ne $child.simpleSettingValue -and $null -ne $child.simpleSettingValue.value) {
+                                        $childValue = $child.simpleSettingValue.value
                                     }
 
                                     # Add object to our temporary list


### PR DESCRIPTION
Additionally handle simpleSettingsValue that have no choiceSettingValue, so that value extraction happens for these cases too.

Fixes https://github.com/KelvinTegelaar/CIPP/issues/4714