### PR TITLE
fix: Separate username copyField from display label

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUser.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUser.ps1
@@ -61,7 +61,11 @@ function Invoke-AddUser {
             $body = [pscustomobject] @{
                 'Results'  = @(
                     $CreationResults.Results[0],
-                    $CreationResults.Results[1],
+                    @{
+                        'resultText' = $CreationResults.Results[1]
+                        'copyField'  = $CreationResults.Username
+                        'state'      = 'success'
+                    },
                     @{
                         'resultText' = $CreationResults.Results[2]
                         'copyField'  = $CreationResults.password


### PR DESCRIPTION
The username copy functionality previously included the label prefix ("Username: ") when copying to the clipboard. This update wraps the username in a structured result object with a dedicated copyField, ensuring that only the raw UPN is copied, similar to the existing behavior for the password field.

Fixes KelvinTegelaar/CIPP#5645