### PR TITLE
feat: Add OOO calendar options for Exchange

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecScheduleOOOVacation.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecScheduleOOOVacation.ps1
@@ -26,12 +26,36 @@ function Invoke-ExecScheduleOOOVacation {
         $UserDisplay = ($UserUPNs | Select-Object -First 3) -join ', '
         if ($UserUPNs.Count -gt 3) { $UserDisplay += " (+$($UserUPNs.Count - 3) more)" }
 
+        # Convert epoch timestamps to datetime strings for Scheduled mode
+        $StartTimeStr = [DateTimeOffset]::FromUnixTimeSeconds([int64]$StartDate).DateTime.ToString()
+        $EndTimeStr   = [DateTimeOffset]::FromUnixTimeSeconds([int64]$EndDate).DateTime.ToString()
+
         $SharedParams = [PSCustomObject]@{
             TenantFilter    = $TenantFilter
             Users           = $UserUPNs
             InternalMessage = $InternalMessage
             ExternalMessage = $ExternalMessage
             APIName         = $APIName
+            StartTime       = $StartTimeStr
+            EndTime         = $EndTimeStr
+        }
+
+        # Calendar options — conditionally add when truthy in the request body
+        if ($Request.Body.CreateOOFEvent) {
+            $SharedParams | Add-Member -NotePropertyName 'CreateOOFEvent' -NotePropertyValue $true
+        }
+        if (-not [string]::IsNullOrWhiteSpace($Request.Body.OOFEventSubject)) {
+            $SharedParams | Add-Member -NotePropertyName 'OOFEventSubject' -NotePropertyValue $Request.Body.OOFEventSubject
+        }
+        if ($Request.Body.AutoDeclineFutureRequestsWhenOOF) {
+            $SharedParams | Add-Member -NotePropertyName 'AutoDeclineFutureRequestsWhenOOF' -NotePropertyValue $true
+        }
+        if ($Request.Body.DeclineEventsForScheduledOOF) {
+            $SharedParams | Add-Member -NotePropertyName 'DeclineEventsForScheduledOOF' -NotePropertyValue $true
+            $SharedParams | Add-Member -NotePropertyName 'DeclineAllEventsForScheduledOOF' -NotePropertyValue $true
+        }
+        if (-not [string]::IsNullOrWhiteSpace($Request.Body.DeclineMeetingMessage)) {
+            $SharedParams | Add-Member -NotePropertyName 'DeclineMeetingMessage' -NotePropertyValue $Request.Body.DeclineMeetingMessage
         }
 
         # Add task — enables OOO with messages at start date

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecSetOoO.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecSetOoO.ps1
@@ -51,8 +51,27 @@ function Invoke-ExecSetOoO {
             $EndTime = $Request.Body.EndTime -match '^\d+$' ? [DateTimeOffset]::FromUnixTimeSeconds([int]$Request.Body.EndTime).DateTime : $Request.Body.EndTime
             $SplatParams.StartTime = $StartTime
             $SplatParams.EndTime = $EndTime
+
+            # Calendar options — only pass when explicitly provided in the request body
+            if ($null -ne $Request.Body.CreateOOFEvent) {
+                $SplatParams.CreateOOFEvent = [bool]$Request.Body.CreateOOFEvent
+            }
+            if (-not [string]::IsNullOrWhiteSpace($Request.Body.OOFEventSubject)) {
+                $SplatParams.OOFEventSubject = $Request.Body.OOFEventSubject
+            }
+            if ($null -ne $Request.Body.AutoDeclineFutureRequestsWhenOOF) {
+                $SplatParams.AutoDeclineFutureRequestsWhenOOF = [bool]$Request.Body.AutoDeclineFutureRequestsWhenOOF
+            }
+            if ($null -ne $Request.Body.DeclineEventsForScheduledOOF) {
+                $SplatParams.DeclineEventsForScheduledOOF = [bool]$Request.Body.DeclineEventsForScheduledOOF
+                $SplatParams.DeclineAllEventsForScheduledOOF = [bool]$Request.Body.DeclineEventsForScheduledOOF
+            }
+            if (-not [string]::IsNullOrWhiteSpace($Request.Body.DeclineMeetingMessage)) {
+                $SplatParams.DeclineMeetingMessage = $Request.Body.DeclineMeetingMessage
+            }
         }
 
+        Write-Information "Setting Out of Office with the following parameters: $($SplatParams | ConvertTo-Json -Depth 10)"
         $Results = Set-CIPPOutOfOffice @SplatParams
         $StatusCode = [HttpStatusCode]::OK
     } catch {

--- a/Modules/CIPPCore/Public/Get-CIPPOutOfOffice.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPOutOfOffice.ps1
@@ -10,11 +10,17 @@ function Get-CIPPOutOfOffice {
     try {
         $OutOfOffice = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-MailboxAutoReplyConfiguration' -cmdParams @{Identity = $UserID } -Anchor $UserID
         $Results = @{
-            AutoReplyState  = $OutOfOffice.AutoReplyState
-            StartTime       = $OutOfOffice.StartTime.ToString('yyyy-MM-dd HH:mm')
-            EndTime         = $OutOfOffice.EndTime.ToString('yyyy-MM-dd HH:mm')
-            InternalMessage = $OutOfOffice.InternalMessage
-            ExternalMessage = $OutOfOffice.ExternalMessage
+            AutoReplyState                  = $OutOfOffice.AutoReplyState
+            StartTime                       = $OutOfOffice.StartTime ? $OutOfOffice.StartTime.ToString('yyyy-MM-dd HH:mm') : $null
+            EndTime                         = $OutOfOffice.EndTime ? $OutOfOffice.EndTime.ToString('yyyy-MM-dd HH:mm') : $null
+            InternalMessage                 = $OutOfOffice.InternalMessage
+            ExternalMessage                 = $OutOfOffice.ExternalMessage
+            CreateOOFEvent                  = $OutOfOffice.CreateOOFEvent
+            OOFEventSubject                 = $OutOfOffice.OOFEventSubject
+            AutoDeclineFutureRequestsWhenOOF = $OutOfOffice.AutoDeclineFutureRequestsWhenOOF
+            DeclineEventsForScheduledOOF    = $OutOfOffice.DeclineEventsForScheduledOOF
+            DeclineAllEventsForScheduledOOF = $OutOfOffice.DeclineAllEventsForScheduledOOF
+            DeclineMeetingMessage           = $OutOfOffice.DeclineMeetingMessage
         } | ConvertTo-Json
         return $Results
     } catch {

--- a/Modules/CIPPCore/Public/Set-CIPPOutOfoffice.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPOutOfoffice.ps1
@@ -12,7 +12,13 @@ function Set-CIPPOutOfOffice {
         $APIName = 'Set Out of Office',
         $Headers,
         $StartTime,
-        $EndTime
+        $EndTime,
+        [bool]$CreateOOFEvent,
+        [string]$OOFEventSubject,
+        [bool]$AutoDeclineFutureRequestsWhenOOF,
+        [bool]$DeclineEventsForScheduledOOF,
+        [bool]$DeclineAllEventsForScheduledOOF,
+        [string]$DeclineMeetingMessage
     )
 
     try {
@@ -38,6 +44,26 @@ function Set-CIPPOutOfOffice {
             $EndTime = $EndTime ? $EndTime : (Get-Date $StartTime).AddDays(7)
             $CmdParams.StartTime = $StartTime
             $CmdParams.EndTime = $EndTime
+
+            # Calendar options — only included when explicitly provided
+            if ($PSBoundParameters.ContainsKey('CreateOOFEvent')) {
+                $CmdParams.CreateOOFEvent = $CreateOOFEvent
+            }
+            if ($PSBoundParameters.ContainsKey('OOFEventSubject')) {
+                $CmdParams.OOFEventSubject = $OOFEventSubject
+            }
+            if ($PSBoundParameters.ContainsKey('AutoDeclineFutureRequestsWhenOOF')) {
+                $CmdParams.AutoDeclineFutureRequestsWhenOOF = $AutoDeclineFutureRequestsWhenOOF
+            }
+            if ($PSBoundParameters.ContainsKey('DeclineEventsForScheduledOOF')) {
+                $CmdParams.DeclineEventsForScheduledOOF = $DeclineEventsForScheduledOOF
+            }
+            if ($PSBoundParameters.ContainsKey('DeclineAllEventsForScheduledOOF')) {
+                $CmdParams.DeclineAllEventsForScheduledOOF = $DeclineAllEventsForScheduledOOF
+            }
+            if ($PSBoundParameters.ContainsKey('DeclineMeetingMessage')) {
+                $CmdParams.DeclineMeetingMessage = $DeclineMeetingMessage
+            }
         }
 
         $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Set-MailboxAutoReplyConfiguration' -cmdParams $CmdParams -Anchor $UserID

--- a/Modules/CIPPCore/Public/Set-CIPPVacationOOO.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPVacationOOO.ps1
@@ -6,7 +6,15 @@ function Set-CIPPVacationOOO {
         [string]$InternalMessage,
         [string]$ExternalMessage,
         [string]$APIName = 'OOO Vacation Mode',
-        $Headers
+        $Headers,
+        $StartTime,
+        $EndTime,
+        [bool]$CreateOOFEvent,
+        [string]$OOFEventSubject,
+        [bool]$AutoDeclineFutureRequestsWhenOOF,
+        [bool]$DeclineEventsForScheduledOOF,
+        [bool]$DeclineAllEventsForScheduledOOF,
+        [string]$DeclineMeetingMessage
     )
 
     $Results = [System.Collections.Generic.List[string]]::new()
@@ -14,21 +22,56 @@ function Set-CIPPVacationOOO {
     foreach ($upn in $Users) {
         if ([string]::IsNullOrWhiteSpace($upn)) { continue }
         try {
+            # Use Scheduled when StartTime/EndTime are provided (vacation always has dates),
+            # otherwise fall back to Enabled for backwards compatibility with in-flight tasks
+            $State = if ($Action -eq 'Add') {
+                if ($PSBoundParameters.ContainsKey('StartTime') -and $PSBoundParameters.ContainsKey('EndTime')) { 'Scheduled' } else { 'Enabled' }
+            } else { 'Disabled' }
+
             $SplatParams = @{
                 UserID       = $upn
                 TenantFilter = $TenantFilter
-                State        = if ($Action -eq 'Add') { 'Enabled' } else { 'Disabled' }
+                State        = $State
                 APIName      = $APIName
                 Headers      = $Headers
             }
-            # Only pass messages on Add — Remove only disables, preserving any messages
-            # the user may have updated themselves during vacation
+
             if ($Action -eq 'Add') {
+                # Pass start/end times when available
+                if ($PSBoundParameters.ContainsKey('StartTime')) {
+                    $SplatParams.StartTime = $StartTime
+                }
+                if ($PSBoundParameters.ContainsKey('EndTime')) {
+                    $SplatParams.EndTime = $EndTime
+                }
+
+                # Only pass messages on Add — Remove only disables, preserving any messages
+                # the user may have updated themselves during vacation
                 if (-not [string]::IsNullOrWhiteSpace($InternalMessage)) {
                     $SplatParams.InternalMessage = $InternalMessage
                 }
                 if (-not [string]::IsNullOrWhiteSpace($ExternalMessage)) {
                     $SplatParams.ExternalMessage = $ExternalMessage
+                }
+
+                # Calendar options — pass through when explicitly provided
+                if ($PSBoundParameters.ContainsKey('CreateOOFEvent')) {
+                    $SplatParams.CreateOOFEvent = $CreateOOFEvent
+                }
+                if ($PSBoundParameters.ContainsKey('OOFEventSubject')) {
+                    $SplatParams.OOFEventSubject = $OOFEventSubject
+                }
+                if ($PSBoundParameters.ContainsKey('AutoDeclineFutureRequestsWhenOOF')) {
+                    $SplatParams.AutoDeclineFutureRequestsWhenOOF = $AutoDeclineFutureRequestsWhenOOF
+                }
+                if ($PSBoundParameters.ContainsKey('DeclineEventsForScheduledOOF')) {
+                    $SplatParams.DeclineEventsForScheduledOOF = $DeclineEventsForScheduledOOF
+                }
+                if ($PSBoundParameters.ContainsKey('DeclineAllEventsForScheduledOOF')) {
+                    $SplatParams.DeclineAllEventsForScheduledOOF = $DeclineAllEventsForScheduledOOF
+                }
+                if ($PSBoundParameters.ContainsKey('DeclineMeetingMessage')) {
+                    $SplatParams.DeclineMeetingMessage = $DeclineMeetingMessage
                 }
             }
             $result = Set-CIPPOutOfOffice @SplatParams


### PR DESCRIPTION
Introduce new Out of Office (OOO) calendar options, including the ability to block calendar events, decline invitations, and cancel meetings. Enhance the Set-MailboxAutoReplyConfiguration command with parameters for managing OOO events, ensuring backward compatibility for existing functionality.

Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/5623