### PR TITLE
Fix: Enhance error handling in licensing checks

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ListStandardsCompare.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ListStandardsCompare.ps1
@@ -65,8 +65,12 @@ function Invoke-ListStandardsCompare {
 
         if ($FieldValue -is [System.Boolean]) {
             $FieldValue = [bool]$FieldValue
-        } elseif ($FieldValue -like '*{*') {
-            $FieldValue = ConvertFrom-Json -InputObject $FieldValue -ErrorAction SilentlyContinue
+        } elseif ($FieldValue -like '[{*') {
+            try {
+                $FieldValue = ConvertFrom-Json -InputObject $FieldValue -ErrorAction SilentlyContinue
+            } catch {
+                $FieldValue = [string]$FieldValue
+            }
         } else {
             $FieldValue = [string]$FieldValue
         }

--- a/Modules/CIPPCore/Public/Functions/Test-CIPPStandardLicense.ps1
+++ b/Modules/CIPPCore/Public/Functions/Test-CIPPStandardLicense.ps1
@@ -55,8 +55,10 @@ function Test-CIPPStandardLicense {
         return $true
     } catch {
         if (!$SkipLog.IsPresent) {
-            Write-LogMessage -API 'Standards' -tenant $TenantFilter -message "Error checking license capabilities for standard $StandardName`: $($_.Exception.Message)" -sev Error
-            Set-CIPPStandardsCompareField -FieldName "standards.$StandardName" -FieldValue "License Missing: Error checking license capabilities - $($_.Exception.Message)" -Tenant $TenantFilter
+            # Sanitize exception message to prevent JSON parsing issues - remove characters that could interfere with JSON detection
+            $SanitizedMessage = $_.Exception.Message -replace '[{}\[\]]', ''
+            Write-LogMessage -API 'Standards' -tenant $TenantFilter -message "Error checking license capabilities for standard $StandardName`: $SanitizedMessage" -sev Error
+            Set-CIPPStandardsCompareField -FieldName "standards.$StandardName" -FieldValue "License Missing: Error checking license capabilities - $SanitizedMessage" -Tenant $TenantFilter
         }
         return $false
     }


### PR DESCRIPTION
Improve error handling during licensing checks by sanitizing exception messages to prevent JSON parsing issues, ensuring the applied standards report loads correctly.