### PR TITLE
Fix: drift intune deletion detection

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Standards/Push-CIPPStandardsList.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Activity Triggers/Standards/Push-CIPPStandardsList.ps1
@@ -79,7 +79,7 @@ function Push-CIPPStandardsList {
                 $BulkRequests = $TypeMap.GetEnumerator() | ForEach-Object {
                     @{
                         id     = $_.Key
-                        url    = "$($_.Value)?`$orderby=lastModifiedDateTime desc&`$select=id,lastModifiedDateTime&`$top=999"
+                        url    = "$($_.Value)?`$orderby=lastModifiedDateTime desc&`$select=id,lastModifiedDateTime,displayName,name&`$top=999"
                         method = 'GET'
                     }
                 }
@@ -88,6 +88,7 @@ function Push-CIPPStandardsList {
                     $TrackingTable = Get-CippTable -tablename 'IntunePolicyTypeTracking'
                     $BulkResults = New-GraphBulkRequest -Requests $BulkRequests -tenantid $TenantFilter -NoPaginateIds @($BulkRequests.id)
                     $PolicyTimestamps = @{}
+                    $PolicyNamesByType = @{}
 
                     foreach ($Result in $BulkResults) {
                         $FirstPolicy = if ($Result.body.value) { $Result.body.value[0] } else { $null }
@@ -143,6 +144,7 @@ function Push-CIPPStandardsList {
                         }
 
                         $PolicyTimestamps[$Result.id] = $Changed
+                        $PolicyNamesByType[$Result.id] = @($Result.body.value | ForEach-Object { $_.displayName; $_.name } | Where-Object { $_ })
                         Write-Host "POLICY TYPE CHANGE CHECK: $($Result.id) -> Changed=$Changed (GraphCount=$GraphCount, CachedCount=$($Cached.PolicyCount), IdChanged=$IdChanged)"
                     }
 
@@ -222,9 +224,20 @@ function Push-CIPPStandardsList {
                             Write-Host "COMPLIANCE CHECK: $AlignmentKey | InLookup=$IsDeployed | Compliant=$IsCompliant | LookupValue=$($IntuneComplianceLookup[$AlignmentKey])"
 
                             if ($IsCompliant) {
-                                # Policy unchanged and compliant - no action needed
-                                Write-Host "NO INTUNE CHANGE: Filtering out $Key for $TenantFilter (compliant)"
-                                [void]$ComputedStandards.Remove($Key)
+                                # Verify the policy still exists in Graph before trusting compliance
+                                $TemplateDisplayName = $ParsedTemplate.Displayname
+                                $TypeNames = if ($PolicyType -eq 'AppProtection') {
+                                    @($PolicyNamesByType['AppProtection_Android']) + @($PolicyNamesByType['AppProtection_iOS'])
+                                } else {
+                                    @($PolicyNamesByType[$PolicyType])
+                                }
+                                if ($TypeNames -contains $TemplateDisplayName) {
+                                    # Policy unchanged, exists in Graph, and compliant - safe to skip
+                                    Write-Host "NO INTUNE CHANGE: Filtering out $Key for $TenantFilter (compliant)"
+                                    [void]$ComputedStandards.Remove($Key)
+                                } else {
+                                    Write-Host "KEEPING: $Key - policy '$TemplateDisplayName' not found in Graph for type $PolicyType (deleted?)"
+                                }
                             } else {
                                 Write-Host "KEEPING: $Key - not compliant or not in lookup (InLookup=$IsDeployed, Compliant=$IsCompliant)"
                             }


### PR DESCRIPTION
# Summary

Adds explicit displayName existence check during drift eval- the logic count was seen as unchanged and the last detected state was aligned. Fixes https://github.com/KelvinTegelaar/CIPP/issues/5751

# Description

The drift optimization in Push-CIPPStandardsList was eagerly updating the IntunePolicyTypeTracking cache before the standard actually ran, so if a policy was deleted from Intune, subsequent runs saw "count unchanged + compliant" and permanently skipped re-evaluation. The fix adds a policy existence check — when the filter would skip an IntuneTemplate standard, it now verifies the template's displayName still exists in the bulk Graph response for that policy type, and if it's missing (deleted), forces re-evaluation instead of trusting stale compliance data. Additionally, Remove-CIPPCache now clears the IntunePolicyTypeTracking table so that "Clear Cache" actually resets drift optimization

# Testing

As a warning, others were having difficulty reproducing this.

1. Create an Intune configuration policy (e.g. "Test Config Refresh") in a test tenant
2. In CIPP, create an Intune template from that policy and add it as a drift standard for the tenant
3. Run drift - confirm it shows aligned
4. Delete "Test Config Refresh" from Intune
5. Run drift again - should now show not aligned (this is the bug fix, previously it stayed aligned forever)
6. Run drift a third time - confirm it still shows not aligned (verifies no regression from the tracking cache)