### PR TITLE
fix: Get-CIPPAlertExpiringLicenses.ps1

### DIFF
--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertExpiringLicenses.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertExpiringLicenses.ps1
@@ -10,6 +10,7 @@ function Get-CIPPAlertExpiringLicenses {
         $InputValue,
         $TenantFilter
     )
+
     try {
         # Parse input parameters - default to 30 days if not specified
         # Support both old format (direct value) and new format (object with properties)
@@ -22,41 +23,53 @@ function Get-CIPPAlertExpiringLicenses {
             $UnassignedOnly = $false
         }
 
-        $AlertData = Get-CIPPLicenseOverview -TenantFilter $TenantFilter | ForEach-Object {
-            $UnassignedCount = [int]$_.CountAvailable
+        $AlertData = @(
+            Get-CIPPLicenseOverview -TenantFilter $TenantFilter | ForEach-Object {
 
-            # If unassigned only filter is enabled, skip licenses with no unassigned units
-            if ($UnassignedOnly -and $UnassignedCount -le 0) {
-                return
-            }
+                $UnassignedCount = [int]$_.CountAvailable
 
-            foreach ($Term in $TermData) {
-                if ($Term.DaysUntilRenew -lt $DaysThreshold -and $Term.DaysUntilRenew -gt 0) {
-                    $Message = if ($UnassignedOnly) {
-                        "$($_.License) has $UnassignedCount unassigned license(s) expiring in $($Term.DaysUntilRenew) days. The estimated term is $($Term.Term)"
-                    } else {
-                        "$($_.License) will expire in $($Term.DaysUntilRenew) days. The estimated term is $($Term.Term)"
-                    }
+                # If unassigned only filter is enabled, skip licenses with no unassigned units
+                if ($UnassignedOnly -and $UnassignedCount -le 0) {
+                    return
+                }
 
-                    Write-Host $Message
-                    [PSCustomObject]@{
-                        Message        = $Message
-                        License        = $_.License
-                        SkuId          = $_.skuId
-                        DaysUntilRenew = $Term.DaysUntilRenew
-                        Term           = $Term.Term
-                        Status         = $Term.Status
-                        TotalLicenses  = $Term.TotalLicenses
-                        CountUsed      = $_.CountUsed
-                        CountAvailable = $UnassignedCount
-                        NextLifecycle  = $Term.NextLifecycle
-                        Tenant         = $_.Tenant
+                # FIX: term rows are in TermInfo on the overview object
+                $TermData = @($_.TermInfo)
+
+                foreach ($Term in $TermData) {
+                    $DaysUntilRenew = [int]$Term.DaysUntilRenew
+
+                    if ($DaysUntilRenew -lt $DaysThreshold -and $DaysUntilRenew -gt 0) {
+
+                        $Message = if ($UnassignedOnly) {
+                            "$($_.License) has $UnassignedCount unassigned license(s) expiring in $DaysUntilRenew days. The estimated term is $($Term.Term)"
+                        } else {
+                            "$($_.License) will expire in $DaysUntilRenew days. The estimated term is $($Term.Term)"
+                        }
+
+                        [PSCustomObject]@{
+                            Message        = $Message
+                            License        = $_.License
+                            SkuId          = $_.skuId
+                            DaysUntilRenew = $DaysUntilRenew
+                            Term           = $Term.Term
+                            Status         = $Term.Status
+                            TotalLicenses  = $Term.TotalLicenses
+                            CountUsed      = $_.CountUsed
+                            CountAvailable = $UnassignedCount
+                            NextLifecycle  = $Term.NextLifecycle
+                            Tenant         = $_.Tenant
+                        }
                     }
                 }
             }
-        }
+        )
+
         Write-AlertTrace -cmdletName $MyInvocation.MyCommand -tenantFilter $TenantFilter -data $AlertData
 
     } catch {
+        Write-AlertTrace -cmdletName $MyInvocation.MyCommand -tenantFilter $TenantFilter -error $_
+        throw
     }
 }
+``


### PR DESCRIPTION
$TermData is not returned by Get-CIPPLicenseOverview, adapting code to get data from $_.TermInfo