### PR TITLE
Feat: Filter SMTP sign-ins by date range

### DIFF
--- a/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertSmtpAuthSuccess.ps1
+++ b/Modules/CIPPCore/Public/Alerts/Get-CIPPAlertSmtpAuthSuccess.ps1
@@ -12,8 +12,16 @@ function Get-CIPPAlertSmtpAuthSuccess {
     )
 
     try {
+        $lookupDays = if ($InputValue.SmtpAuthSuccessDays) { [int]$InputValue.SmtpAuthSuccessDays } else { 7 }
+        $lookupDays = [Math]::Min($lookupDays, 30)
+
+        $endDateTime = (Get-Date).ToUniversalTime()
+        $startDateTime = $endDateTime.AddDays(-$lookupDays)
+        $startDateTimeString = $startDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $endDateTimeString = $endDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+
         # Graph API endpoint for sign-ins
-        $uri = "https://graph.microsoft.com/v1.0/auditLogs/signIns?`$filter=(clientAppUsed eq 'Authenticated SMTP' or clientAppUsed eq 'SMTP') and status/errorCode eq 0"
+        $uri = "https://graph.microsoft.com/v1.0/auditLogs/signIns?`$filter=createdDateTime ge $startDateTimeString and createdDateTime le $endDateTimeString and (clientAppUsed eq 'Authenticated SMTP' or clientAppUsed eq 'SMTP') and status/errorCode eq 0"
 
         # Call Graph API for the given tenant
         $SignIns = New-GraphGetRequest -uri $uri -tenantid $TenantFilter


### PR DESCRIPTION
Limit Graph API sign-in queries to a recent UTC date range. Adds SmtpAuthSuccessDays lookup (defaults to 7, capped at 30) and computes start/end datetimes formatted as yyyy-MM-ddTHH:mm:ssZ. Updates the signIns URI to include createdDateTime ge/le filters so only sign-ins within the specified window are returned.
UI: https://github.com/KelvinTegelaar/CIPP/pull/5733