### PR TITLE
Fix: Logging message for NudgeMFA state 

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardNudgeMFA.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardNudgeMFA.ps1
@@ -35,20 +35,20 @@ function Invoke-CIPPStandardNudgeMFA {
     ##$Rerun -Type Standard -Tenant $Tenant -Settings $Settings 'NudgeMFA'
     Write-Host "NudgeMFA: $($Settings | ConvertTo-Json -Compress)"
     # Get state value using null-coalescing operator
-    $state = $Settings.state.value ?? $Settings.state
+    $State = $Settings.state.value ?? $Settings.state
 
     try {
         $CurrentState = New-GraphGetRequest -Uri 'https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy' -tenantid $Tenant
-        $StateIsCorrect = ($CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.state -eq $state) -and
-                        ($CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.snoozeDurationInDays -eq $Settings.snoozeDurationInDays) -and
-                        ($CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.enforceRegistrationAfterAllowedSnoozes -eq $true)
+        $StateIsCorrect = ($CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.state -eq $State) -and
+        ($CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.snoozeDurationInDays -eq $Settings.snoozeDurationInDays) -and
+        ($CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.enforceRegistrationAfterAllowedSnoozes -eq $true)
     } catch {
         Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Failed to get Authenticator App Nudge state, check your permissions and try again' -sev Error -LogData (Get-CippException -Exception $_)
-        exit 0
+        return
     }
 
     if ($Settings.remediate -eq $true) {
-        $StateName = $Settings.state ? 'Enabled' : 'Disabled'
+        $StateName = $State.Substring(0, 1).ToUpper() + $State.Substring(1)
         try {
             $GraphRequest = @{
                 tenantid    = $Tenant
@@ -59,7 +59,7 @@ function Invoke-CIPPStandardNudgeMFA {
                 Body        = @{
                     registrationEnforcement = @{
                         authenticationMethodsRegistrationCampaign = @{
-                            state                                  = $state
+                            state                                  = $State
                             snoozeDurationInDays                   = $Settings.snoozeDurationInDays
                             enforceRegistrationAfterAllowedSnoozes = $true
                             includeTargets                         = $CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.includeTargets
@@ -71,7 +71,8 @@ function Invoke-CIPPStandardNudgeMFA {
             New-GraphPostRequest @GraphRequest
             Write-LogMessage -API 'Standards' -tenant $Tenant -message "$StateName Authenticator App Nudge with a snooze duration of $($Settings.snoozeDurationInDays)" -sev Info
         } catch {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to set Authenticator App Nudge to $state. Error: $($_.Exception.message)" -sev Error -LogData $_
+            $ErrorMessage = Get-CippException -Exception $_
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to set Authenticator App Nudge to $State. Error: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
         }
     }
 
@@ -85,8 +86,8 @@ function Invoke-CIPPStandardNudgeMFA {
     }
 
     if ($Settings.report -eq $true) {
-        $state = $StateIsCorrect ? $true : ($CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign | Select-Object snoozeDurationInDays, state)
-        Set-CIPPStandardsCompareField -FieldName 'standards.NudgeMFA' -FieldValue $state -Tenant $Tenant
+        $State = $StateIsCorrect ? $true : ($CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign | Select-Object snoozeDurationInDays, state)
+        Set-CIPPStandardsCompareField -FieldName 'standards.NudgeMFA' -FieldValue $State -Tenant $Tenant
         Add-CIPPBPAField -FieldName 'NudgeMFA' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $Tenant
     }
 }


### PR DESCRIPTION
Correct the logging message to accurately reflect the NudgeMFA state, ensuring it shows "Enabled" or "Disabled" based on the actual configuration.