### PR TITLE
Add cmdlets to remove extension API keys

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionClearHIBPKey.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionClearHIBPKey.ps1
@@ -1,0 +1,22 @@
+function Invoke-ExecExtensionClearHIBPKey {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        CIPP.Extension.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $Results = try {
+        Remove-ExtensionAPIKey -Extension 'HIBP' | Out-Null
+        'Successfully cleared the HIBP API key.'
+    } catch {
+        "Failed to clear the HIBP API key"
+    }
+
+    return ([HttpResponseContext]@{
+            StatusCode = [HttpStatusCode]::OK
+            Body       = @{'Results' = $Results }
+        })
+}

--- a/Modules/CIPPCore/Public/Remove-CippKeyVaultSecret.ps1
+++ b/Modules/CIPPCore/Public/Remove-CippKeyVaultSecret.ps1
@@ -1,0 +1,58 @@
+function Remove-CippKeyVaultSecret {
+    <#
+    .SYNOPSIS
+    Deletes a secret from Azure Key Vault using REST API (no Az.KeyVault module required)
+
+    .DESCRIPTION
+    Lightweight replacement for Remove-AzKeyVaultSecret that uses REST API directly.
+
+    .PARAMETER VaultName
+    Name of the Key Vault. If not provided, derives from WEBSITE_DEPLOYMENT_ID environment variable.
+
+    .PARAMETER Name
+    Name of the secret to delete.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$VaultName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    try {
+        if (-not $VaultName) {
+            if ($env:WEBSITE_DEPLOYMENT_ID) {
+                $VaultName = ($env:WEBSITE_DEPLOYMENT_ID -split '-')[0]
+            } else {
+                throw 'VaultName not provided and WEBSITE_DEPLOYMENT_ID environment variable not set'
+            }
+        }
+
+        $token = Get-CIPPAzIdentityToken -ResourceUrl 'https://vault.azure.net'
+        $uri = "https://$VaultName.vault.azure.net/secrets/$Name`?api-version=7.4"
+
+        $response = Invoke-RestMethod -Uri $uri -Headers @{ Authorization = "Bearer $token" } -Method Delete -ErrorAction Stop
+
+        return @{
+            Name      = $Name
+            VaultName = $VaultName
+            Id        = $response.recoveryId
+            Deleted   = $true
+        }
+    } catch {
+        if ($_.Exception.Message -match '404|NotFound') {
+            return @{
+                Name      = $Name
+                VaultName = $VaultName
+                Id        = $null
+                Deleted   = $false
+                Status    = 'NotFound'
+            }
+        }
+
+        Write-Error "Failed to delete secret '$Name' from vault '$VaultName': $($_.Exception.Message)"
+        throw
+    }
+}

--- a/Modules/CippExtensions/Public/Extension Functions/Remove-ExtensionAPIKey.ps1
+++ b/Modules/CippExtensions/Public/Extension Functions/Remove-ExtensionAPIKey.ps1
@@ -1,0 +1,33 @@
+function Remove-ExtensionAPIKey {
+    <#
+    .FUNCTIONALITY
+        Internal
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Extension
+    )
+
+    $Var = "Ext_$Extension"
+    if ($env:AzureWebJobsStorage -eq 'UseDevelopmentStorage=true' -or $env:NonLocalHostAzurite -eq 'true') {
+        $DevSecretsTable = Get-CIPPTable -tablename 'DevSecrets'
+        $DevSecretRows = Get-AzDataTableEntity @DevSecretsTable -Filter "PartitionKey eq '$Extension'"
+        if ($DevSecretRows) {
+            Remove-AzDataTableEntity @DevSecretsTable -Entity @($DevSecretRows) -Force -ErrorAction Stop
+            Write-Information "Deleted $(@($DevSecretRows).Count) DevSecrets row(s) for '$Extension'."
+        } else {
+            Write-Information "No existing DevSecrets row found for '$Extension' to delete."
+        }
+    } else {
+        $keyvaultname = ($env:WEBSITE_DEPLOYMENT_ID -split '-')[0]
+        try {
+            $null = Remove-CippKeyVaultSecret -VaultName $keyvaultname -Name $Extension
+        } catch {
+            Write-Warning "Unable to delete secret '$Extension' from '$keyvaultname'"
+        }
+    }
+
+    Remove-Item -Path "env:$Var" -Force -ErrorAction SilentlyContinue
+
+    return $true
+}


### PR DESCRIPTION
Introduce three new PowerShell functions to support removing extension API keys and Key Vault secrets:

- Invoke-ExecExtensionClearHIBPKey: HTTP entrypoint that clears the HIBP API key by calling Remove-ExtensionAPIKey and returns an HTTP response.
- Remove-CippKeyVaultSecret: Lightweight REST-based Key Vault secret deletion (no Az.KeyVault dependency). Derives vault name from WEBSITE_DEPLOYMENT_ID when not provided, obtains an AAD token via Get-CIPPAzIdentityToken, calls the Vault REST API, and returns deletion metadata; handles 404 not found and reports errors.
- Remove-ExtensionAPIKey: Removes extension API keys from a DevSecrets table when running with local Azurite/dev storage, or deletes the secret from Key Vault in production; clears the corresponding env variable and logs outcomes.

Adds error handling, informative logging, and safe behavior for local development vs production Key Vault usage.

UI: https://github.com/KelvinTegelaar/CIPP/pull/5703