### PR TITLE
Add app and service principal expiry checks

### DIFF
--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertAppCertificateExpiry.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertAppCertificateExpiry.ps1
@@ -11,23 +11,55 @@ function Get-CIPPAlertAppCertificateExpiry {
         $TenantFilter
     )
 
+    $Now = Get-Date
+    $AlertData = @()
+
     try {
-        Write-Host "Checking app expire for $($TenantFilter)"
-        $appList = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/applications?`$select=appId,displayName,keyCredentials" -tenantid $TenantFilter
+        $appList = New-CIPPDbRequest -TenantFilter $TenantFilter -Type 'Apps'
     } catch {
-        return
+        $appList = @()
     }
 
-    $AlertData = foreach ($App in $applist) {
-        Write-Host "checking $($App.displayName)"
+    $AppAlertData = foreach ($App in $appList) {
         if ($App.keyCredentials) {
             foreach ($Credential in $App.keyCredentials) {
-                if ($Credential.endDateTime -lt (Get-Date).AddDays(30) -and $Credential.endDateTime -gt (Get-Date).AddDays(-7)) {
-                    Write-Host ("Application '{0}' has certificates expiring on {1}" -f $App.displayName, $Credential.endDateTime)
-                    @{ DisplayName = $App.displayName; Expires = $Credential.endDateTime }
+                if ($Credential.endDateTime -lt $Now.AddDays(30) -and $Credential.endDateTime -gt $Now.AddDays(-7)) {
+                    @{
+                        DisplayName = $App.displayName
+                        Expires     = $Credential.endDateTime
+                        AppId       = $App.appId
+                        Type        = 'Application'
+                    }
                 }
             }
         }
     }
+
+    try {
+        $servicePrincipals = New-CIPPDbRequest -TenantFilter $TenantFilter -Type 'ServicePrincipals'
+    } catch {
+        $servicePrincipals = @()
+    }
+
+    $SamlAlertData = foreach ($ServicePrincipal in $servicePrincipals) {
+        $ExpiryDate = $null
+        if ($ServicePrincipal.preferredTokenSigningKeyEndDateTime) {
+            $ExpiryDate = [datetime]$ServicePrincipal.preferredTokenSigningKeyEndDateTime
+        }
+        if ($ExpiryDate -and $ExpiryDate -lt $Now.AddDays(30) -and $ExpiryDate -gt $Now.AddDays(-7)) {
+            @{
+                DisplayName        = $ServicePrincipal.displayName
+                Expires            = $ExpiryDate
+                AppId              = $ServicePrincipal.appId
+                ServicePrincipalId = $ServicePrincipal.id
+                Type               = 'SamlServicePrincipal'
+            }
+        }
+    }
+
+    $AlertData = @(
+        @($AppAlertData)
+        @($SamlAlertData)
+    ) | Where-Object { $null -ne $_ }
     Write-AlertTrace -cmdletName $MyInvocation.MyCommand -tenantFilter $TenantFilter -data $AlertData
 }


### PR DESCRIPTION
Replace direct Graph query with New-CIPPDbRequest for Applications and ServicePrincipals, and centralize current time in $Now. Collect application certificate expiries (including appId and Type) and add checks for service principal SAML token signing key expiries (preferredTokenSigningKeyEndDateTime). Handle request failures by falling back to empty lists, merge app and SP results into a single $AlertData array, and emit trace via Write-AlertTrace. Also adjust date filtering logic and enrich returned objects with identifying fields.

Fixes: https://github.com/KelvinTegelaar/CIPP/issues/5720