### PR TITLE
feat: support group memberships in user templates and filter unavailable licenses

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUserDefaults.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUserDefaults.ps1
@@ -73,6 +73,30 @@ function Invoke-AddUserDefaults {
         $SetSponsor = $Request.Body.setSponsor
         $CopyFrom = $Request.Body.copyFrom
 
+        # Fetch group memberships from source user if provided
+        $GroupMemberships = @()
+        if ($Request.Body.sourceUserId -and $TenantFilter) {
+            try {
+                Write-Host "Fetching group memberships from source user: $($Request.Body.sourceUserId)"
+                $SourceGroups = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users/$($Request.Body.sourceUserId)/memberOf" -tenantid $TenantFilter
+                $GroupMemberships = @($SourceGroups | Where-Object {
+                    $_.'@odata.type' -eq '#microsoft.graph.group' -and
+                    $_.groupTypes -notcontains 'DynamicMembership' -and
+                    $_.onPremisesSyncEnabled -ne $true
+                } | ForEach-Object {
+                    @{
+                        id          = $_.id
+                        displayName = $_.displayName
+                        mailEnabled = $_.mailEnabled
+                        groupTypes  = $_.groupTypes
+                    }
+                })
+                Write-Host "Found $($GroupMemberships.Count) group memberships to store in template"
+            } catch {
+                Write-Warning "Failed to fetch group memberships: $($_.Exception.Message)"
+            }
+        }
+
         # Create template object with all fields from CippAddEditUser
         $TemplateObject = @{
             tenantFilter     = $TenantFilter
@@ -104,6 +128,7 @@ function Invoke-AddUserDefaults {
             setManager       = $SetManager
             setSponsor       = $SetSponsor
             copyFrom         = $CopyFrom
+            groupMemberships = $GroupMemberships
         }
 
         # Use existing GUID if editing, otherwise generate new one

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUserDefaults.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUserDefaults.ps1
@@ -149,7 +149,7 @@ function Invoke-AddUserDefaults {
 
         $Action = if ($Request.Body.GUID) { 'Updated' } else { 'Created' }
         $Result = "$Action User Default Template '$($TemplateName)' with GUID $GUID"
-        Write-LogMessage -headers $Headers -API $APIName -message $Result -Sev 'Info'
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message $Result -Sev 'Info'
         $StatusCode = [HttpStatusCode]::OK
 
     } catch {

--- a/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
@@ -20,6 +20,23 @@ function New-CIPPUserTask {
 
     try {
         if ($UserObj.licenses.value) {
+            # Filter out licenses with no available units
+            try {
+                $SubscribedSkus = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/subscribedSkus' -tenantid $UserObj.tenantFilter
+                $FilteredLicenses = @(foreach ($LicenseId in $UserObj.licenses.value) {
+                    $Sku = $SubscribedSkus | Where-Object { $_.skuId -eq $LicenseId }
+                    $Available = [int]$Sku.prepaidUnits.enabled - [int]$Sku.consumedUnits
+                    if ($Sku -and $Available -le 0) {
+                        $null = $Results.Add("Skipped license $($Sku.skuPartNumber): no available units")
+                        Write-LogMessage -headers $Headers -API $APIName -tenant $UserObj.tenantFilter -message "Skipped license $($Sku.skuPartNumber) for $($CreationResults.Username): no available units" -Sev 'Warn'
+                    } else {
+                        $LicenseId
+                    }
+                })
+                $UserObj.licenses = [PSCustomObject]@{ value = $FilteredLicenses }
+            } catch {
+                Write-Warning "Failed to check available licenses: $($_.Exception.Message)"
+            }
             if ($UserObj.sherwebLicense.value) {
                 $null = Set-SherwebSubscription -Headers $Headers -TenantFilter $UserObj.tenantFilter -SKU $UserObj.sherwebLicense.value -Add 1
                 $null = $Results.Add('Added Sherweb License, scheduling assignment')
@@ -66,6 +83,25 @@ function New-CIPPUserTask {
         $CopyFrom = Set-CIPPCopyGroupMembers -Headers $Headers -CopyFromId $UserObj.copyFrom.value -UserID $CreationResults.Username -TenantFilter $UserObj.tenantFilter
         $CopyFrom.Success | ForEach-Object { $Results.Add($_) }
         $CopyFrom.Error | ForEach-Object { $Results.Add($_) }
+    }
+
+    if ($UserObj.groupMemberships -and ($UserObj.groupMemberships | Measure-Object).Count -gt 0) {
+        Write-Host "Adding user to $(@($UserObj.groupMemberships).Count) groups from template"
+        $ODataBind = 'https://graph.microsoft.com/v1.0/directoryObjects/{0}' -f $CreationResults.User.id
+        $AddMemberBody = @{ '@odata.id' = $ODataBind } | ConvertTo-Json -Compress
+        foreach ($Group in $UserObj.groupMemberships) {
+            try {
+                if ($Group.mailEnabled -and $Group.groupTypes -notcontains 'Unified') {
+                    $Params = @{ Identity = $Group.id; Member = $CreationResults.Username; BypassSecurityGroupManagerCheck = $true }
+                    $null = New-ExoRequest -tenantid $UserObj.tenantFilter -cmdlet 'Add-DistributionGroupMember' -cmdParams $Params -UseSystemMailbox $true
+                } else {
+                    $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/groups/$($Group.id)/members/`$ref" -tenantid $UserObj.tenantFilter -body $AddMemberBody -Verbose
+                }
+                $Results.Add("Added user to group from template: $($Group.displayName)")
+            } catch {
+                $Results.Add("Failed to add to group $($Group.displayName): $($_.Exception.Message)")
+            }
+        }
     }
 
     if ($UserObj.setManager) {

--- a/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
@@ -22,13 +22,12 @@ function New-CIPPUserTask {
         if ($UserObj.licenses.value) {
             # Filter out licenses with no available units
             try {
-                $SubscribedSkus = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/subscribedSkus' -tenantid $UserObj.tenantFilter
+                $LicenseOverview = Get-CIPPLicenseOverview -TenantFilter $UserObj.tenantFilter
                 $FilteredLicenses = @(foreach ($LicenseId in $UserObj.licenses.value) {
-                    $Sku = $SubscribedSkus | Where-Object { $_.skuId -eq $LicenseId }
-                    $Available = [int]$Sku.prepaidUnits.enabled - [int]$Sku.consumedUnits
-                    if ($Sku -and $Available -le 0) {
-                        $null = $Results.Add("Skipped license $($Sku.skuPartNumber): no available units")
-                        Write-LogMessage -headers $Headers -API $APIName -tenant $UserObj.tenantFilter -message "Skipped license $($Sku.skuPartNumber) for $($CreationResults.Username): no available units" -Sev 'Warn'
+                    $Sku = $LicenseOverview | Where-Object { $_.skuId -eq $LicenseId }
+                    if ($Sku -and [int]$Sku.availableUnits -le 0) {
+                        $null = $Results.Add("Skipped license $($Sku.License): no available units")
+                        Write-LogMessage -headers $Headers -API $APIName -tenant $UserObj.tenantFilter -message "Skipped license $($Sku.License) for $($CreationResults.Username): no available units" -Sev 'Warn'
                     } else {
                         $LicenseId
                     }
@@ -87,16 +86,12 @@ function New-CIPPUserTask {
 
     if ($UserObj.groupMemberships -and ($UserObj.groupMemberships | Measure-Object).Count -gt 0) {
         Write-Host "Adding user to $(@($UserObj.groupMemberships).Count) groups from template"
-        $ODataBind = 'https://graph.microsoft.com/v1.0/directoryObjects/{0}' -f $CreationResults.User.id
-        $AddMemberBody = @{ '@odata.id' = $ODataBind } | ConvertTo-Json -Compress
         foreach ($Group in $UserObj.groupMemberships) {
             try {
-                if ($Group.mailEnabled -and $Group.groupTypes -notcontains 'Unified') {
-                    $Params = @{ Identity = $Group.id; Member = $CreationResults.Username; BypassSecurityGroupManagerCheck = $true }
-                    $null = New-ExoRequest -tenantid $UserObj.tenantFilter -cmdlet 'Add-DistributionGroupMember' -cmdParams $Params -UseSystemMailbox $true
-                } else {
-                    $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/groups/$($Group.id)/members/`$ref" -tenantid $UserObj.tenantFilter -body $AddMemberBody -Verbose
-                }
+                $GroupType = if ($Group.groupTypes -contains 'Unified') { 'Microsoft 365' }
+                    elseif ($Group.mailEnabled) { 'Distribution list' }
+                    else { 'Security' }
+                Add-CIPPGroupMember -Headers $Headers -GroupType $GroupType -GroupId $Group.id -Member $CreationResults.Username -TenantFilter $UserObj.tenantFilter -APIName $APIName
                 $Results.Add("Added user to group from template: $($Group.displayName)")
             } catch {
                 $Results.Add("Failed to add to group $($Group.displayName): $($_.Exception.Message)")


### PR DESCRIPTION
- Implements KelvinTegelaar/CIPP#5595
- Fetch group memberships via Graph API when creating a template with `sourceUserId` and store them in the template
- Filter out licenses with no available units before assignment, log skipped licenses