### PR TITLE
Feat: Add functionality for managing restricted users in Exchange Online

### DIFF
--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertRestrictedUsers.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertRestrictedUsers.ps1
@@ -1,0 +1,42 @@
+﻿function Get-CIPPAlertRestrictedUsers {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [Alias('input')]
+        $InputValue,
+        $TenantFilter
+    )
+
+    try {
+        # Get blocked sender addresses using Exchange Online cmdlet
+        $BlockedUsers = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-BlockedSenderAddress'
+
+        if ($BlockedUsers) {
+            $AlertData = foreach ($User in $BlockedUsers) {
+                # Parse the reason to make it more readable
+                $ReasonParts = $User.Reason -split ';'
+                $LimitType = ($ReasonParts | Where-Object { $_ -like 'ExceedingLimitType=*' }) -replace 'ExceedingLimitType=', ''
+                $InternalCount = ($ReasonParts | Where-Object { $_ -like 'InternalRecipientCountToday=*' }) -replace 'InternalRecipientCountToday=', ''
+                $ExternalCount = ($ReasonParts | Where-Object { $_ -like 'ExternalRecipientCountToday=*' }) -replace 'ExternalRecipientCountToday=', ''
+
+                [PSCustomObject]@{
+                    SenderAddress   = $User.SenderAddress
+                    Message         = "User $($User.SenderAddress) is restricted from sending email. Block type: $($LimitType ?? 'Unknown'). Created: $($User.CreatedDatetime)"
+                    BlockType       = if ($LimitType) { "$LimitType recipient limit exceeded" } else { 'Email sending limit exceeded' }
+                    TemporaryBlock  = $User.TemporaryBlock
+                    InternalCount   = $InternalCount
+                    ExternalCount   = $ExternalCount
+                    CreatedDatetime = $User.CreatedDatetime
+                    Reason          = $User.Reason
+                }
+            }
+            Write-AlertTrace -cmdletName $MyInvocation.MyCommand -tenantFilter $TenantFilter -data $AlertData
+        }
+    } catch {
+        Write-AlertMessage -tenant $($TenantFilter) -message "Could not get restricted users for $($TenantFilter): $(Get-NormalizedError -message $_.Exception.message)"
+    }
+}

