### PR TITLE
Feat: Add standardized webhook schema support and authentication methods

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-CIPPOffboardingComplete.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-CIPPOffboardingComplete.ps1
@@ -107,7 +107,7 @@ function Push-CIPPOffboardingComplete {
 
             # Send post-execution alerts if configured
             if ($TaskInfo.PostExecution -and $ProcessedResults) {
-                Send-CIPPScheduledTaskAlert -Results $ProcessedResults -TaskInfo $TaskInfo -TenantFilter $TenantFilter
+                Send-CIPPScheduledTaskAlert -Results $ProcessedResults -TaskInfo $TaskInfo -TenantFilter $TenantFilter -TaskType 'User Offboarding'
             }
         }
         Write-LogMessage -API 'Offboarding' -tenant $TenantFilter -message "Offboarding completed for $Username" -sev Info -headers $Headers

--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-SchedulerCIPPNotifications.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Push-SchedulerCIPPNotifications.ps1
@@ -109,7 +109,8 @@ function Push-SchedulerCIPPNotifications {
         if (![string]::IsNullOrEmpty($config.webhook)) {
             if ($Currentlog) {
                 $JSONContent = $Currentlog | ConvertTo-Json -Compress
-                Send-CIPPAlert -Type 'webhook' -JSONContent $JSONContent -TenantFilter $Tenant -APIName 'Alerts'
+                $Title = "Logbook Notification: Alerts found starting at $((Get-Date).AddMinutes(-15))"
+                Send-CIPPAlert -Type 'webhook' -Title $Title -JSONContent $JSONContent -TenantFilter $Tenant -APIName 'Alerts' -SchemaSource 'Logbook Notification' -InvokingCommand 'Push-SchedulerCIPPNotifications' -UseStandardizedSchema:$([boolean]$Config.UseStandardizedSchema)
                 $UpdateLogs = $CurrentLog | ForEach-Object { $_.sentAsAlert = $true; $_ }
                 if ($UpdateLogs) { Add-CIPPAzDataTableEntity @Table -Entity $UpdateLogs -Force }
             }
@@ -118,7 +119,8 @@ function Push-SchedulerCIPPNotifications {
                 $Data = $CurrentStandardsLogs
                 $JSONContent = New-CIPPAlertTemplate -Data $Data -Format 'json' -InputObject 'table' -CIPPURL $CIPPURL
                 $CurrentStandardsLogs | ConvertTo-Json -Compress
-                Send-CIPPAlert -Type 'webhook' -JSONContent $JSONContent -TenantFilter $Tenant -APIName 'Alerts'
+                $Title = "Standards Notification: Out of sync standards detected"
+                Send-CIPPAlert -Type 'webhook' -Title $Title -JSONContent $JSONContent -TenantFilter $Tenant -APIName 'Alerts' -SchemaSource 'Standards Notification' -InvokingCommand 'Push-SchedulerCIPPNotifications' -UseStandardizedSchema:$([boolean]$Config.UseStandardizedSchema)
                 $updateStandards = $CurrentStandardsLogs | ForEach-Object {
                     if ($_.PSObject.Properties.Name -contains 'sentAsAlert') {
                         $_.sentAsAlert = $true

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ExecAddAlert.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ExecAddAlert.ps1
@@ -8,32 +8,18 @@ function Invoke-ExecAddAlert {
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
     $Headers = $Request.Headers
-
+    $TenantFilter = $Request.Body.tenantFilter ?? $env:TenantID
 
     $Severity = 'Alert'
 
     $Result = if ($Request.Body.sendEmailNow -or $Request.Body.sendWebhookNow -eq $true -or $Request.Body.writeLog -eq $true -or $Request.Body.sendPsaNow -eq $true) {
-        $sev = ([pscustomobject]$Request.body.Severity).value -join (',')
-        if ($Request.body.email -or $Request.body.webhook) {
-            Write-Host 'found config, setting'
-            $config = @{
-                email             = $Request.body.email
-                webhook           = $Request.body.webhook
-                onepertenant      = $Request.body.onePerTenant
-                logsToInclude     = $Request.body.logsToInclude
-                sendtoIntegration = $true
-                sev               = $sev
-            }
-            Write-Host "setting notification config to $($config | ConvertTo-Json)"
-            $Results = Set-cippNotificationConfig @Config
-            Write-Host $Results
-        }
         $Title = 'CIPP Notification Test'
         if ($Request.Body.sendEmailNow -eq $true) {
             $CIPPAlert = @{
                 Type        = 'email'
                 Title       = $Title
                 HTMLContent = $Request.Body.text
+                TenantFilter = $TenantFilter
             }
             Send-CIPPAlert @CIPPAlert
         }
@@ -46,6 +32,7 @@ function Invoke-ExecAddAlert {
                 Type        = 'webhook'
                 Title       = $Title
                 JSONContent = $JSONContent
+                TenantFilter = $TenantFilter
             }
             Send-CIPPAlert @CIPPAlert
         }
@@ -54,6 +41,7 @@ function Invoke-ExecAddAlert {
                 Type        = 'psa'
                 Title       = $Title
                 HTMLContent = $Request.Body.text
+                TenantFilter = $TenantFilter
             }
             Send-CIPPAlert @CIPPAlert
         }

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecNotificationConfig.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecNotificationConfig.ps1
@@ -9,12 +9,13 @@ Function Invoke-ExecNotificationConfig {
     param($Request, $TriggerMetadata)
     $sev = ([pscustomobject]$Request.body.Severity).value -join (',')
     $config = @{
-        email             = $Request.body.email
-        webhook           = $Request.body.webhook
-        onepertenant      = $Request.body.onePerTenant
-        logsToInclude     = $Request.body.logsToInclude
-        sendtoIntegration = $Request.body.sendtoIntegration
-        sev               = $sev
+        email                  = $Request.body.email
+        webhook                = $Request.body.webhook
+        onepertenant           = $Request.body.onePerTenant
+        logsToInclude          = $Request.body.logsToInclude
+        sendtoIntegration      = $Request.body.sendtoIntegration
+        UseStandardizedSchema  = [boolean]$Request.body.UseStandardizedSchema
+        sev                    = $sev
     }
     $Results = Set-cippNotificationConfig @Config
     $body = [pscustomobject]@{'Results' = $Results }

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecNotificationConfig.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecNotificationConfig.ps1
@@ -11,6 +11,13 @@ Function Invoke-ExecNotificationConfig {
     $config = @{
         email                  = $Request.body.email
         webhook                = $Request.body.webhook
+        webhookAuthType        = $Request.body.webhookAuthType.value
+        webhookAuthToken       = $Request.body.webhookAuthToken
+        webhookAuthUsername    = $Request.body.webhookAuthUsername
+        webhookAuthPassword    = $Request.body.webhookAuthPassword
+        webhookAuthHeaderName  = $Request.body.webhookAuthHeaderName
+        webhookAuthHeaderValue = $Request.body.webhookAuthHeaderValue
+        webhookAuthHeaders     = $Request.body.webhookAuthHeaders
         onepertenant           = $Request.body.onePerTenant
         logsToInclude          = $Request.body.logsToInclude
         sendtoIntegration      = $Request.body.sendtoIntegration

--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-ListNotificationConfig.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-ListNotificationConfig.ps1
@@ -16,7 +16,7 @@ Function Invoke-ListNotificationConfig {
         $Config = @{}
     }
     #$config | Add-Member -NotePropertyValue @() -NotePropertyName 'logsToInclude' -Force
-    $config.logsToInclude = @(([pscustomobject]$config | Select-Object * -ExcludeProperty schedule, type, tenantid, onepertenant, sendtoIntegration, partitionkey, rowkey, tenant, ETag, email, logsToInclude, Severity, Alert, Info, Error, timestamp, webhook, includeTenantId, UseStandardizedSchema).psobject.properties.name)
+    $config.logsToInclude = @(([pscustomobject]$config | Select-Object * -ExcludeProperty schedule, type, tenantid, onepertenant, sendtoIntegration, partitionkey, rowkey, tenant, ETag, email, logsToInclude, Severity, Alert, Info, Error, timestamp, webhook, includeTenantId, UseStandardizedSchema, webhookAuthType, webhookAuthToken, webhookAuthUsername, webhookAuthPassword, webhookAuthHeaderName, webhookAuthHeaderValue, webhookAuthHeaders).psobject.properties.name)
     if (!$config.logsToInclude) {
         $config.logsToInclude = @('None')
     }

--- a/Modules/CIPPCore/Public/Entrypoints/Invoke-ListNotificationConfig.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Invoke-ListNotificationConfig.ps1
@@ -16,7 +16,7 @@ Function Invoke-ListNotificationConfig {
         $Config = @{}
     }
     #$config | Add-Member -NotePropertyValue @() -NotePropertyName 'logsToInclude' -Force
-    $config.logsToInclude = @(([pscustomobject]$config | Select-Object * -ExcludeProperty schedule, type, tenantid, onepertenant, sendtoIntegration, partitionkey, rowkey, tenant, ETag, email, logsToInclude, Severity, Alert, Info, Error, timestamp, webhook, includeTenantId).psobject.properties.name)
+    $config.logsToInclude = @(([pscustomobject]$config | Select-Object * -ExcludeProperty schedule, type, tenantid, onepertenant, sendtoIntegration, partitionkey, rowkey, tenant, ETag, email, logsToInclude, Severity, Alert, Info, Error, timestamp, webhook, includeTenantId, UseStandardizedSchema).psobject.properties.name)
     if (!$config.logsToInclude) {
         $config.logsToInclude = @('None')
     }

--- a/Modules/CIPPCore/Public/New-CIPPStandardizedWebhookSchema.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPStandardizedWebhookSchema.ps1
@@ -1,0 +1,84 @@
+function New-CIPPStandardizedWebhookSchema {
+    <#
+    .SYNOPSIS
+        Builds a standardized webhook alert payload.
+
+    .DESCRIPTION
+        Converts legacy alert payloads (string/object/array) into a stable, versioned JSON schema
+        for webhook consumers.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Title,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TenantFilter,
+
+        [Parameter(Mandatory = $false)]
+        $Payload,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Source = 'CIPP',
+
+        [Parameter(Mandatory = $false)]
+        [string]$InvokingCommand
+    )
+
+    $NormalizedPayload = $null
+
+    if ($null -eq $Payload) {
+        $NormalizedPayload = [pscustomobject]@{}
+    } elseif ($Payload -is [string]) {
+        if (Test-Json -Json $Payload -ErrorAction SilentlyContinue) {
+            $NormalizedPayload = $Payload | ConvertFrom-Json -Depth 50
+        } else {
+            $NormalizedPayload = [pscustomobject]@{
+                message = $Payload
+            }
+        }
+    } else {
+        $NormalizedPayload = $Payload
+    }
+
+    $AlertCount = if ($NormalizedPayload -is [array]) { $NormalizedPayload.Count } else { 1 }
+
+    $DetectedInvokingCommand = $null
+
+    if ($NormalizedPayload -is [array] -and $NormalizedPayload.Count -gt 0) {
+        if ($NormalizedPayload[0].PSObject.Properties.Name -contains 'API') {
+            $ApiList = @($NormalizedPayload | Where-Object { $_.API } | Select-Object -ExpandProperty API -Unique)
+            if ($ApiList.Count -gt 0) {
+                $DetectedInvokingCommand = $ApiList -join ', '
+            }
+        }
+    } elseif ($NormalizedPayload -isnot [string] -and $null -ne $NormalizedPayload) {
+        if ($NormalizedPayload.PSObject.Properties.Name -contains 'task' -and $NormalizedPayload.task) {
+            if ($NormalizedPayload.task.PSObject.Properties.Name -contains 'command' -and $NormalizedPayload.task.command) {
+                $DetectedInvokingCommand = [string]$NormalizedPayload.task.command
+            }
+        }
+
+        if (-not $DetectedInvokingCommand -and $NormalizedPayload.PSObject.Properties.Name -contains 'TaskInfo' -and $NormalizedPayload.TaskInfo) {
+            if ($NormalizedPayload.TaskInfo.PSObject.Properties.Name -contains 'Command' -and $NormalizedPayload.TaskInfo.Command) {
+                $DetectedInvokingCommand = [string]$NormalizedPayload.TaskInfo.Command
+            }
+        }
+
+    }
+
+    $ResolvedInvokingCommand = if (![string]::IsNullOrWhiteSpace($InvokingCommand)) { $InvokingCommand } elseif ($DetectedInvokingCommand) { $DetectedInvokingCommand } else { $null }
+
+    $SchemaObject = [ordered]@{
+        schemaVersion = '1.0'
+        source        = $Source
+        invoking      = $ResolvedInvokingCommand
+        title         = $Title
+        tenant        = $TenantFilter
+        generatedAt   = [datetime]::UtcNow.ToString('o')
+        alertCount    = $AlertCount
+        payload       = $NormalizedPayload
+    }
+
+    return [pscustomobject]$SchemaObject
+}

--- a/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
+++ b/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
@@ -10,9 +10,12 @@ function Send-CIPPAlert {
         $altEmail,
         $altWebhook,
         $APIName = 'Send Alert',
+        $SchemaSource,
+        $InvokingCommand,
         $Headers,
         $TableName,
-        $RowKey = [string][guid]::NewGuid()
+        $RowKey = [string][guid]::NewGuid(),
+        [switch]$UseStandardizedSchema
     )
     Write-Information 'Shipping Alert'
     $Table = Get-CIPPTable -TableName SchedulerConfig
@@ -102,7 +105,13 @@ function Send-CIPPAlert {
         Write-Information 'Trying to send webhook'
 
         $ExtensionTable = Get-CIPPTable -TableName Extensionsconfig
-        $Configuration = ((Get-CIPPAzDataTableEntity @ExtensionTable).config | ConvertFrom-Json)
+        $ExtensionConfig = Get-CIPPAzDataTableEntity @ExtensionTable
+        # Check if config exists and is not null before parsing
+        if ($ExtensionConfig.config -and -not [string]::IsNullOrWhiteSpace($ExtensionConfig.config)) {
+            $Configuration = $ExtensionConfig.config | ConvertFrom-Json
+        } else {
+            $Configuration = $null
+        }
 
         if ($Configuration.CFZTNA.WebhookEnabled -eq $true -and $Configuration.CFZTNA.Enabled -eq $true) {
             $CFAPIKey = Get-ExtensionAPIKey -Extension 'CFZTNA'
@@ -112,34 +121,75 @@ function Send-CIPPAlert {
             $Headers = $null
         }
 
-        $ReplacedContent = Get-CIPPTextReplacement -TenantFilter $TenantFilter -Text $JSONContent -EscapeForJson
+        $UseStandardizedWebhookSchema = [boolean]$Config.UseStandardizedSchema
+        if ($PSBoundParameters.ContainsKey('UseStandardizedSchema')) {
+            $UseStandardizedWebhookSchema = [boolean]$UseStandardizedSchema
+        }
+
+        $EffectiveTitle = if ([string]::IsNullOrWhiteSpace($Title)) {
+            '{0} - {1} - Webhook Alert' -f $APIName, $TenantFilter
+        } else {
+            $Title
+        }
+
+        $EffectiveSchemaSource = if (![string]::IsNullOrWhiteSpace($SchemaSource)) {
+            $SchemaSource
+        } elseif (![string]::IsNullOrWhiteSpace($APIName)) {
+            $APIName
+        } else {
+            'CIPP'
+        }
+
+        $WebhookContent = if ($UseStandardizedWebhookSchema) {
+            New-CIPPStandardizedWebhookSchema -Title $EffectiveTitle -TenantFilter $TenantFilter -Payload $JSONContent -Source $EffectiveSchemaSource -InvokingCommand $InvokingCommand
+        } else {
+            $JSONContent
+        }
+
+        if ($WebhookContent -isnot [string]) {
+            $WebhookContent = $WebhookContent | ConvertTo-Json -Compress -Depth 50
+        }
+
+        $ReplacedContent = Get-CIPPTextReplacement -TenantFilter $TenantFilter -Text $WebhookContent -EscapeForJson
         try {
             if (![string]::IsNullOrWhiteSpace($Config.webhook) -or ![string]::IsNullOrWhiteSpace($AltWebhook)) {
-                if ($PSCmdlet.ShouldProcess($Config.webhook, 'Sending webhook')) {
-                    $webhook = if ($AltWebhook) { $AltWebhook } else { $Config.webhook }
+                $webhook = if ($AltWebhook) { $AltWebhook } else { $Config.webhook }
+                if ($PSCmdlet.ShouldProcess($webhook, 'Sending webhook')) {
                     switch -wildcard ($webhook) {
                         '*webhook.office.com*' {
-                            $TeamsBody = [PSCustomObject]@{
-                                text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. <br><br>$ReplacedContent"
-                            } | ConvertTo-Json -Compress
-                            $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $TeamsBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                            if ($UseStandardizedWebhookSchema) {
+                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $ReplacedContent -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                            } else {
+                                $TeamsBody = [PSCustomObject]@{
+                                    text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. <br><br>$ReplacedContent"
+                                } | ConvertTo-Json -Compress
+                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $TeamsBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                            }
                         }
                         '*discord.com*' {
-                            $DiscordBody = [PSCustomObject]@{
-                                content = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
-                            } | ConvertTo-Json -Compress
-                            $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $DiscordBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                            if ($UseStandardizedWebhookSchema) {
+                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $ReplacedContent -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                            } else {
+                                $DiscordBody = [PSCustomObject]@{
+                                    content = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
+                                } | ConvertTo-Json -Compress
+                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $DiscordBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                            }
                         }
                         '*slack.com*' {
-                            $SlackBlocks = Get-SlackAlertBlocks -JSONBody $JSONContent
-                            if ($SlackBlocks.blocks) {
-                                $SlackBody = $SlackBlocks | ConvertTo-Json -Depth 10 -Compress
+                            if ($UseStandardizedWebhookSchema) {
+                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $ReplacedContent -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
                             } else {
-                                $SlackBody = [PSCustomObject]@{
-                                    text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
-                                } | ConvertTo-Json -Compress
+                                $SlackBlocks = Get-SlackAlertBlocks -JSONBody $JSONContent
+                                if ($SlackBlocks.blocks) {
+                                    $SlackBody = $SlackBlocks | ConvertTo-Json -Depth 10 -Compress
+                                } else {
+                                    $SlackBody = [PSCustomObject]@{
+                                        text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
+                                    } | ConvertTo-Json -Compress
+                                }
+                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $SlackBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
                             }
-                            $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $SlackBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
                         }
                         default {
                             $RestMethod = @{

--- a/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
+++ b/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
@@ -104,6 +104,79 @@ function Send-CIPPAlert {
     if ($Type -eq 'webhook') {
         Write-Information 'Trying to send webhook'
 
+        $GetWebhookSecret = {
+            param(
+                [string]$SecretName
+            )
+
+            if ($env:AzureWebJobsStorage -eq 'UseDevelopmentStorage=true' -or $env:NonLocalHostAzurite -eq 'true') {
+                $DevSecretsTable = Get-CIPPTable -tablename 'DevSecrets'
+                return (Get-CIPPAzDataTableEntity @DevSecretsTable -Filter "PartitionKey eq '$SecretName' and RowKey eq '$SecretName'").APIKey
+            }
+
+            $KeyVaultName = ($env:WEBSITE_DEPLOYMENT_ID -split '-')[0]
+            return (Get-CippKeyVaultSecret -VaultName $KeyVaultName -Name $SecretName -AsPlainText)
+        }
+
+        $RequestHeaders = @{}
+        if ($Headers -is [hashtable]) {
+            foreach ($HeaderName in $Headers.Keys) {
+                $RequestHeaders[$HeaderName] = $Headers[$HeaderName]
+            }
+        }
+
+        $WebhookAuthType = [string]$Config.webhookAuthType
+        switch ($WebhookAuthType.ToLowerInvariant()) {
+            'bearer' {
+                $WebhookAuthToken = [string]$Config.webhookAuthToken
+                if ($WebhookAuthToken -eq 'SentToKeyVault') {
+                    $WebhookAuthToken = & $GetWebhookSecret -SecretName 'CIPPNotificationsWebhookAuthToken'
+                }
+                if (![string]::IsNullOrWhiteSpace($WebhookAuthToken)) {
+                    $RequestHeaders['Authorization'] = "Bearer $WebhookAuthToken"
+                }
+            }
+            'basic' {
+                $WebhookAuthPassword = [string]$Config.webhookAuthPassword
+                if ($WebhookAuthPassword -eq 'SentToKeyVault') {
+                    $WebhookAuthPassword = & $GetWebhookSecret -SecretName 'CIPPNotificationsWebhookAuthPassword'
+                }
+                if (![string]::IsNullOrWhiteSpace($Config.webhookAuthUsername) -and ![string]::IsNullOrWhiteSpace($WebhookAuthPassword)) {
+                    $BasicAuthBytes = [System.Text.Encoding]::UTF8.GetBytes("$($Config.webhookAuthUsername):$WebhookAuthPassword")
+                    $RequestHeaders['Authorization'] = 'Basic {0}' -f [System.Convert]::ToBase64String($BasicAuthBytes)
+                }
+            }
+            'apikey' {
+                $WebhookAuthHeaderValue = [string]$Config.webhookAuthHeaderValue
+                if ($WebhookAuthHeaderValue -eq 'SentToKeyVault') {
+                    $WebhookAuthHeaderValue = & $GetWebhookSecret -SecretName 'CIPPNotificationsWebhookAuthHeaderValue'
+                }
+                if (![string]::IsNullOrWhiteSpace($Config.webhookAuthHeaderName) -and ![string]::IsNullOrWhiteSpace($WebhookAuthHeaderValue)) {
+                    $RequestHeaders[$Config.webhookAuthHeaderName] = $WebhookAuthHeaderValue
+                }
+            }
+            'customheaders' {
+                $WebhookAuthHeaders = [string]$Config.webhookAuthHeaders
+                if ($WebhookAuthHeaders -eq 'SentToKeyVault') {
+                    $WebhookAuthHeaders = & $GetWebhookSecret -SecretName 'CIPPNotificationsWebhookAuthHeaders'
+                }
+                if (![string]::IsNullOrWhiteSpace($WebhookAuthHeaders)) {
+                    try {
+                        $CustomHeaders = $WebhookAuthHeaders | ConvertFrom-Json -AsHashtable
+                        if ($CustomHeaders -is [hashtable]) {
+                            foreach ($HeaderName in $CustomHeaders.Keys) {
+                                if (![string]::IsNullOrWhiteSpace([string]$HeaderName)) {
+                                    $RequestHeaders[[string]$HeaderName] = [string]$CustomHeaders[$HeaderName]
+                                }
+                            }
+                        }
+                    } catch {
+                        Write-LogMessage -API 'Webhook Alerts' -message 'Webhook custom headers JSON is invalid. Continuing without custom auth headers.' -tenant $TenantFilter -sev warning
+                    }
+                }
+            }
+        }
+
         $ExtensionTable = Get-CIPPTable -TableName Extensionsconfig
         $ExtensionConfig = Get-CIPPAzDataTableEntity @ExtensionTable
         # Check if config exists and is not null before parsing
@@ -115,10 +188,9 @@ function Send-CIPPAlert {
 
         if ($Configuration.CFZTNA.WebhookEnabled -eq $true -and $Configuration.CFZTNA.Enabled -eq $true) {
             $CFAPIKey = Get-ExtensionAPIKey -Extension 'CFZTNA'
-            $Headers = @{'CF-Access-Client-Id' = $Configuration.CFZTNA.ClientId; 'CF-Access-Client-Secret' = "$CFAPIKey" }
+            $RequestHeaders['CF-Access-Client-Id'] = $Configuration.CFZTNA.ClientId
+            $RequestHeaders['CF-Access-Client-Secret'] = "$CFAPIKey"
             Write-Information 'CF-Access-Client-Id and CF-Access-Client-Secret headers added to webhook API request'
-        } else {
-            $Headers = $null
         }
 
         $UseStandardizedWebhookSchema = [boolean]$Config.UseStandardizedSchema
@@ -155,30 +227,45 @@ function Send-CIPPAlert {
             if (![string]::IsNullOrWhiteSpace($Config.webhook) -or ![string]::IsNullOrWhiteSpace($AltWebhook)) {
                 $webhook = if ($AltWebhook) { $AltWebhook } else { $Config.webhook }
                 if ($PSCmdlet.ShouldProcess($webhook, 'Sending webhook')) {
+                    $RestMethod = @{
+                        Uri                = $webhook
+                        Method             = 'POST'
+                        ContentType        = 'application/json'
+                        StatusCodeVariable = 'WebhookStatusCode'
+                        SkipHttpErrorCheck = $true
+                    }
+                    if ($RequestHeaders.Count -gt 0) {
+                        $RestMethod['Headers'] = $RequestHeaders
+                    }
                     switch -wildcard ($webhook) {
                         '*webhook.office.com*' {
                             if ($UseStandardizedWebhookSchema) {
-                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $ReplacedContent -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                                $RestMethod['Body'] = $ReplacedContent
+                                $WebhookResponse = Invoke-RestMethod @RestMethod
                             } else {
                                 $TeamsBody = [PSCustomObject]@{
                                     text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. <br><br>$ReplacedContent"
                                 } | ConvertTo-Json -Compress
-                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $TeamsBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                                $RestMethod['Body'] = $TeamsBody
+                                $WebhookResponse = Invoke-RestMethod @RestMethod
                             }
                         }
                         '*discord.com*' {
                             if ($UseStandardizedWebhookSchema) {
-                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $ReplacedContent -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                                $RestMethod['Body'] = $ReplacedContent
+                                $WebhookResponse = Invoke-RestMethod @RestMethod
                             } else {
                                 $DiscordBody = [PSCustomObject]@{
                                     content = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
                                 } | ConvertTo-Json -Compress
-                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $DiscordBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                                $RestMethod['Body'] = $DiscordBody
+                                $WebhookResponse = Invoke-RestMethod @RestMethod
                             }
                         }
                         '*slack.com*' {
                             if ($UseStandardizedWebhookSchema) {
-                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $ReplacedContent -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                                $RestMethod['Body'] = $ReplacedContent
+                                $WebhookResponse = Invoke-RestMethod @RestMethod
                             } else {
                                 $SlackBlocks = Get-SlackAlertBlocks -JSONBody $JSONContent
                                 if ($SlackBlocks.blocks) {
@@ -188,21 +275,12 @@ function Send-CIPPAlert {
                                         text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
                                     } | ConvertTo-Json -Compress
                                 }
-                                $WebhookResponse = Invoke-RestMethod -Uri $webhook -Method POST -ContentType 'Application/json' -Body $SlackBody -StatusCodeVariable WebhookStatusCode -SkipHttpErrorCheck
+                                $RestMethod['Body'] = $SlackBody
+                                $WebhookResponse = Invoke-RestMethod @RestMethod
                             }
                         }
                         default {
-                            $RestMethod = @{
-                                Uri                = $webhook
-                                Method             = 'POST'
-                                ContentType        = 'application/json'
-                                Body               = $ReplacedContent
-                                StatusCodeVariable = 'WebhookStatusCode'
-                                SkipHttpErrorCheck = $true
-                            }
-                            if ($Headers) {
-                                $RestMethod['Headers'] = $Headers
-                            }
+                            $RestMethod['Body'] = $ReplacedContent
                             $WebhookResponse = Invoke-RestMethod @RestMethod
                         }
                     }

--- a/Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1
+++ b/Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1
@@ -71,6 +71,11 @@ function Send-CIPPScheduledTaskAlert {
 
         Write-Information 'Scheduler: Sending the results to configured targets.'
 
+        $NotificationTable = Get-CIPPTable -TableName SchedulerConfig
+        $NotificationFilter = "RowKey eq 'CippNotifications' and PartitionKey eq 'CippNotifications'"
+        $NotificationConfig = [pscustomobject](Get-CIPPAzDataTableEntity @NotificationTable -Filter $NotificationFilter)
+        $UseStandardizedSchema = [boolean]$NotificationConfig.UseStandardizedSchema
+
         # Send to configured alert targets
         switch -wildcard ($TaskInfo.PostExecution) {
             '*psa*' {
@@ -80,14 +85,34 @@ function Send-CIPPScheduledTaskAlert {
                 Send-CIPPAlert -Type 'email' -Title $title -HTMLContent $HTML -TenantFilter $TenantFilter
             }
             '*webhook*' {
-                $Webhook = [PSCustomObject]@{
-                    'tenantId'     = $TenantInfo.customerId
-                    'Tenant'       = $TenantFilter
-                    'TaskInfo'     = $TaskInfo
-                    'Results'      = $Results
-                    'AlertComment' = $TaskInfo.AlertComment
+                $Webhook = if ($UseStandardizedSchema) {
+                    [PSCustomObject]@{
+                        tenantId     = $TenantInfo.customerId
+                        tenant       = $TenantFilter
+                        taskType     = $TaskType
+                        task         = [PSCustomObject]@{
+                            id         = $TaskInfo.RowKey
+                            name       = $TaskInfo.Name
+                            command    = $TaskInfo.Command
+                            state      = $TaskInfo.TaskState
+                            reference  = $TaskInfo.Reference
+                            scheduled  = $TaskInfo.ScheduledTime
+                            executed   = $TaskInfo.ExecutedTime
+                            partition  = $TaskInfo.PartitionKey
+                        }
+                        results      = $Results
+                        alertComment = $TaskInfo.AlertComment
+                    }
+                } else {
+                    [PSCustomObject]@{
+                        tenantId     = $TenantInfo.customerId
+                        Tenant       = $TenantFilter
+                        TaskInfo     = $TaskInfo
+                        Results      = $Results
+                        AlertComment = $TaskInfo.AlertComment
+                    }
                 }
-                Send-CIPPAlert -Type 'webhook' -Title $title -TenantFilter $TenantFilter -JSONContent $($Webhook | ConvertTo-Json -Depth 20)
+                Send-CIPPAlert -Type 'webhook' -Title $title -TenantFilter $TenantFilter -JSONContent $($Webhook | ConvertTo-Json -Depth 20) -APIName 'Scheduled Task Alerts' -SchemaSource $TaskType -InvokingCommand $TaskInfo.Command -UseStandardizedSchema:$UseStandardizedSchema
             }
         }
 

--- a/Modules/CIPPCore/Public/Set-CIPPNotificationConfig.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPNotificationConfig.ps1
@@ -7,24 +7,26 @@ function Set-CIPPNotificationConfig {
         $logsToInclude,
         $sendtoIntegration,
         $sev,
+        [boolean]$UseStandardizedSchema,
         $APIName = 'Set Notification Config'
     )
 
-    $results = try {
+    try {
         $Table = Get-CIPPTable -TableName SchedulerConfig
         $SchedulerConfig = @{
-            'tenant'            = 'Any'
-            'tenantid'          = 'TenantId'
-            'type'              = 'CIPPNotifications'
-            'schedule'          = 'Every 15 minutes'
-            'Severity'          = [string]$sev
-            'email'             = "$($email)"
-            'webhook'           = "$($webhook)"
-            'onePerTenant'      = [boolean]$onePerTenant
-            'sendtoIntegration' = [boolean]$sendtoIntegration
-            'includeTenantId'   = $true
-            'PartitionKey'      = 'CippNotifications'
-            'RowKey'            = 'CippNotifications'
+            'tenant'                 = 'Any'
+            'tenantid'               = 'TenantId'
+            'type'                   = 'CIPPNotifications'
+            'schedule'               = 'Every 15 minutes'
+            'Severity'               = [string]$sev
+            'email'                  = "$($email)"
+            'webhook'                = "$($webhook)"
+            'onePerTenant'           = [boolean]$onePerTenant
+            'sendtoIntegration'      = [boolean]$sendtoIntegration
+            'UseStandardizedSchema'  = [boolean]$UseStandardizedSchema
+            'includeTenantId'        = $true
+            'PartitionKey'           = 'CippNotifications'
+            'RowKey'                 = 'CippNotifications'
         }
         foreach ($logvalue in [pscustomobject]$logsToInclude) {
             $SchedulerConfig[([pscustomobject]$logvalue.value)] = $true

--- a/Modules/CIPPCore/Public/Set-CIPPNotificationConfig.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPNotificationConfig.ps1
@@ -3,6 +3,13 @@ function Set-CIPPNotificationConfig {
     param (
         $email,
         $webhook,
+        $webhookAuthType,
+        $webhookAuthToken,
+        $webhookAuthUsername,
+        $webhookAuthPassword,
+        $webhookAuthHeaderName,
+        $webhookAuthHeaderValue,
+        $webhookAuthHeaders,
         $onepertenant,
         $logsToInclude,
         $sendtoIntegration,
@@ -13,6 +20,50 @@ function Set-CIPPNotificationConfig {
 
     try {
         $Table = Get-CIPPTable -TableName SchedulerConfig
+        $ExistingConfig = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'CippNotifications' and RowKey eq 'CippNotifications'"
+
+        $StoreWebhookSecret = {
+            param(
+                [string]$SecretName,
+                [string]$SecretValue
+            )
+
+            if ($env:AzureWebJobsStorage -eq 'UseDevelopmentStorage=true' -or $env:NonLocalHostAzurite -eq 'true') {
+                $DevSecretsTable = Get-CIPPTable -tablename 'DevSecrets'
+                $Secret = [PSCustomObject]@{
+                    'PartitionKey' = $SecretName
+                    'RowKey'       = $SecretName
+                    'APIKey'       = $SecretValue
+                }
+                Add-CIPPAzDataTableEntity @DevSecretsTable -Entity $Secret -Force | Out-Null
+            } else {
+                $KeyVaultName = ($env:WEBSITE_DEPLOYMENT_ID -split '-')[0]
+                Set-CippKeyVaultSecret -VaultName $KeyVaultName -Name $SecretName -SecretValue (ConvertTo-SecureString -AsPlainText -Force -String $SecretValue) | Out-Null
+            }
+        }
+
+        $WebhookSecretMap = @(
+            @{ Field = 'webhookAuthToken'; SecretName = 'CIPPNotificationsWebhookAuthToken'; Value = [string]$webhookAuthToken }
+            @{ Field = 'webhookAuthPassword'; SecretName = 'CIPPNotificationsWebhookAuthPassword'; Value = [string]$webhookAuthPassword }
+            @{ Field = 'webhookAuthHeaderValue'; SecretName = 'CIPPNotificationsWebhookAuthHeaderValue'; Value = [string]$webhookAuthHeaderValue }
+            @{ Field = 'webhookAuthHeaders'; SecretName = 'CIPPNotificationsWebhookAuthHeaders'; Value = [string]$webhookAuthHeaders }
+        )
+
+        $WebhookSecretMarkers = @{}
+        foreach ($SecretInfo in $WebhookSecretMap) {
+            $IncomingValue = [string]$SecretInfo.Value
+            $ExistingValue = [string]$ExistingConfig.($SecretInfo.Field)
+
+            if (![string]::IsNullOrWhiteSpace($IncomingValue) -and $IncomingValue -ne 'SentToKeyVault') {
+                & $StoreWebhookSecret -SecretName $SecretInfo.SecretName -SecretValue $IncomingValue
+                $WebhookSecretMarkers[$SecretInfo.Field] = 'SentToKeyVault'
+            } elseif ($IncomingValue -eq 'SentToKeyVault' -or $ExistingValue -eq 'SentToKeyVault') {
+                $WebhookSecretMarkers[$SecretInfo.Field] = 'SentToKeyVault'
+            } else {
+                $WebhookSecretMarkers[$SecretInfo.Field] = ''
+            }
+        }
+
         $SchedulerConfig = @{
             'tenant'                 = 'Any'
             'tenantid'               = 'TenantId'
@@ -21,6 +72,13 @@ function Set-CIPPNotificationConfig {
             'Severity'               = [string]$sev
             'email'                  = "$($email)"
             'webhook'                = "$($webhook)"
+            'webhookAuthType'        = "$($webhookAuthType)"
+            'webhookAuthToken'       = "$($WebhookSecretMarkers.webhookAuthToken)"
+            'webhookAuthUsername'    = "$($webhookAuthUsername)"
+            'webhookAuthPassword'    = "$($WebhookSecretMarkers.webhookAuthPassword)"
+            'webhookAuthHeaderName'  = "$($webhookAuthHeaderName)"
+            'webhookAuthHeaderValue' = "$($WebhookSecretMarkers.webhookAuthHeaderValue)"
+            'webhookAuthHeaders'     = "$($WebhookSecretMarkers.webhookAuthHeaders)"
             'onePerTenant'           = [boolean]$onePerTenant
             'sendtoIntegration'      = [boolean]$sendtoIntegration
             'UseStandardizedSchema'  = [boolean]$UseStandardizedSchema

--- a/Modules/CIPPCore/Public/Webhooks/Invoke-CIPPWebhookProcessing.ps1
+++ b/Modules/CIPPCore/Public/Webhooks/Invoke-CIPPWebhookProcessing.ps1
@@ -144,6 +144,9 @@ function Invoke-CippWebhookProcessing {
                     Title        = $GenerateJSON.Title
                     JSONContent  = $JsonContent
                     TenantFilter = $TenantFilter
+                    APIName      = 'Audit Log Alerts'
+                    SchemaSource = 'Audit Log Alert'
+                    InvokingCommand = 'Start-AuditLogProcessingOrchestrator'
                 }
                 Write-Host 'Sending Webhook Content'
                 Send-CIPPAlert @CippAlert


### PR DESCRIPTION
This pull request introduces significant enhancements to the alerting and notification system, focusing on improved webhook support, standardized payload schemas, and expanded configuration options for webhook authentication. The changes aim to make webhook integrations more flexible, secure, and easier to consume for downstream systems.

**Key improvements include:**
- Introduction of a standardized webhook payload schema for consistent alert delivery.
- Expanded support for various webhook authentication methods, including secrets retrieval from Azure Key Vault.
- Additional configuration options for notification settings, including schema usage and custom headers.
- Updates to alert-sending logic to leverage new schema and authentication features.

### Standardized Webhook Schema Support
* Added the `New-CIPPStandardizedWebhookSchema` function to generate a stable, versioned JSON schema for webhook alerts, ensuring consistent payloads for consumers.
* Updated `Send-CIPPAlert` to support a `-UseStandardizedSchema` switch, generating and sending standardized payloads for webhooks when enabled. [[1]](diffhunk://#diff-bc6e0d2ff2ecb8a1c2e819169a3d3b7663f3e49f6616171e8311c22aa34bf442R13-R18) [[2]](diffhunk://#diff-bc6e0d2ff2ecb8a1c2e819169a3d3b7663f3e49f6616171e8311c22aa34bf442R107-R269)

### Webhook Authentication Enhancements
* Extended notification configuration to support multiple webhook authentication types (Bearer, Basic, API Key, custom headers), with support for retrieving secrets from Azure Key Vault or development storage. [[1]](diffhunk://#diff-0d2db73f927d93615add2647cdb47bc8695f6092c2275c24787682a08cf44e98R14-R24) [[2]](diffhunk://#diff-bc6e0d2ff2ecb8a1c2e819169a3d3b7663f3e49f6616171e8311c22aa34bf442R107-R269)
* Modified `Send-CIPPAlert` to dynamically build request headers based on the configured authentication method, including error handling for malformed custom headers.

### Notification Configuration and Delivery Updates
* Added new configuration fields (`UseStandardizedSchema`, webhook auth fields) to notification config objects and ensured they are handled in config listing and setting functions. [[1]](diffhunk://#diff-0d2db73f927d93615add2647cdb47bc8695f6092c2275c24787682a08cf44e98R14-R24) [[2]](diffhunk://#diff-5935bf8134715b7da8a6a01b1d732fa97a02f2b90865ce30d1cd73aefafcd3ceL19-R19)
* Updated alert-sending logic in various entrypoints to pass new parameters (e.g., `TenantFilter`, `Title`, `SchemaSource`, `InvokingCommand`, `UseStandardizedSchema`) to `Send-CIPPAlert`. [[1]](diffhunk://#diff-1bfade26dc62263ceeb71b029d7b9bdced397b24046eb5b6ad5557b7a8bf982dL110-R110) [[2]](diffhunk://#diff-c2f9cd031938c1979288bc280c20aa02b3a28573f2d9d7b01621b79b1ba5a26fL112-R113) [[3]](diffhunk://#diff-c2f9cd031938c1979288bc280c20aa02b3a28573f2d9d7b01621b79b1ba5a26fL121-R123) [[4]](diffhunk://#diff-e483db11e7556354f2f1266e4e13d3d5606539b589b5eb8719b077db21810ec2L11-R22) [[5]](diffhunk://#diff-e483db11e7556354f2f1266e4e13d3d5606539b589b5eb8719b077db21810ec2R35) [[6]](diffhunk://#diff-e483db11e7556354f2f1266e4e13d3d5606539b589b5eb8719b077db21810ec2R44)

### Webhook Platform Compatibility
* Enhanced webhook delivery logic in `Send-CIPPAlert` to send either standardized or legacy payloads, with platform-specific formatting for Teams, Discord, and Slack webhooks. [[1]](diffhunk://#diff-bc6e0d2ff2ecb8a1c2e819169a3d3b7663f3e49f6616171e8311c22aa34bf442R107-R269) [[2]](diffhunk://#diff-bc6e0d2ff2ecb8a1c2e819169a3d3b7663f3e49f6616171e8311c22aa34bf442L142-R283)

These changes collectively improve the robustness, interoperability, and security of the alerting system, making it easier to integrate with a wide range of webhook consumers and authentication scenarios.Introduce an opt-in, versioned webhook schema and plumbing to emit it. Adds New-CIPPStandardizedWebhookSchema to normalize legacy payloads. Send-CIPPAlert gains SchemaSource, InvokingCommand and UseStandardizedSchema handling, builds/serializes standardized payloads and adapts Teams/Discord/Slack sends accordingly; also hardens extension config parsing. Notification config endpoints (Invoke-ExecNotificationConfig, Set-CIPPNotificationConfig, Invoke-ListNotificationConfig) now expose/handle UseStandardizedSchema. Callers (scheduler notifications, scheduled task alerts, webhook processing, offboarding) are updated to send titles, schema source, invoking command and the standardized flag where appropriate.

Resolves: https://github.com/KelvinTegelaar/CIPP/issues/3884
UI: https://github.com/KelvinTegelaar/CIPP/pull/5705