### PR TITLE
Fix: Custom scripts fixes

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Tests/Push-CIPPTest.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Tests/Push-CIPPTest.ps1
@@ -13,6 +13,13 @@ function Push-CIPPTest {
     Write-Information "Running test $TestId for tenant $TenantFilter"
 
     try {
+        if ($TestId -like 'CustomScript-*') {
+            Write-Information "Executing Invoke-CippTestCustomScripts for $TenantFilter (ScriptGuid: $ScriptGuid)"
+            Invoke-CippTestCustomScripts -Tenant $TenantFilter -ScriptGuid $ScriptGuid
+            Write-Host "Returning true, test has run for $tenantFilter"
+            return @{ testRun = $true }
+        }
+
         $FunctionName = "Invoke-CippTest$TestId"
 
         if (-not (Get-Command $FunctionName -ErrorAction SilentlyContinue)) {

--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Tests/Push-CIPPTestsList.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Tests/Push-CIPPTestsList.ps1
@@ -23,6 +23,9 @@ function Push-CIPPTestsList {
             $_ -replace '^Invoke-CippTest', ''
         }
 
+        # Custom scripts are scheduled individually using ScriptGuid identifiers
+        $AllTests = @($AllTests | Where-Object { $_ -ne 'CustomScripts' })
+
         if ($AllTests.Count -eq 0) {
             Write-Information 'No test functions found'
             return @()
@@ -36,11 +39,38 @@ function Push-CIPPTestsList {
         }
 
         # Build test task list for this tenant — returned for PostExecution aggregation
-        $Tasks = foreach ($Test in $AllTests) {
-            [PSCustomObject]@{
+        $Tasks = [System.Collections.Generic.List[object]]::new()
+        foreach ($Test in $AllTests) {
+            $Tasks.Add([PSCustomObject]@{
                 FunctionName = 'CIPPTest'
                 TenantFilter = $TenantFilter
                 TestId       = $Test
+            })
+        }
+
+        # Add custom scripts as individual tests (CustomScript-<Guid>) using latest enabled versions
+        $CustomTestsTable = Get-CippTable -tablename 'CustomPowershellScripts'
+        $CustomScripts = @(Get-CIPPAzDataTableEntity @CustomTestsTable -Filter "PartitionKey eq 'CustomScript'")
+        if ($CustomScripts.Count -gt 0) {
+            $LatestCustomScripts = $CustomScripts |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_.ScriptGuid) } |
+                Group-Object -Property ScriptGuid |
+                ForEach-Object {
+                    $_.Group | Sort-Object -Property Version -Descending | Select-Object -First 1
+                }
+
+            foreach ($Script in @($LatestCustomScripts)) {
+                # We can't prefilter this on table lookup as each script version has its own Enabled property, so we need to check here if the latest version is enabled
+                $IsEnabled = if ($Script.PSObject.Properties['Enabled']) { [bool]$Script.Enabled } else { $true }
+                if (-not $IsEnabled) {
+                    continue
+                }
+
+                $Tasks.Add([PSCustomObject]@{
+                        FunctionName = 'CIPPTest'
+                        TenantFilter = $TenantFilter
+                        TestId       = "CustomScript-$($Script.ScriptGuid)"
+                    })
             }
         }
 

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tools/Custom-Scripts/Invoke-AddCustomScript.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tools/Custom-Scripts/Invoke-AddCustomScript.ps1
@@ -12,10 +12,62 @@ function Invoke-AddCustomScript {
     $Headers = $Request.Headers
 
     try {
+        $Action = $Request.Body.Action
         $RestoreToVersion = $Request.Body.RestoreToVersion
         $ScriptGuid = $Request.Body.ScriptGuid
 
-        if ($RestoreToVersion) {
+        if ($Action) {
+            if ([string]::IsNullOrWhiteSpace($ScriptGuid)) {
+                throw 'ScriptGuid is required for action operations'
+            }
+
+            $Table = Get-CippTable -tablename 'CustomPowershellScripts'
+            $Filter = "PartitionKey eq 'CustomScript' and ScriptGuid eq '{0}'" -f $ScriptGuid
+            $ExistingVersions = @(Get-CIPPAzDataTableEntity @Table -Filter $Filter)
+            if (-not $ExistingVersions -or $ExistingVersions.Count -eq 0) {
+                throw "Script with GUID '$ScriptGuid' not found"
+            }
+
+            $LatestVersion = $ExistingVersions | Sort-Object -Property Version -Descending | Select-Object -First 1
+            $CurrentEnabled = if ($LatestVersion.PSObject.Properties['Enabled']) { [bool]$LatestVersion.Enabled } else { $true }
+            $CurrentAlertOnFailure = if ($LatestVersion.PSObject.Properties['AlertOnFailure']) { [bool]$LatestVersion.AlertOnFailure } else { $false }
+
+            $NewEnabled = $CurrentEnabled
+            $NewAlertOnFailure = $CurrentAlertOnFailure
+
+            switch ($Action) {
+                'EnableScript' {
+                    $NewEnabled = $true
+                }
+                'DisableScript' {
+                    $NewEnabled = $false
+                }
+                'EnableAlerts' {
+                    $NewAlertOnFailure = $true
+                }
+                'DisableAlerts' {
+                    $NewAlertOnFailure = $false
+                }
+            }
+
+            $MergeEntity = @{
+                PartitionKey   = $LatestVersion.PartitionKey
+                RowKey         = $LatestVersion.RowKey
+                Enabled        = $NewEnabled
+                AlertOnFailure = $NewAlertOnFailure
+            }
+
+            Add-CIPPAzDataTableEntity @Table -Entity $MergeEntity -OperationType UpsertMerge
+            Write-LogMessage -API $APIName -headers $Headers -message "Updated custom script '$($LatestVersion.ScriptName)' via action '$Action', Enabled: $NewEnabled, AlertOnFailure: $NewAlertOnFailure)" -sev 'Info'
+
+            $Body = @{
+                Results = "Successfully updated custom script '$($LatestVersion.ScriptName)'"
+            }
+
+            $StatusCode = [HttpStatusCode]::OK
+        }
+
+        elseif ($RestoreToVersion) {
             if ([string]::IsNullOrWhiteSpace($ScriptGuid)) {
                 throw 'ScriptGuid is required for restore operation'
             }

--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tools/Custom-Scripts/Invoke-ExecCustomScript.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tools/Custom-Scripts/Invoke-ExecCustomScript.ps1
@@ -3,7 +3,7 @@ function Invoke-ExecCustomScript {
     .FUNCTIONALITY
         Entrypoint
     .ROLE
-        CIPP.CustomScript.Execute
+        CIPP.CustomScript.ReadWrite
     #>
     [CmdletBinding()]
     param($Request, $TriggerMetadata)

--- a/Modules/CIPPCore/Public/Tests/Custom/Invoke-CippTestCustomScripts.ps1
+++ b/Modules/CIPPCore/Public/Tests/Custom/Invoke-CippTestCustomScripts.ps1
@@ -3,11 +3,15 @@ function Invoke-CippTestCustomScripts {
     .SYNOPSIS
     Run enabled custom scripts as CIPP tests
     #>
-    param($Tenant)
+    param(
+        $Tenant,
+        [string]$ScriptGuid
+    )
 
     try {
         $Table = Get-CippTable -tablename 'CustomPowershellScripts'
-        $Scripts = @(Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'CustomScript'")
+        $Filter = "PartitionKey eq 'CustomScript' and ScriptGuid eq '$ScriptGuid'"
+        $Scripts = @(Get-CIPPAzDataTableEntity @Table -Filter $Filter)
         if (-not $Scripts) {
             return
         }
@@ -16,7 +20,13 @@ function Invoke-CippTestCustomScripts {
             $_.Group | Sort-Object -Property Version -Descending | Select-Object -First 1
         }
 
+        if (-not [string]::IsNullOrWhiteSpace($ScriptGuid) -and $LatestScripts.Count -eq 0) {
+            Write-Information "No latest custom script found for ScriptGuid: $ScriptGuid"
+            return
+        }
+
         foreach ($Script in $LatestScripts) {
+            # We can't prefilter this on table lookup as each script version has its own Enabled property, so we need to check here if the latest version is enabled
             $IsEnabled = if ($Script.PSObject.Properties['Enabled']) { [bool]$Script.Enabled } else { $true }
             if (-not $IsEnabled) {
                 continue


### PR DESCRIPTION
Add support for scheduling and executing custom PowerShell scripts as individual CIPP tests. Push-CIPPTestsList now excludes the aggregate 'CustomScripts' entry and enumerates latest enabled versions of CustomPowershellScripts, adding tasks named CustomScript-<ScriptGuid> for each enabled latest version. Push-CIPPTest handles TestId matching CustomScript-* by invoking Invoke-CippTestCustomScripts and returning a testRun result. Invoke-CippTestCustomScripts gained a ScriptGuid parameter and now filters table lookups by ScriptGuid, ensures only the latest enabled version runs, and logs when no matching latest script is found. Also update Invoke-ExecCustomScript role from CIPP.CustomScript.Execute to CIPP.CustomScript.ReadWrite.

enable/disable actions