--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertRestrictedUsers.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertRestrictedUsers.ps1
@@ -12,7 +12,6 @@
     )
 
     try {
-        # Get blocked sender addresses using Exchange Online cmdlet
         $BlockedUsers = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-BlockedSenderAddress'
 
         if ($BlockedUsers) {

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecRemoveRestrictedUser.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecRemoveRestrictedUser.ps1
@@ -1,0 +1,46 @@
+﻿using namespace System.Net
+
+function Invoke-ExecRemoveRestrictedUser {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Mailbox.ReadWrite
+    .DESCRIPTION
+        Removes a user from the restricted senders list in Exchange Online.
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+
+    # Interact with query parameters or the body of the request.
+    $TenantFilter = $Request.Body.tenantFilter
+    $SenderAddress = $Request.Body.SenderAddress
+
+    try {
+        if ([string]::IsNullOrEmpty($SenderAddress)) { throw 'SenderAddress parameter is required' }
+        if ([string]::IsNullOrEmpty($TenantFilter)) { throw 'tenantFilter parameter is required' }
+
+        # Remove the user from the restricted list
+        $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Remove-BlockedSenderAddress' -cmdParams @{SenderAddress = $SenderAddress }
+        $Results = "Successfully removed $SenderAddress from the restricted users list."
+
+
+        Write-LogMessage -headers $Headers -API $APIName -message $Results -Sev 'Info' -tenant $TenantFilter
+        $StatusCode = [HttpStatusCode]::OK
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        $Results = "Failed to remove $SenderAddress from restricted list: $($ErrorMessage.NormalizedError)"
+        Write-LogMessage -headers $Headers -API $APIName -message $Results -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
+        $StatusCode = [HttpStatusCode]::InternalServerError
+    }
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{Results = $Results }
+        })
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListRestrictedUsers.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListRestrictedUsers.ps1
@@ -1,0 +1,60 @@
+﻿using namespace System.Net
+
+function Invoke-ListRestrictedUsers {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Mailbox.Read
+    .DESCRIPTION
+        Lists users from the restricted senders list in Exchange Online.
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    Write-LogMessage -headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
+
+    # Interact with query parameters or the body of the request.
+    $TenantFilter = $Request.Query.tenantFilter
+
+    try {
+        $BlockedUsers = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-BlockedSenderAddress'
+
+        if ($BlockedUsers) {
+            $GraphRequest = foreach ($User in $BlockedUsers) {
+                # Parse the reason to make it more readable
+                $ReasonParts = $User.Reason -split ';'
+                $LimitType = ($ReasonParts | Where-Object { $_ -like 'ExceedingLimitType=*' }) -replace 'ExceedingLimitType=', ''
+                $InternalCount = ($ReasonParts | Where-Object { $_ -like 'InternalRecipientCountToday=*' }) -replace 'InternalRecipientCountToday=', ''
+                $ExternalCount = ($ReasonParts | Where-Object { $_ -like 'ExternalRecipientCountToday=*' }) -replace 'ExternalRecipientCountToday=', ''
+
+                [PSCustomObject]@{
+                    SenderAddress   = $User.SenderAddress
+                    Reason          = $User.Reason
+                    BlockType       = if ($LimitType) { "$LimitType recipient limit exceeded" } else { 'Email sending limit exceeded' }
+                    CreatedDatetime = $User.CreatedDatetime
+                    ChangedDatetime = $User.ChangedDatetime
+                    TemporaryBlock  = $User.TemporaryBlock
+                    InternalCount   = $InternalCount
+                    ExternalCount   = $ExternalCount
+                }
+            }
+        } else {
+            $GraphRequest = @()
+        }
+
+        $StatusCode = [HttpStatusCode]::OK
+    } catch {
+        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+        $StatusCode = [HttpStatusCode]::Forbidden
+        $GraphRequest = $ErrorMessage
+    }
+
+    # Associate values to output bindings by calling 'Push-OutputBinding'.
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @($GraphRequest)
+        })
+}

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListSharedMailboxAccountEnabled.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListSharedMailboxAccountEnabled.ps1
@@ -1,6 +1,6 @@
 using namespace System.Net
 
-Function Invoke-ListSharedMailboxAccountEnabled {
+function Invoke-ListSharedMailboxAccountEnabled {
     <#
     .FUNCTIONALITY
         Entrypoint
@@ -28,24 +28,26 @@ Function Invoke-ListSharedMailboxAccountEnabled {
             if ($User) {
                 # Return all shared mailboxes with license information
                 [PSCustomObject]@{
-                    UserPrincipalName = $User.userPrincipalName
-                    displayName = $User.displayName
-                    givenName = $User.givenName
-                    surname = $User.surname
-                    accountEnabled = $User.accountEnabled
-                    assignedLicenses = $User.assignedLicenses
-                    id = $User.id
+                    UserPrincipalName     = $User.userPrincipalName
+                    displayName           = $User.displayName
+                    givenName             = $User.givenName
+                    surname               = $User.surname
+                    accountEnabled        = $User.accountEnabled
+                    assignedLicenses      = $User.assignedLicenses
+                    id                    = $User.id
                     onPremisesSyncEnabled = $User.onPremisesSyncEnabled
                 }
             }
         }
+        $StatusCode = [HttpStatusCode]::OK
     } catch {
-        Write-LogMessage -API 'Tenant' -tenant $TenantFilter -message "Shared Mailbox List on $($TenantFilter). Error: $($_.exception.message)" -sev 'Error'
+        $StatusCode = [HttpStatusCode]::InternalServerError
+        Write-LogMessage -API $APIName -tenant $TenantFilter -message "Shared Mailbox List on $($TenantFilter). Error: $($_.exception.message)" -sev 'Error'
     }
     $GraphRequest = $SharedMailboxDetails
     # Associate values to output bindings by calling 'Push-OutputBinding'.
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
-            StatusCode = [HttpStatusCode]::OK
+            StatusCode = $StatusCode
             Body       = @($GraphRequest)
         })
 


### PR DESCRIPTION
Introduce alerts for users restricted from sending emails due to spam limits and implement functions to list and remove these restricted users in Exchange Online. Enhance logging and formatting for better clarity.

- Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/4736