### PR TITLE
Chore: Remove unnecessary role and scope entries from SAMManifest.json

### DIFF
--- a/Modules/CIPPCore/Public/SAMManifest.json
+++ b/Modules/CIPPCore/Public/SAMManifest.json
@@ -44,10 +44,6 @@
           "type": "Role"
         },
         {
-          "id": "3b55498e-47ec-484f-8136-9013221c06a9",
-          "type": "Role"
-        },
-        {
           "id": "35930dcf-aceb-4bd1-b99a-8ffed403c974",
           "type": "Role"
         },
@@ -72,15 +68,7 @@
           "type": "Role"
         },
         {
-          "id": "2f51be20-0bb4-4fed-bf7b-db946066c75e",
-          "type": "Role"
-        },
-        {
           "id": "243333ab-4d21-40cb-a475-36241daa0842",
-          "type": "Role"
-        },
-        {
-          "id": "58ca0d9a-1575-47e1-a3cb-007ef2e4583b",
           "type": "Role"
         },
         {
@@ -96,15 +84,7 @@
           "type": "Scope"
         },
         {
-          "id": "06a5fe6d-c49d-46a7-b082-56b1b14103c7",
-          "type": "Role"
-        },
-        {
           "id": "5ac13192-7ace-4fcf-b828-1a26f28068ee",
-          "type": "Role"
-        },
-        {
-          "id": "7ab1d382-f21e-4acd-a863-ba3e13f7da61",
           "type": "Role"
         },
         {
@@ -121,10 +101,6 @@
         },
         {
           "id": "bf7b1a76-6e77-406b-b258-bf5c7720e98f",
-          "type": "Role"
-        },
-        {
-          "id": "5b567255-7703-4780-807c-7be8301ae99b",
           "type": "Role"
         },
         {
@@ -212,10 +188,6 @@
           "type": "Role"
         },
         {
-          "id": "45cc0394-e837-488b-a098-1918f48d186c",
-          "type": "Role"
-        },
-        {
           "id": "34bf0e97-1971-4929-b999-9e2442d941d7",
           "type": "Role"
         },
@@ -289,10 +261,6 @@
         },
         {
           "id": "ebf0f66e-9fb1-49e4-a278-222f76911cf4",
-          "type": "Scope"
-        },
-        {
-          "id": "233e0cf1-dd62-48bc-b65b-b38fe87fcf8e",
           "type": "Scope"
         },
         {
@@ -460,10 +428,6 @@
           "type": "Scope"
         },
         {
-          "id": "1d89d70c-dcac-4248-b214-903c457af83a",
-          "type": "Scope"
-        },
-        {
           "id": "a84a9652-ffd3-496e-a991-22ba5529156a",
           "type": "Scope"
         },
@@ -532,10 +496,6 @@
           "type": "Scope"
         },
         {
-          "id": "48638b3c-ad68-4383-8ac4-e6880ee6ca57",
-          "type": "Scope"
-        },
-        {
           "id": "39d65650-9d3e-4223-80db-a335590d027e",
           "type": "Scope"
         },
@@ -561,10 +521,6 @@
         },
         {
           "id": "204e0828-b5ca-4ad8-b9f3-f32a958e7cc4",
-          "type": "Scope"
-        },
-        {
-          "id": "aec28ec7-4d02-4e8c-b864-50163aea77eb",
           "type": "Scope"
         },
         {


### PR DESCRIPTION
Remove unnecessary role and scope entries, as the ReadWrite version already exists on the CIPP-SAM app.

The following roles have been removed:

### Application

- ChannelMember.Read.All
- DeviceManagementManagedDevices.Read.All
- DeviceManagementRBAC.Read.All
- DeviceManagementServiceConfig.Read.All
- Group.Read.All
- SecurityIncident.Read.All

### Delegated

- ChannelSettings.Read.All
- PrivilegedAccess.Read.AzureResources
- TeamSettings.Read.All
- UserAuthenticationMethod.Read.All