### PR TITLE
Fix: Onboarding errors and correct variable names in permission scripts

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-ExecOnboardTenantQueue.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-ExecOnboardTenantQueue.ps1
@@ -316,8 +316,8 @@ function Push-ExecOnboardTenantQueue {
                     $LastCPVError = ''
                     do {
                         try {
-                            Add-CIPPApplicationPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $env:ApplicationID -tenantfilter $Relationship.customer.tenantId
-                            Add-CIPPDelegatedPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $env:ApplicationID -tenantfilter $Relationship.customer.tenantId
+                            Add-CIPPApplicationPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $env:ApplicationID -TenantFilter $Relationship.customer.tenantId
+                            Add-CIPPDelegatedPermission -RequiredResourceAccess 'CIPPDefaults' -ApplicationId $env:ApplicationID -TenantFilter $Relationship.customer.tenantId
                             $CPVSuccess = $true
                             $Refreshing = $false
                         } catch {
@@ -361,16 +361,16 @@ function Push-ExecOnboardTenantQueue {
                         defaultDomainName = $Tenant.defaultDomainName
                     }
                 }
-                $Table = Get-CippTable -tablename 'templates'
-                $ExistingTemplates = Get-CippazDataTableEntity @Table -Filter "PartitionKey eq 'StandardsTemplateV2'" | Where-Object { $_.JSON -match 'AllTenants' }
+                $Table = Get-CIPPTable -tablename 'templates'
+                $ExistingTemplates = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'StandardsTemplateV2'" | Where-Object { $_.JSON -match 'AllTenants' }
                 foreach ($AllTenantsTemplate in $ExistingTemplates) {
                     $object = $AllTenantsTemplate.JSON | ConvertFrom-Json
-                    $NewExcludedTenants = [system.collections.generic.list[object]]::new()
+                    $NewExcludedTenants = [System.Collections.Generic.List[object]]::new()
                     if (!$object.excludedTenants) {
                         $object | Add-Member -MemberType NoteProperty -Name 'excludedTenants' -Value @() -Force
                     }
-                    foreach ($Tenant in $object.excludedTenants) {
-                        $NewExcludedTenants.Add($Tenant)
+                    foreach ($ExcludedStandardsTenant in $object.excludedTenants) {
+                        $NewExcludedTenants.Add($ExcludedStandardsTenant)
                     }
                     $NewExcludedTenants.Add($AddExclusionObj)
                     $object.excludedTenants = $NewExcludedTenants

--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,8 @@
     "cipp",
     "CIPP",
     "CIPP-API",
+    "CIPPCPV",
+    "CIPPGDAP",
     "Connectwise",
     "CPIM",
     "Datto",


### PR DESCRIPTION
Resolve a null exception error(Onboarding failed. Exception: Cannot bind argument to parameter 'Exception' because it is null) during onboarding when `StandardsExcludeAllTenants` is true and correct the `TenantFilter` variable name in the permission scripts.

-Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/4771