### PR TITLE
Fix: sanitize mailnickname

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-AddGroupTemplate.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-AddGroupTemplate.ps1
@@ -13,12 +13,6 @@ function Invoke-AddGroupTemplate {
         if (!$Request.Body.displayName) {
             throw 'You must enter a displayname'
         }
-        if (!$Request.Body.username) {
-            throw 'You must enter a username'
-        }
-        if (!$Request.Body.groupType) {
-            throw 'You must select a group type'
-        }
 
         # Normalize group type to match New-CIPPGroup expectations
         # Handle values from ListGroups calculatedGroupType and frontend form values

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-AddGroupTemplate.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-AddGroupTemplate.ps1
@@ -13,6 +13,12 @@ function Invoke-AddGroupTemplate {
         if (!$Request.Body.displayName) {
             throw 'You must enter a displayname'
         }
+        if (!$Request.Body.username) {
+            throw 'You must enter a username'
+        }
+        if (!$Request.Body.groupType) {
+            throw 'You must select a group type'
+        }
 
         # Normalize group type to match New-CIPPGroup expectations
         # Handle values from ListGroups calculatedGroupType and frontend form values

--- a/Modules/CIPPCore/Public/New-CIPPGroup.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPGroup.ps1
@@ -78,10 +78,13 @@ function New-CIPPGroup {
         }
 
         # Determine if we should generate a mailNickname with a GUID, or use the username field
-        if (-not $GroupObject.Username) {
+        if (-not $GroupObject.Username -or $NormalizedGroupType -in @('Generic', 'AzureRole')) {
             $MailNickname = (New-Guid).guid.substring(0, 10)
         } else {
-            $MailNickname = $GroupObject.Username
+            $MailNickname = ($GroupObject.Username -split '@')[0] -replace '[^a-zA-Z0-9_-]', ''
+            if ([String]::IsNullOrEmpty($MailNickname)) {
+                $MailNickname = (New-Guid).guid
+            }
         }
 
         Write-LogMessage -API $APIName -tenant $TenantFilter -message "Creating group $($GroupObject.displayName) of type $NormalizedGroupType$(if ($NeedsEmail) { " with email $Email" })" -Sev Info


### PR DESCRIPTION
- Resolves KelvinTegelaar/CIPP#5678
- Sanitize `mailNickname` for security group creation
- Add input validation for `username` and `groupType` in group template creation