### PR TITLE
Add technician extraction and update action to GDAP invite

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/GDAP/Invoke-ExecGDAPInvite.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/GDAP/Invoke-ExecGDAPInvite.ps1
@@ -15,6 +15,26 @@ function Invoke-ExecGDAPInvite {
 
 
     $Action = $Request.Body.Action ?? $Request.Query.Action ?? 'Create'
+    $InviteId = $Request.Body.InviteId
+    $Reference = $Request.Body.Reference
+    $Table = Get-CIPPTable -TableName 'GDAPInvites'
+
+    # Extract technician from headers (same logic as Write-LogMessage)
+    if ($Headers.'x-ms-client-principal-idp' -eq 'azureStaticWebApps' -or !$Headers.'x-ms-client-principal-idp') {
+        $user = $headers.'x-ms-client-principal'
+        $Technician = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($user)) | ConvertFrom-Json).userDetails
+    } elseif ($Headers.'x-ms-client-principal-idp' -eq 'aad') {
+        $Table = Get-CIPPTable -TableName 'ApiClients'
+        $Client = Get-CIPPAzDataTableEntity @Table -Filter "RowKey eq '$($headers.'x-ms-client-principal-name')'"
+        $Technician = $Client.AppName ?? 'CIPP-API'
+    } else {
+        try {
+            $user = $headers.'x-ms-client-principal'
+            $Technician = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($user)) | ConvertFrom-Json).userDetails
+        } catch {
+            $Technician = 'System'
+        }
+    }
 
     switch ($Action) {
         'Create' {
@@ -26,7 +46,6 @@ function Invoke-ExecGDAPInvite {
                 $AutoExtendDuration = 'P180D'
             }
 
-            $Table = Get-CIPPTable -TableName 'GDAPInvites'
             try {
                 $Step = 'Creating GDAP relationship'
                 $JSONBody = @{
@@ -75,7 +94,11 @@ function Invoke-ExecGDAPInvite {
                             'InviteUrl'     = $InviteUrl
                             'OnboardingUrl' = $OnboardingUrl
                             'RoleMappings'  = [string](@($RoleMappings) | ConvertTo-Json -Depth 10 -Compress)
+                            'Technician'    = $Technician
                         }
+
+                        if ($Reference) { $InviteEntity['Reference'] = $Reference }
+
                         Add-CIPPAzDataTableEntity @Table -Entity $InviteEntity
 
                         $Message = 'GDAP relationship invite created. Log in as a Global Admin in the new tenant to approve the invite.'
@@ -103,9 +126,28 @@ function Invoke-ExecGDAPInvite {
                 Invite  = $InviteEntity
             }
         }
+        'Update'{
+            $Invite = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'invite' and RowKey eq '$InviteId'"
+            if ($Invite) {
+
+                $InviteEntity = [PSCustomObject]@{
+                    'PartitionKey' = 'invite'
+                    'RowKey'       = $InviteId
+                    'Technician'   = $Technician
+                }
+
+                if ($Reference) { $InviteEntity['Reference'] = $Reference }
+
+                Add-CIPPAzDataTableEntity @Table -Entity $InviteEntity -OperationType 'UpsertMerge'
+                $Message = 'Invite updated'
+            } else {
+                $Message = 'Invite not found'
+            }
+            $body = @{
+                Message = $Message
+            }
+        }
         'Delete' {
-            $InviteId = $Request.Body.InviteId
-            $Table = Get-CIPPTable -TableName 'GDAPInvites'
             $Invite = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'invite' and RowKey eq '$InviteId'"
             if ($Invite) {
                 Remove-AzDataTableEntity @Table -Entity $Invite


### PR DESCRIPTION
Introduces logic to extract the technician from request headers and store it with GDAP invite entities. Adds an 'Update' action to allow updating invite entities with technician and reference information.

Resolves: https://github.com/KelvinTegelaar/CIPP/issues/4718
UI PR: 