### PR TITLE
Delete all matching Standards templates safely

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-RemoveStandardTemplate.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-RemoveStandardTemplate.ps1
@@ -11,19 +11,24 @@ function Invoke-RemoveStandardTemplate {
     $APIName = $Request.Params.CIPPEndpoint
     $Headers = $Request.Headers
 
-
     # Interact with query parameters or the body of the request.
     $ID = $Request.Body.ID ?? $Request.Query.ID
+    $TemplateName = ''
     try {
         $Table = Get-CippTable -tablename 'templates'
         $Filter = "PartitionKey eq 'StandardsTemplateV2' and (GUID eq '$ID' or RowKey eq '$ID' or OriginalEntityId eq '$ID')"
-        $ClearRow = Get-CIPPAzDataTableEntity @Table -Filter $Filter -Property PartitionKey, RowKey, ETag, JSON
-        if ($ClearRow.JSON) {
-            $TemplateName = (ConvertFrom-Json -InputObject $ClearRow.JSON -ErrorAction SilentlyContinue).templateName
-        } else {
-            $TemplateName = ''
+        $MergedRows = @(Get-CIPPAzDataTableEntity @Table -Filter $Filter)
+        if ($MergedRows.JSON) {
+            try {
+                $TemplateName = (ConvertFrom-Json -InputObject $MergedRows.JSON -ErrorAction SilentlyContinue).templateName
+            } catch {
+                $TemplateName = ''
+            }
         }
-        Remove-AzDataTableEntity -Force @Table -Entity $ClearRow
+        $RowsToDelete = @(Get-AzDataTableEntity @Table -Filter $Filter -Property PartitionKey, RowKey, ETag)
+        foreach ($Row in $RowsToDelete) {
+            Remove-AzDataTableEntity -Force @Table -Entity $Row
+        }
         $Result = "Removed Standards Template named: '$($TemplateName)' with id: $($ID)"
         Write-LogMessage -Headers $Headers -API $APIName -message $Result -Sev Info
         $StatusCode = [HttpStatusCode]::OK


### PR DESCRIPTION
Fixes issues where standards were split over multiple rows and were unable to be deleted.