### PR TITLE
Fix: Usage location fallback and enhance logging in Set-CIPPUserLicense

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUserBulk.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUserBulk.ps1
@@ -131,7 +131,7 @@ function Invoke-AddUserBulk {
                     if ($AssignedLicenses) {
                         $GuidPattern = '([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})'
                         $LicenseSkus = $AssignedLicenses.value ?? $AssignedLicenses | Where-Object { $_ -match $GuidPattern }
-                        Set-CIPPUserLicense -UserId $BulkResult.id -AddLicenses $LicenseSkus -TenantFilter $TenantFilter
+                        Set-CIPPUserLicense -UserId $BulkResult.id -AddLicenses $LicenseSkus -TenantFilter $TenantFilter -APIName $APIName -Headers $Headers
                     }
                     $Results.Add(@{
                             resultText = $Message.resultText

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
@@ -126,12 +126,12 @@ function Invoke-EditUser {
                     $Results.Add( 'Success. User license is already correct.' )
                 } else {
                     if ($UserObj.removeLicenses) {
-                        $licResults = Set-CIPPUserLicense -UserId $UserObj.id -TenantFilter $UserObj.tenantFilter -RemoveLicenses $CurrentLicenses.assignedLicenses.skuId -Headers $Headers
+                        $licResults = Set-CIPPUserLicense -UserId $UserObj.id -TenantFilter $UserObj.tenantFilter -RemoveLicenses $CurrentLicenses.assignedLicenses.skuId -Headers $Headers -APIName $APIName
                         $Results.Add($licResults)
                     } else {
                         #Remove all objects from $CurrentLicenses.assignedLicenses.skuId that are in $licenses
                         $RemoveLicenses = $CurrentLicenses.assignedLicenses.skuId | Where-Object { $_ -notin $licenses }
-                        $licResults = Set-CIPPUserLicense -UserId $UserObj.id -TenantFilter $UserObj.tenantFilter -RemoveLicenses $RemoveLicenses -AddLicenses $licenses -Headers $headers
+                        $licResults = Set-CIPPUserLicense -UserId $UserObj.id -TenantFilter $UserObj.tenantFilter -RemoveLicenses $RemoveLicenses -AddLicenses $licenses -Headers $Headers -APIName $APIName
                         $Results.Add($licResults)
                     }
 

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecBulkLicense.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecBulkLicense.ps1
@@ -1,4 +1,4 @@
-Function Invoke-ExecBulkLicense {
+function Invoke-ExecBulkLicense {
     <#
     .FUNCTIONALITY
         Entrypoint
@@ -11,7 +11,8 @@ Function Invoke-ExecBulkLicense {
         $TriggerMetadata
     )
 
-    $APIName = $TriggerMetadata.FunctionName
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
     $Results = [System.Collections.Generic.List[string]]::new()
     $StatusCode = [HttpStatusCode]::OK
 
@@ -48,12 +49,12 @@ Function Invoke-ExecBulkLicense {
                         $RemoveLicenses = $Licenses
                     } elseif ($LicenseOperation -eq 'Replace') {
                         $RemoveReplace = $User.assignedLicenses.skuId
-                        if ($RemoveReplace) { Set-CIPPUserLicense -UserId $UserId -TenantFilter $TenantFilter -RemoveLicenses $RemoveReplace }
+                        if ($RemoveReplace) { Set-CIPPUserLicense -UserId $UserId -TenantFilter $TenantFilter -RemoveLicenses $RemoveReplace -APIName $APIName -Headers $Headers }
                     } elseif ($RemoveAllLicenses) {
                         $RemoveLicenses = $User.assignedLicenses.skuId
                     }
                     #todo: Actually build bulk support into set-cippuserlicense.
-                    $TaskResults = Set-CIPPUserLicense -UserId $UserId -TenantFilter $TenantFilter -AddLicenses $AddLicenses -RemoveLicenses $RemoveLicenses
+                    $TaskResults = Set-CIPPUserLicense -UserId $UserId -TenantFilter $TenantFilter -AddLicenses $AddLicenses -RemoveLicenses $RemoveLicenses -APIName $APIName -Headers $Headers
 
                     $Results.Add($TaskResults)
                     Write-LogMessage -API $APIName -tenant $TenantFilter -message "Successfully processed licenses for user $UserPrincipalName" -Sev 'Info'

--- a/Modules/CIPPCore/Public/Set-CIPPUserLicense.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPUserLicense.ps1
@@ -5,7 +5,8 @@ function Set-CIPPUserLicense {
         [Parameter(Mandatory)][string]$TenantFilter,
         [Parameter()][array]$AddLicenses = @(),
         [Parameter()][array]$RemoveLicenses = @(),
-        $Headers
+        $Headers,
+        $APIName = 'Set User License'
     )
 
     # Build the addLicenses array
@@ -28,7 +29,25 @@ function Set-CIPPUserLicense {
     Write-Host "License body JSON: $LicenseBodyJson"
 
     try {
-        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$UserId/assignLicense" -tenantid $TenantFilter -type POST -body $LicenseBodyJson -Verbose
+        try {
+            $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$UserId/assignLicense" -tenantid $TenantFilter -type POST -body $LicenseBodyJson -Verbose
+        } catch {
+            # Handle if the error is due to missing usage location
+            if ($_.Exception.Message -like '*invalid usage location*') {
+                $Table = Get-CippTable -tablename 'UserSettings'
+                $UserSettings = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'UserSettings' and RowKey eq 'allUsers'"
+                if ($UserSettings) { $DefaultUsageLocation = (ConvertFrom-Json $UserSettings.JSON -Depth 5 -ErrorAction SilentlyContinue).usageLocation.value }
+                $DefaultUsageLocation ??= 'US' # Fallback to US if not set
+
+                $UsageLocationJson = ConvertTo-Json -InputObject @{'usageLocation' = $DefaultUsageLocation } -Depth 5 -Compress
+                $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$UserId" -tenantid $TenantFilter -type PATCH -body $UsageLocationJson -Verbose
+                Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message "Set usage location for user $UserId to $DefaultUsageLocation" -Sev 'Info'
+                # Retry assigning the license
+                $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$UserId/assignLicense" -tenantid $TenantFilter -type POST -body $LicenseBodyJson -Verbose
+            } else {
+                throw $_
+            }
+        }
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
         Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to assign the license. Error: $($ErrorMessage.NormalizedError)" -Sev Error -LogData $ErrorMessage


### PR DESCRIPTION
Implement a fallback for the usage location when it is null and improve logging by adding headers and API name in the Set-CIPPUserLicense function.
This helps if you have made the users in a way that dosnt set the usage location, like "Add shared mailbox" and "Add room mailbox".