### PR TITLE
fix: omit userType from Autopilot OOBE settings in self-deploying mode

### DIFF
--- a/Modules/CIPPCore/Public/Set-CIPPDefaultAPDeploymentProfile.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPDefaultAPDeploymentProfile.ps1
@@ -20,7 +20,20 @@ function Set-CIPPDefaultAPDeploymentProfile {
     )
 
     try {
-        if ($Language -eq 'user-select') { $Language = '' }
+        if ($Language -in @('user-select', 'os-default')) { $Language = '' }
+
+        # userType in outOfBoxExperienceSetting is only valid for user-driven (singleUser) mode.
+        # The Intune API rejects it for self-deploying (shared) mode.
+        $OutOfBoxSetting = [ordered]@{
+            'deviceUsageType'              = "$DeploymentMode"
+            'escapeLinkHidden'             = $([bool]($true))
+            'privacySettingsHidden'        = $([bool]($HidePrivacy))
+            'eulaHidden'                   = $([bool]($HideTerms))
+            'keyboardSelectionPageSkipped' = $([bool]($AutoKeyboard))
+        }
+        if ($DeploymentMode -ne 'shared') {
+            $OutOfBoxSetting['userType'] = "$UserType"
+        }
 
         $ObjBody = [pscustomobject]@{
             '@odata.type'                   = '#microsoft.graph.azureADWindowsAutopilotDeploymentProfile'
@@ -32,14 +45,7 @@ function Set-CIPPDefaultAPDeploymentProfile {
             'deviceType'                    = 'windowsPc'
             'hardwareHashExtractionEnabled' = $([bool]($CollectHash))
             'roleScopeTagIds'               = @()
-            'outOfBoxExperienceSetting'     = @{
-                'deviceUsageType'              = "$DeploymentMode"
-                'escapeLinkHidden'             = $([bool]($true))
-                'privacySettingsHidden'        = $([bool]($HidePrivacy))
-                'eulaHidden'                   = $([bool]($HideTerms))
-                'userType'                     = "$UserType"
-                'keyboardSelectionPageSkipped' = $([bool]($AutoKeyboard))
-            }
+            'outOfBoxExperienceSetting'     = $OutOfBoxSetting
         }
         $Body = ConvertTo-Json -InputObject $ObjBody -Depth 10
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAutopilotProfile.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAutopilotProfile.ps1
@@ -69,7 +69,7 @@ function Invoke-CIPPStandardAutopilotProfile {
         ($CurrentConfig.outOfBoxExperienceSetting.deviceUsageType -eq $DeploymentMode) -and
         ($CurrentConfig.outOfBoxExperienceSetting.privacySettingsHidden -eq $Settings.HidePrivacy) -and
         ($CurrentConfig.outOfBoxExperienceSetting.eulaHidden -eq $Settings.HideTerms) -and
-        ($CurrentConfig.outOfBoxExperienceSetting.userType -eq $userType) -and
+        ($DeploymentMode -eq 'shared' -or $CurrentConfig.outOfBoxExperienceSetting.userType -eq $userType) -and
         ($CurrentConfig.outOfBoxExperienceSetting.keyboardSelectionPageSkipped -eq $Settings.AutoKeyboard)
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
@@ -78,14 +78,26 @@ function Invoke-CIPPStandardAutopilotProfile {
     }
 
     $CurrentValue = $CurrentConfig | Select-Object -Property displayName, description, deviceNameTemplate, locale, preprovisioningAllowed, hardwareHashExtractionEnabled, @{Name = 'outOfBoxExperienceSetting'; Expression = {
-            [PSCustomObject]@{
+            $oobe = [PSCustomObject]@{
                 deviceUsageType              = $_.outOfBoxExperienceSetting.deviceUsageType
                 privacySettingsHidden        = $_.outOfBoxExperienceSetting.privacySettingsHidden
                 eulaHidden                   = $_.outOfBoxExperienceSetting.eulaHidden
-                userType                     = $_.outOfBoxExperienceSetting.userType
                 keyboardSelectionPageSkipped = $_.outOfBoxExperienceSetting.keyboardSelectionPageSkipped
             }
+            if ($DeploymentMode -ne 'shared') {
+                $oobe | Add-Member -NotePropertyName 'userType' -NotePropertyValue $_.outOfBoxExperienceSetting.userType
+            }
+            $oobe
         }
+    }
+    $ExpectedOobe = [PSCustomObject]@{
+        deviceUsageType              = $DeploymentMode
+        privacySettingsHidden        = $Settings.HidePrivacy
+        eulaHidden                   = $Settings.HideTerms
+        keyboardSelectionPageSkipped = $Settings.AutoKeyboard
+    }
+    if ($DeploymentMode -ne 'shared') {
+        $ExpectedOobe | Add-Member -NotePropertyName 'userType' -NotePropertyValue $userType
     }
     $ExpectedValue = [PSCustomObject]@{
         displayName                   = $Settings.DisplayName
@@ -94,13 +106,7 @@ function Invoke-CIPPStandardAutopilotProfile {
         locale                        = $Settings.Languages.value
         preprovisioningAllowed        = $Settings.AllowWhiteGlove
         hardwareHashExtractionEnabled = $Settings.CollectHash
-        outOfBoxExperienceSetting     = [PSCustomObject]@{
-            deviceUsageType              = $DeploymentMode
-            privacySettingsHidden        = $Settings.HidePrivacy
-            eulaHidden                   = $Settings.HideTerms
-            userType                     = $userType
-            keyboardSelectionPageSkipped = $Settings.AutoKeyboard
-        }
+        outOfBoxExperienceSetting     = $ExpectedOobe
     }
 
     # Remediate if the state is not correct


### PR DESCRIPTION
## Summary
- The Intune API returns a generic error when `userType` is included in `outOfBoxExperienceSetting` for self-deploying (shared) mode Autopilot profiles, as there is no user context during self-deploying OOBE
- `userType` is now conditionally omitted from the request body when `deploymentMode` is `shared`
- The `StateIsCorrect` comparison in the Autopilot standard is updated to skip the `userType` check for shared mode, preventing an infinite re-remediation loop (the API never returns `userType` on shared profiles, so the check always failed)
- `CurrentValue`/`ExpectedValue` report projections also updated to exclude `userType` for shared mode for accurate drift reporting
- Defensively extended the locale mapping to also convert the internal `os-default` value to an empty string alongside user-select, preventing that value from being sent as an invalid BCP-47 locale tag

## Related Issues
Fixes https://github.com/KelvinTegelaar/CIPP/issues/5554