### PR TITLE
Add litigation/retention mailbox fields

### DIFF
--- a/Modules/CIPPCore/Public/Set-CIPPDBCacheMailboxes.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPDBCacheMailboxes.ps1
@@ -26,7 +26,7 @@ function Set-CIPPDBCacheMailboxes {
         Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Caching mailboxes' -sev Debug
 
         # Get mailboxes with select properties
-        $Select = 'id,ExchangeGuid,ArchiveGuid,UserPrincipalName,DisplayName,PrimarySMTPAddress,RecipientType,RecipientTypeDetails,EmailAddresses,WhenSoftDeleted,IsInactiveMailbox,ForwardingSmtpAddress,DeliverToMailboxAndForward,ForwardingAddress,HiddenFromAddressListsEnabled,ExternalDirectoryObjectId,MessageCopyForSendOnBehalfEnabled,MessageCopyForSentAsEnabled,GrantSendOnBehalfTo'
+        $Select = 'id,ExchangeGuid,ArchiveGuid,UserPrincipalName,DisplayName,PrimarySMTPAddress,RecipientType,RecipientTypeDetails,EmailAddresses,WhenSoftDeleted,IsInactiveMailbox,ForwardingSmtpAddress,DeliverToMailboxAndForward,ForwardingAddress,HiddenFromAddressListsEnabled,ExternalDirectoryObjectId,MessageCopyForSendOnBehalfEnabled,MessageCopyForSentAsEnabled,GrantSendOnBehalfTo,PersistedCapabilities,LitigationHoldEnabled,LitigationHoldDate,LitigationHoldDuration,ComplianceTagHoldApplied,RetentionHoldEnabled,InPlaceHolds,RetentionPolicy'
         $ExoRequest = @{
             tenantid  = $TenantFilter
             cmdlet    = 'Get-Mailbox'
@@ -52,6 +52,14 @@ function Set-CIPPDBCacheMailboxes {
                     ExternalDirectoryObjectId,
                     MessageCopyForSendOnBehalfEnabled,
                     MessageCopyForSentAsEnabled,
+                    LitigationHoldEnabled,
+                    LitigationHoldDate,
+                    LitigationHoldDuration,
+                    @{ Name = 'LicensedForLitigationHold'; Expression = { ($_.PersistedCapabilities -contains 'EXCHANGE_S_ARCHIVE_ADDON' -or $_.PersistedCapabilities -contains 'BPOS_S_ArchiveAddOn' -or $_.PersistedCapabilities -contains 'EXCHANGE_S_ENTERPRISE' -or $_.PersistedCapabilities -contains 'BPOS_S_DlpAddOn' -or $_.PersistedCapabilities -contains 'BPOS_S_Enterprise') } },
+                    ComplianceTagHoldApplied,
+                    RetentionHoldEnabled,
+                    InPlaceHolds,
+                    RetentionPolicy,
                     GrantSendOnBehalfTo))
         }
 


### PR DESCRIPTION
Expand mailbox properties cached by Set-CIPPDBCacheMailboxes to include litigation hold, retention, and compliance-related attributes. The Get-Mailbox select list and Select-Object output were updated to include PersistedCapabilities, LitigationHoldEnabled/Date/Duration, a computed LicensedForLitigationHold (from PersistedCapabilities), ComplianceTagHoldApplied, RetentionHoldEnabled, InPlaceHolds, and RetentionPolicy

Fixes issues where you were no longer able to set these actions due to missing values: Enable Auto-Expanding Archive
Set Litigation Hold
Enable Online Archive