### PR TITLE
Fallback to using defaultDomainName instead of customerId for looking up ReplaceMap.

### DIFF
--- a/Modules/CIPPCore/Public/Get-CIPPTextReplacement.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPTextReplacement.ps1
@@ -64,6 +64,10 @@ function Get-CIPPTextReplacement {
     }
     # Tenant Specific Variables
     $ReplaceMap = Get-CIPPAzDataTableEntity @ReplaceTable -Filter "PartitionKey eq '$CustomerId'"
+    # If no results found by customerId, try by defaultDomainName
+    if (!$ReplaceMap) {
+        $ReplaceMap = Get-CIPPAzDataTableEntity @ReplaceTable -Filter "PartitionKey eq '$($Tenant.defaultDomainName)'"
+    }
     if ($ReplaceMap) {
         foreach ($Var in $ReplaceMap) {
             if ($EscapeForJson.IsPresent) {


### PR DESCRIPTION
When editing a tenant and adding tenant specific variables, the value saved is not the customerId, but rather the defaultDomainName. This results in Get-CIPPTextReplacement not being able to find it, therefore not using it.

Ideally we should only have one true lookup identifier, but we can't just change it as that would cause issues.

Resolves https://github.com/KelvinTegelaar/CIPP/issues/4692