### PR TITLE
feat: Intune Policy Comparison endpoint and comparison engine fixes

### DIFF
--- a/Modules/CIPPCore/Public/Compare-CIPPIntuneObject.ps1
+++ b/Modules/CIPPCore/Public/Compare-CIPPIntuneObject.ps1
@@ -514,6 +514,19 @@ function Compare-CIPPIntuneObject {
                             Value  = $value
                             Source = 'Reference'
                         }
+                    } elseif ($settingInstance.simpleSettingCollectionValue) {
+                        $label = if ($intuneObj?.displayName) {
+                            $intuneObj.displayName
+                        } else {
+                            $settingInstance.settingDefinitionId
+                        }
+                        $values = @($settingInstance.simpleSettingCollectionValue | ForEach-Object { $_.value })
+                        [PSCustomObject]@{
+                            Key    = "Simple-$($settingInstance.settingDefinitionId)"
+                            Label  = $label
+                            Value  = ($values | Sort-Object) -join ', '
+                            Source = 'Reference'
+                        }
                     } elseif ($settingInstance.choiceSettingValue?.value) {
                         $label = if ($intuneObj?.displayName) {
                             $intuneObj.displayName
@@ -534,6 +547,30 @@ function Compare-CIPPIntuneObject {
                             Key    = "Choice-$($settingInstance.settingDefinitionId)"
                             Label  = $label
                             Value  = $value
+                            Source = 'Reference'
+                        }
+
+                        # Recurse into children of choice settings (e.g. firewall profile sub-settings)
+                        if ($settingInstance.choiceSettingValue.children) {
+                            $childResults = Process-GroupSettingChildren -Children $settingInstance.choiceSettingValue.children -Source 'Reference' -IntuneCollectionIndex $intuneCollectionIndex
+                            foreach ($cr in $childResults) { $cr }
+                        }
+                    } elseif ($settingInstance.choiceSettingCollectionValue) {
+                        $label = if ($intuneObj?.displayName) {
+                            $intuneObj.displayName
+                        } else {
+                            $settingInstance.settingDefinitionId
+                        }
+                        $values = [System.Collections.Generic.List[string]]::new()
+                        foreach ($choiceValue in $settingInstance.choiceSettingCollectionValue) {
+                            $option = $intuneObj.options | Where-Object { $_.id -eq $choiceValue.value }
+                            $displayValue = if ($option?.displayName) { $option.displayName } else { $choiceValue.value }
+                            $values.Add($displayValue)
+                        }
+                        [PSCustomObject]@{
+                            Key    = "Choice-$($settingInstance.settingDefinitionId)"
+                            Label  = $label
+                            Value  = ($values | Sort-Object) -join ', '
                             Source = 'Reference'
                         }
                     } else {
@@ -586,6 +623,19 @@ function Compare-CIPPIntuneObject {
                             Value  = $value
                             Source = 'Difference'
                         }
+                    } elseif ($settingInstance.simpleSettingCollectionValue) {
+                        $label = if ($intuneObj?.displayName) {
+                            $intuneObj.displayName
+                        } else {
+                            $settingInstance.settingDefinitionId
+                        }
+                        $values = @($settingInstance.simpleSettingCollectionValue | ForEach-Object { $_.value })
+                        [PSCustomObject]@{
+                            Key    = "Simple-$($settingInstance.settingDefinitionId)"
+                            Label  = $label
+                            Value  = ($values | Sort-Object) -join ', '
+                            Source = 'Difference'
+                        }
                     } elseif ($settingInstance.choiceSettingValue?.value) {
                         $label = if ($intuneObj?.displayName) {
                             $intuneObj.displayName
@@ -608,6 +658,30 @@ function Compare-CIPPIntuneObject {
                             Value  = $value
                             Source = 'Difference'
                         }
+
+                        # Recurse into children of choice settings (e.g. firewall profile sub-settings)
+                        if ($settingInstance.choiceSettingValue.children) {
+                            $childResults = Process-GroupSettingChildren -Children $settingInstance.choiceSettingValue.children -Source 'Difference' -IntuneCollectionIndex $intuneCollectionIndex
+                            foreach ($cr in $childResults) { $cr }
+                        }
+                    } elseif ($settingInstance.choiceSettingCollectionValue) {
+                        $label = if ($intuneObj?.displayName) {
+                            $intuneObj.displayName
+                        } else {
+                            $settingInstance.settingDefinitionId
+                        }
+                        $values = [System.Collections.Generic.List[string]]::new()
+                        foreach ($choiceValue in $settingInstance.choiceSettingCollectionValue) {
+                            $option = $intuneObj.options | Where-Object { $_.id -eq $choiceValue.value }
+                            $displayValue = if ($option?.displayName) { $option.displayName } else { $choiceValue.value }
+                            $values.Add($displayValue)
+                        }
+                        [PSCustomObject]@{
+                            Key    = "Choice-$($settingInstance.settingDefinitionId)"
+                            Label  = $label
+                            Value  = ($values | Sort-Object) -join ', '
+                            Source = 'Difference'
+                        }
                     } else {
                         $label = if ($intuneObj?.displayName) {
                             $intuneObj.displayName
@@ -628,11 +702,16 @@ function Compare-CIPPIntuneObject {
 
         $result = [System.Collections.Generic.List[PSObject]]::new()
 
-        $allKeys = @($referenceItems | Select-Object -ExpandProperty Key) + @($differenceItems | Select-Object -ExpandProperty Key) | Sort-Object -Unique
+        $refItemsByKey = @{}
+        foreach ($item in $referenceItems) { $refItemsByKey[$item.Key] = $item }
+        $diffItemsByKey = @{}
+        foreach ($item in $differenceItems) { $diffItemsByKey[$item.Key] = $item }
+
+        $allKeys = @($refItemsByKey.Keys) + @($diffItemsByKey.Keys) | Sort-Object -Unique
 
         foreach ($key in $allKeys) {
-            $refItem = $referenceItems | Where-Object { $_.Key -eq $key } | Select-Object -First 1
-            $diffItem = $differenceItems | Where-Object { $_.Key -eq $key } | Select-Object -First 1
+            $refItem = $refItemsByKey[$key]
+            $diffItem = $diffItemsByKey[$key]
 
             $settingId = $key
             if ($key -like 'Simple-*') {
@@ -654,14 +733,14 @@ function Compare-CIPPIntuneObject {
             $diffValue = $diffRawValue
 
             if ($null -ne $settingDefinition -and $null -ne $settingDefinition.options) {
-                if ($null -ne $refRawValue -and $refRawValue -match '_\d+$') {
+                if ($null -ne $refRawValue -and $refRawValue -is [string]) {
                     $option = $settingDefinition.options | Where-Object { $_.id -eq $refRawValue }
                     if ($null -ne $option -and $null -ne $option.displayName) {
                         $refValue = $option.displayName
                     }
                 }
 
-                if ($null -ne $diffRawValue -and $diffRawValue -match '_\d+$') {
+                if ($null -ne $diffRawValue -and $diffRawValue -is [string]) {
                     $option = $settingDefinition.options | Where-Object { $_.id -eq $diffRawValue }
                     if ($null -ne $option -and $null -ne $option.displayName) {
                         $diffValue = $option.displayName

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ExecCompareIntunePolicy.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ExecCompareIntunePolicy.ps1
@@ -1,0 +1,188 @@
+function Invoke-ExecCompareIntunePolicy {
+    <#
+    .FUNCTIONALITY
+        Entrypoint,AnyTenant
+    .ROLE
+        Endpoint.MEM.Read
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+
+    # URLName to TemplateType mapping (bridges frontend policy names to Get-CIPPIntunePolicy parameter)
+    $URLNameToTemplateType = @{
+        'DeviceConfigurations'         = 'Device'
+        'ConfigurationPolicies'        = 'Catalog'
+        'GroupPolicyConfigurations'    = 'Admin'
+        'deviceCompliancePolicies'     = 'deviceCompliancePolicies'
+        'WindowsDriverUpdateProfiles'  = 'windowsDriverUpdateProfiles'
+        'WindowsFeatureUpdateProfiles' = 'windowsFeatureUpdateProfiles'
+        'windowsQualityUpdatePolicies' = 'windowsQualityUpdatePolicies'
+        'windowsQualityUpdateProfiles' = 'windowsQualityUpdateProfiles'
+    }
+
+    try {
+        $Body = $Request.Body
+        $SourceA = $Body.sourceA
+        $SourceB = $Body.sourceB
+
+        if (-not $SourceA -or -not $SourceB) {
+            throw 'Both sourceA and sourceB are required'
+        }
+
+        # Resolve a source descriptor to its policy object and metadata
+        function Resolve-PolicySource {
+            param(
+                [Parameter(Mandatory = $true)]
+                $Source,
+                [string]$Label
+            )
+
+            if ($Source.type -eq 'template') {
+                if (-not $Source.templateGuid) {
+                    throw "$Label : templateGuid is required for template sources"
+                }
+                $Table = Get-CippTable -tablename 'templates'
+                $Filter = "PartitionKey eq 'IntuneTemplate' and RowKey eq '$($Source.templateGuid)'"
+                $TemplateEntity = Get-CIPPAzDataTableEntity @Table -Filter $Filter
+
+                if (-not $TemplateEntity) {
+                    throw "$Label : Template with GUID '$($Source.templateGuid)' not found"
+                }
+
+                $JSONData = $TemplateEntity.JSON | ConvertFrom-Json -Depth 100
+                $PolicyObj = $JSONData.RAWJson | ConvertFrom-Json -Depth 100
+                $TemplateType = $JSONData.Type
+
+                return @{
+                    Object       = $PolicyObj
+                    TemplateType = $TemplateType
+                    Label        = "$($JSONData.Displayname) (Template)"
+                    RawData      = $PolicyObj
+                }
+
+            } elseif ($Source.type -eq 'tenantPolicy') {
+                if (-not $Source.tenantFilter -or -not $Source.policyId -or -not $Source.urlName) {
+                    throw "$Label : tenantFilter, policyId, and urlName are required for tenant policy sources"
+                }
+
+                $TemplateType = $URLNameToTemplateType[$Source.urlName]
+                if (-not $TemplateType) {
+                    throw "$Label : Unknown policy type '$($Source.urlName)'"
+                }
+
+                $Policy = Get-CIPPIntunePolicy -TemplateType $TemplateType -PolicyID $Source.policyId -tenantFilter $Source.tenantFilter -Headers $Headers -APINAME $APIName
+
+                if (-not $Policy) {
+                    throw "$Label : Policy '$($Source.policyId)' not found in tenant '$($Source.tenantFilter)'"
+                }
+
+                $PolicyObj = $Policy.cippconfiguration | ConvertFrom-Json -Depth 100
+                $DisplayName = $Policy.displayName ?? $Policy.name ?? $Source.policyId
+
+                return @{
+                    Object       = $PolicyObj
+                    TemplateType = $TemplateType
+                    Label        = "$DisplayName ($($Source.tenantFilter))"
+                    RawData      = $PolicyObj
+                }
+
+            } elseif ($Source.type -eq 'communityRepo') {
+                if (-not $Source.fullName -or -not $Source.branch -or -not $Source.path) {
+                    throw "$Label : fullName, branch, and path are required for community repo sources"
+                }
+
+                $FileContent = Get-GitHubFileContents -FullName $Source.fullName -Path $Source.path -Branch $Source.branch
+                if (-not $FileContent -or -not $FileContent.content) {
+                    throw "$Label : Could not retrieve file '$($Source.path)' from '$($Source.fullName)' branch '$($Source.branch)'"
+                }
+
+                $ParsedJson = $FileContent.content | ConvertFrom-Json -Depth 100
+
+                if ($ParsedJson.RowKey -and $ParsedJson.JSON) {
+                    # CIPP template format — has RowKey and JSON with RAWJson inside
+                    $JSONData = if ($ParsedJson.JSON -is [string]) {
+                        $ParsedJson.JSON | ConvertFrom-Json -Depth 100
+                    } else {
+                        $ParsedJson.JSON
+                    }
+                    $PolicyObj = if ($JSONData.RAWJson -is [string]) {
+                        $JSONData.RAWJson | ConvertFrom-Json -Depth 100
+                    } else {
+                        $JSONData.RAWJson
+                    }
+                    $TemplateType = $JSONData.Type
+                    $DisplayName = $JSONData.Displayname ?? $Source.path
+                } else {
+                    # Raw policy format — detect type from @odata.id
+                    $TemplateType = switch -Wildcard ($ParsedJson.'@odata.id') {
+                        '*CompliancePolicies*' { 'deviceCompliancePolicies' }
+                        '*deviceConfigurations*' { 'Device' }
+                        '*DriverUpdateProfiles*' { 'windowsDriverUpdateProfiles' }
+                        '*SettingsCatalog*' { 'Catalog' }
+                        '*configurationPolicies*' { 'Catalog' }
+                        '*managedAppPolicies*' { 'AppProtection' }
+                        '*deviceAppManagement*' { 'AppProtection' }
+                        default { 'Unknown' }
+                    }
+                    $PolicyObj = $ParsedJson
+                    $DisplayName = $ParsedJson.displayName ?? $ParsedJson.name ?? $Source.path
+                }
+
+                return @{
+                    Object       = $PolicyObj
+                    TemplateType = $TemplateType
+                    Label        = "$DisplayName (Repo: $($Source.fullName))"
+                    RawData      = $PolicyObj
+                }
+
+            } else {
+                throw "$Label : Invalid source type '$($Source.type)'. Must be 'template', 'tenantPolicy', or 'communityRepo'"
+            }
+        }
+
+        $ResolvedA = Resolve-PolicySource -Source $SourceA -Label 'Source A'
+        $ResolvedB = Resolve-PolicySource -Source $SourceB -Label 'Source B'
+
+        # Determine compare type
+        $CompareParams = @{
+            ReferenceObject  = $ResolvedA.Object
+            DifferenceObject = $ResolvedB.Object
+        }
+
+        if ($ResolvedA.TemplateType -eq 'Catalog' -and $ResolvedB.TemplateType -eq 'Catalog') {
+            $CompareParams['CompareType'] = 'Catalog'
+        }
+
+        # Run the comparison
+        $ComparisonResults = @(Compare-CIPPIntuneObject @CompareParams)
+
+        $ResultBody = @{
+            Results      = $ComparisonResults
+            sourceALabel = $ResolvedA.Label
+            sourceBLabel = $ResolvedB.Label
+            sourceAData  = $ResolvedA.RawData
+            sourceBData  = $ResolvedB.RawData
+            identical    = ($ComparisonResults.Count -eq 0)
+        }
+
+        Write-LogMessage -headers $Headers -API $APIName -message "Compared Intune policies: $($ResolvedA.Label) vs $($ResolvedB.Label) - $($ComparisonResults.Count) differences found" -Sev 'Info'
+
+        return ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::OK
+                Body       = ConvertTo-Json -Depth 100 -InputObject $ResultBody
+            })
+
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -headers $Headers -API $APIName -message "Failed to compare Intune policies: $($ErrorMessage.NormalizedError)" -Sev 'Error' -LogData $ErrorMessage
+        return ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::BadRequest
+                Body       = ConvertTo-Json -Depth 100 -InputObject @{
+                    Results = "Failed to compare policies: $($ErrorMessage.NormalizedError)"
+                }
+            })
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Invoke-ExecCompareIntunePolicy` POST endpoint for comparing Intune policies from templates, tenant policies, or community repos
- Fixes `Compare-CIPPIntuneObject` to handle `SimpleSettingCollectionInstance` and `ChoiceSettingCollectionInstance` at the top level (e.g., ASR exclusions were silently ignored)
- Fixes value resolution regex that missed boolean-style option suffixes (`_true`, `_false`, `_enabled`)

## Changes
- **New endpoint**: `Invoke-ExecCompareIntunePolicy.ps1` — resolves two policy sources and runs comparison
- **Bug fix**: `Compare-CIPPIntuneObject.ps1` — added missing `simpleSettingCollectionValue` and `choiceSettingCollectionValue` branches, fixed `choiceSettingValue.children` recursion, fixed value resolver to use type check instead of regex

**Frontend PR**: https://github.com/KelvinTegelaar/CIPP/pull/5696