### PR TITLE
Implemented #4759 - retains full backwards compatibility.

### DIFF
--- a/Config/standards.json
+++ b/Config/standards.json
@@ -2292,6 +2292,13 @@
     "helpText": "This creates a Safe Links policy that automatically scans, tracks, and and enables safe links for Email, Office, and Teams for both external and internal senders",
     "addedComponent": [
       {
+        "type": "textField",
+        "name": "standards.SafeLinksPolicy.name",
+        "label": "Policy Name",
+        "required": true,
+        "defaultValue": "CIPP Default SafeLinks Policy"
+      },
+      {
         "type": "switch",
         "label": "AllowClickThrough",
         "name": "standards.SafeLinksPolicy.AllowClickThrough"
@@ -2338,6 +2345,13 @@
     ],
     "helpText": "This creates a Anti-Phishing policy that automatically enables Mailbox Intelligence and spoofing, optional switches for Mail tips.",
     "addedComponent": [
+      {
+        "type": "textField",
+        "name": "standards.AntiPhishPolicy.name",
+        "label": "Policy Name",
+        "required": true,
+        "defaultValue": "CIPP Default Anti-Phishing Policy"
+      },
       {
         "type": "number",
         "label": "Phishing email threshold. (Default 1)",
@@ -2549,6 +2563,13 @@
     "helpText": "This creates a Safe Attachment policy",
     "addedComponent": [
       {
+        "type": "textField",
+        "name": "standards.SafeAttachmentPolicy.name",
+        "label": "Policy Name",
+        "required": true,
+        "defaultValue": "CIPP Default Safe Attachment Policy"
+      },
+      {
         "type": "select",
         "multiple": false,
         "label": "Safe Attachment Action",
@@ -2693,6 +2714,13 @@
     "helpText": "This creates a Malware filter policy that enables the default File filter and Zero-hour auto purge for malware.",
     "addedComponent": [
       {
+        "type": "textField",
+        "name": "standards.MalwareFilterPolicy.name",
+        "label": "Policy Name",
+        "required": true,
+        "defaultValue": "CIPP Default Malware Policy"
+      },
+      {
         "type": "select",
         "multiple": false,
         "label": "FileTypeAction",
@@ -2811,7 +2839,15 @@
     "cat": "Defender Standards",
     "tag": [],
     "helpText": "This standard creates a Spam filter policy similar to the default strict policy.",
+    "docsDescription": "This standard creates a Spam filter policy similar to the default strict policy, the following settings are configured to on by default: IncreaseScoreWithNumericIps, IncreaseScoreWithRedirectToOtherPort, MarkAsSpamEmptyMessages, MarkAsSpamJavaScriptInHtml, MarkAsSpamSpfRecordHardFail, MarkAsSpamFromAddressAuthFail, MarkAsSpamNdrBackscatter, MarkAsSpamBulkMail, InlineSafetyTipsEnabled, PhishZapEnabled, SpamZapEnabled",
     "addedComponent": [
+      {
+        "type": "textField",
+        "name": "standards.SpamFilterPolicy.name",
+        "label": "Policy Name",
+        "required": true,
+        "defaultValue": "CIPP Default Spam Filter Policy"
+      },
       {
         "type": "number",
         "label": "Bulk email threshold (Default 7)",

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAntiPhishPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAntiPhishPolicy.ps1
@@ -64,18 +64,26 @@ function Invoke-CIPPStandardAntiPhishPolicy {
     $MDOLicensed = $ServicePlans -contains "ATP_ENTERPRISE"
     Write-Information "MDOLicensed: $MDOLicensed"
 
-    $PolicyList = @('CIPP Default Anti-Phishing Policy','Default Anti-Phishing Policy')
-    $ExistingPolicy = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AntiPhishPolicy' | Where-Object -Property Name -In $PolicyList
+    # Use custom name if provided, otherwise use default for backward compatibility
+    $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default Anti-Phishing Policy' }
+    $PolicyList = @($PolicyName, 'CIPP Default Anti-Phishing Policy','Default Anti-Phishing Policy')
+    $ExistingPolicy = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AntiPhishPolicy' | Where-Object -Property Name -In $PolicyList | Select-Object -First 1
     if ($null -eq $ExistingPolicy.Name) {
-        $PolicyName = $PolicyList[0]
+        # No existing policy - use the configured/default name
+        $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default Anti-Phishing Policy' }
     } else {
+        # Use existing policy name if found
         $PolicyName = $ExistingPolicy.Name
     }
-    $RuleList = @( 'CIPP Default Anti-Phishing Rule','CIPP Default Anti-Phishing Policy')
-    $ExistingRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AntiPhishRule' | Where-Object -Property Name -In $RuleList
+    # Derive rule name from policy name, but check for old names for backward compatibility
+    $DesiredRuleName = "$PolicyName Rule"
+    $RuleList = @($DesiredRuleName, 'CIPP Default Anti-Phishing Rule','CIPP Default Anti-Phishing Policy')
+    $ExistingRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AntiPhishRule' | Where-Object -Property Name -In $RuleList | Select-Object -First 1
     if ($null -eq $ExistingRule.Name) {
-        $RuleName = $RuleList[0]
+        # No existing rule - use the derived name
+        $RuleName = $DesiredRuleName
     } else {
+        # Use existing rule name if found
         $RuleName = $ExistingRule.Name
     }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardMalwareFilterPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardMalwareFilterPolicy.ps1
@@ -50,18 +50,26 @@ function Invoke-CIPPStandardMalwareFilterPolicy {
     } #we're done.
     ##$Rerun -Type Standard -Tenant $Tenant -Settings $Settings 'MalwareFilterPolicy'
 
-    $PolicyList = @('CIPP Default Malware Policy', 'Default Malware Policy')
-    $ExistingPolicy = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MalwareFilterPolicy' | Where-Object -Property Name -In $PolicyList
+    # Use custom name if provided, otherwise use default for backward compatibility
+    $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default Malware Policy' }
+    $PolicyList = @($PolicyName, 'CIPP Default Malware Policy', 'Default Malware Policy')
+    $ExistingPolicy = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MalwareFilterPolicy' | Where-Object -Property Name -In $PolicyList | Select-Object -First 1
     if ($null -eq $ExistingPolicy.Name) {
-        $PolicyName = $PolicyList[0]
+        # No existing policy - use the configured/default name
+        $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default Malware Policy' }
     } else {
+        # Use existing policy name if found
         $PolicyName = $ExistingPolicy.Name
     }
-    $RuleList = @( 'CIPP Default Malware Rule', 'CIPP Default Malware Policy')
-    $ExistingRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MalwareFilterRule' | Where-Object -Property Name -In $RuleList
+    # Derive rule name from policy name, but check for old names for backward compatibility
+    $DesiredRuleName = "$PolicyName Rule"
+    $RuleList = @($DesiredRuleName, 'CIPP Default Malware Rule', 'CIPP Default Malware Policy')
+    $ExistingRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-MalwareFilterRule' | Where-Object -Property Name -In $RuleList | Select-Object -First 1
     if ($null -eq $ExistingRule.Name) {
-        $RuleName = $RuleList[0]
+        # No existing rule - use the derived name
+        $RuleName = $DesiredRuleName
     } else {
+        # Use existing rule name if found
         $RuleName = $ExistingRule.Name
     }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
@@ -49,18 +49,26 @@ function Invoke-CIPPStandardSafeLinksPolicy {
     $MDOLicensed = $ServicePlans -contains 'ATP_ENTERPRISE'
 
     if ($MDOLicensed) {
-        $PolicyList = @('CIPP Default SafeLinks Policy', 'Default SafeLinks Policy')
-        $ExistingPolicy = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksPolicy' | Where-Object -Property Name -In $PolicyList
+        # Use custom name if provided, otherwise use default for backward compatibility
+        $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default SafeLinks Policy' }
+        $PolicyList = @($PolicyName, 'CIPP Default SafeLinks Policy', 'Default SafeLinks Policy')
+        $ExistingPolicy = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksPolicy' | Where-Object -Property Name -In $PolicyList | Select-Object -First 1
         if ($null -eq $ExistingPolicy.Name) {
-            $PolicyName = $PolicyList[0]
+            # No existing policy - use the configured/default name
+            $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default SafeLinks Policy' }
         } else {
+            # Use existing policy name if found
             $PolicyName = $ExistingPolicy.Name
         }
-        $RuleList = @( 'CIPP Default SafeLinks Rule', 'CIPP Default SafeLinks Policy')
-        $ExistingRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksRule' | Where-Object -Property Name -In $RuleList
+        # Derive rule name from policy name, but check for old names for backward compatibility
+        $DesiredRuleName = "$PolicyName Rule"
+        $RuleList = @($DesiredRuleName, 'CIPP Default SafeLinks Rule', 'CIPP Default SafeLinks Policy')
+        $ExistingRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksRule' | Where-Object -Property Name -In $RuleList | Select-Object -First 1
         if ($null -eq $ExistingRule.Name) {
-            $RuleName = $RuleList[0]
+            # No existing rule - use the derived name
+            $RuleName = $DesiredRuleName
         } else {
+            # Use existing rule name if found
             $RuleName = $ExistingRule.Name
         }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
@@ -58,7 +58,8 @@ function Invoke-CIPPStandardSpamFilterPolicy {
         return $true
     } #we're done.
 
-    $PolicyName = 'CIPP Default Spam Filter Policy'
+    # Use custom name if provided, otherwise use default for backward compatibility
+    $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default Spam Filter Policy' }
 
     try {
         $CurrentState = New-ExoRequest -TenantId $Tenant -cmdlet 'Get-HostedContentFilterPolicy' |


### PR DESCRIPTION
Allows custom names for the 5 default EXO policies:
Safe Links
Anti Phish
Malware Filter
Safe Attachment
Spam Filter

Default is still "CIPP Default"

Front-end PR: https://github.com/KelvinTegelaar/CIPP/pull/4761