### PR TITLE
Fix: cache clear drift

### DIFF
--- a/Modules/CIPPCore/Public/GraphHelper/Remove-CIPPCache.ps1
+++ b/Modules/CIPPCore/Public/GraphHelper/Remove-CIPPCache.ps1
@@ -27,6 +27,10 @@ function Remove-CIPPCache {
             }
         }
 
+        'Clearing Intune policy tracking data'
+        $TrackingTableContext = Get-CIPPTable -TableName 'IntunePolicyTypeTracking'
+        Remove-AzDataTable @TrackingTableContext
+
         'Clearing domain analyser results'
         # Remove Domain Analyser cached results
         $DomainsTable = Get-CippTable -tablename 'Domains'


### PR DESCRIPTION
# Summary

`Remove-CIPPCache` now clears the `IntunePolicyTypeTracking` table when performing a full cache clear. Related to [KelvinTegelaar/CIPP#5751](https://github.com/KelvinTegelaar/CIPP/issues/5751)

# Description

The "Clear Cache" action only removed tables matching `^cache`, which didn't include `IntunePolicyTypeTracking`. This meant clearing cache had no effect on drift optimization state - stale policy counts persisted and the drift filter continued trusting old compliance data. The fix adds an explicit removal of the `IntunePolicyTypeTracking` table alongside the existing cache table cleanup.

# Testing

1. Run drift for a tenant with Intune template standards - confirm alignment results
2. Go to CIPP > Clear Cache
3. Run drift again - confirm standards are fully re-evaluated (not skipped by the optimization filter)
4. Check function logs for `Clearing Intune policy tracking data` message during cache clear