### PR TITLE
feat: add MDE onboarding status report with caching

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Security/Invoke-ListMDEOnboarding.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Security/Invoke-ListMDEOnboarding.ps1
@@ -1,0 +1,54 @@
+function Invoke-ListMDEOnboarding {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Security.Defender.Read
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+    $TenantFilter = $Request.Query.tenantFilter
+    $UseReportDB = $Request.Query.UseReportDB
+
+    try {
+        if ($UseReportDB -eq 'true') {
+            try {
+                $GraphRequest = Get-CIPPMDEOnboardingReport -TenantFilter $TenantFilter -ErrorAction Stop
+                $StatusCode = [HttpStatusCode]::OK
+            } catch {
+                Write-Host "Error retrieving MDE onboarding status from report database: $($_.Exception.Message)"
+                $StatusCode = [HttpStatusCode]::InternalServerError
+                $GraphRequest = $_.Exception.Message
+            }
+
+            return ([HttpResponseContext]@{
+                StatusCode = $StatusCode
+                Body       = @($GraphRequest)
+            })
+        }
+
+        $ConnectorId = 'fc780465-2017-40d4-a0c5-307022471b92'
+        $ConnectorUri = "https://graph.microsoft.com/beta/deviceManagement/mobileThreatDefenseConnectors/$ConnectorId"
+        try {
+            $ConnectorState = New-GraphGetRequest -uri $ConnectorUri -tenantid $TenantFilter
+            $PartnerState = $ConnectorState.partnerState
+        } catch {
+            $PartnerState = 'unavailable'
+        }
+
+        $GraphRequest = [PSCustomObject]@{
+            Tenant       = $TenantFilter
+            partnerState = $PartnerState
+        }
+        $StatusCode = [HttpStatusCode]::OK
+    } catch {
+        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+        $StatusCode = [HttpStatusCode]::Forbidden
+        $GraphRequest = $ErrorMessage
+    }
+
+    return ([HttpResponseContext]@{
+        StatusCode = $StatusCode
+        Body       = @($GraphRequest)
+    })
+}

--- a/Modules/CIPPCore/Public/Get-CIPPMDEOnboardingReport.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPMDEOnboardingReport.ps1
@@ -1,0 +1,56 @@
+function Get-CIPPMDEOnboardingReport {
+    <#
+    .SYNOPSIS
+        Generates an MDE onboarding status report from the CIPP Reporting database
+    .PARAMETER TenantFilter
+        The tenant to generate the report for
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TenantFilter
+    )
+
+    try {
+        if ($TenantFilter -eq 'AllTenants') {
+            $AllItems = Get-CIPPDbItem -TenantFilter 'allTenants' -Type 'MDEOnboarding'
+            $Tenants = @($AllItems | Where-Object { $_.RowKey -ne 'MDEOnboarding-Count' } | Select-Object -ExpandProperty PartitionKey -Unique)
+
+            $TenantList = Get-Tenants -IncludeErrors
+            $Tenants = $Tenants | Where-Object { $TenantList.defaultDomainName -contains $_ }
+
+            $AllResults = [System.Collections.Generic.List[PSCustomObject]]::new()
+            foreach ($Tenant in $Tenants) {
+                try {
+                    $TenantResults = Get-CIPPMDEOnboardingReport -TenantFilter $Tenant
+                    foreach ($Result in $TenantResults) {
+                        $Result | Add-Member -NotePropertyName 'Tenant' -NotePropertyValue $Tenant -Force
+                        $AllResults.Add($Result)
+                    }
+                } catch {
+                    Write-LogMessage -API 'MDEOnboardingReport' -tenant $Tenant -message "Failed to get report for tenant: $($_.Exception.Message)" -sev Warning
+                }
+            }
+            return $AllResults
+        }
+
+        $Items = Get-CIPPDbItem -TenantFilter $TenantFilter -Type 'MDEOnboarding' | Where-Object { $_.RowKey -ne 'MDEOnboarding-Count' }
+        if (-not $Items) {
+            throw 'No MDE onboarding data found in reporting database. Sync the report data first.'
+        }
+
+        $CacheTimestamp = ($Items | Where-Object { $_.Timestamp } | Sort-Object Timestamp -Descending | Select-Object -First 1).Timestamp
+
+        $AllResults = [System.Collections.Generic.List[PSCustomObject]]::new()
+        foreach ($Item in $Items) {
+            $ParsedData = $Item.Data | ConvertFrom-Json
+            $ParsedData | Add-Member -NotePropertyName 'CacheTimestamp' -NotePropertyValue $CacheTimestamp -Force
+            $AllResults.Add($ParsedData)
+        }
+
+        return $AllResults
+    } catch {
+        Write-LogMessage -API 'MDEOnboardingReport' -tenant $TenantFilter -message "Failed to generate MDE onboarding report: $($_.Exception.Message)" -sev Error
+        throw
+    }
+}

--- a/Modules/CIPPCore/Public/Invoke-CIPPDBCacheCollection.ps1
+++ b/Modules/CIPPCore/Public/Invoke-CIPPDBCacheCollection.ps1
@@ -117,6 +117,7 @@ function Invoke-CIPPDBCacheCollection {
             'ManagedDeviceEncryptionStates'
             'IntuneAppProtectionPolicies'
             'DetectedApps'
+            'MDEOnboarding'
         )
     }
 

--- a/Modules/CIPPCore/Public/Set-CIPPDBCacheMDEOnboarding.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPDBCacheMDEOnboarding.ps1
@@ -1,0 +1,45 @@
+function Set-CIPPDBCacheMDEOnboarding {
+    <#
+    .SYNOPSIS
+        Caches MDE onboarding status for a tenant
+    .PARAMETER TenantFilter
+        The tenant to cache MDE onboarding status for
+    .PARAMETER QueueId
+        The queue ID to update with total tasks (optional)
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [String]$TenantFilter,
+        [String]$QueueId
+    )
+
+    try {
+        Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Caching MDE onboarding status' -sev Debug
+
+        $ConnectorId = 'fc780465-2017-40d4-a0c5-307022471b92'
+        $ConnectorUri = "https://graph.microsoft.com/beta/deviceManagement/mobileThreatDefenseConnectors/$ConnectorId"
+        try {
+            $ConnectorState = New-GraphGetRequest -uri $ConnectorUri -tenantid $TenantFilter
+            $PartnerState = $ConnectorState.partnerState
+        } catch {
+            $PartnerState = 'unavailable'
+        }
+
+        $Result = @(
+            [PSCustomObject]@{
+                Tenant       = $TenantFilter
+                partnerState = $PartnerState
+                RowKey       = 'MDEOnboarding'
+                PartitionKey = $TenantFilter
+            }
+        )
+
+        Add-CIPPDbItem -TenantFilter $TenantFilter -Type 'MDEOnboarding' -Data @($Result)
+        Add-CIPPDbItem -TenantFilter $TenantFilter -Type 'MDEOnboarding' -Data @($Result) -Count
+
+        Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Cached MDE onboarding status successfully' -sev Debug
+    } catch {
+        Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Failed to cache MDE onboarding status: $($_.Exception.Message)" -sev Error -LogData (Get-CippException -Exception $_)
+    }
+}


### PR DESCRIPTION
- Implements KelvinTegelaar/CIPP#5552
- Add `Invoke-ListMDEOnboarding` endpoint to check MDE connector status via Graph API
- Add `Set-CIPPDBCacheMDEOnboarding` and `Get-CIPPMDEOnboardingReport` for ReportDB caching
- Add `MDEOnboarding` to Intune cache collection for automatic updates