### PR TITLE
Fix: intune drift remediate duds

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardIntuneTemplate.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardIntuneTemplate.ps1
@@ -145,6 +145,10 @@ function Invoke-CIPPStandardIntuneTemplate {
             }
 
             Set-CIPPIntunePolicy @PolicyParams
+            # Remediation succeeded — accept Graph return and update state so report reflects it
+            $CompareResult.compare = $null
+            $CompareResult.MatchFailed = $false
+            $CompareResult.AssignmentsMatch = $true
         } catch {
             $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
             Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to create or update Intune Template $($CompareResult.displayname), Error: $ErrorMessage" -sev 'Error'


### PR DESCRIPTION
# Summary

Updates `Invoke-CIPPStandardIntuneTemplate` to write post-remediation compliance state instead of stale pre-remediation data. Fixes drift deviations permanently showing "Denied" after successful DeniedRemediate one-off remediation.

# Description

`Invoke-CIPPStandardIntuneTemplate` runs its Graph comparison before remediation (~line 90-107) but writes the compliance report after (~line 178) using the same stale `$CompareResult`. When `Set-CIPPIntunePolicy` successfully deploys a policy, `CippStandardsReports` still gets `isCompliant:false` because it's based on the pre-remediation check where the policy didn't exist yet. The `tenantDrift` table retains the `DeniedRemediate` status, so drift keeps surfacing the deviation as "Denied".

The fix clears `$CompareResult.compare`, sets `MatchFailed = $false`, and `AssignmentsMatch = $true` after a successful `Set-CIPPIntunePolicy` call (no exception thrown). If remediation fails, the catch block preserves the original pre-remediation state. The next 12-hour scheduled run re-compares against Graph and corrects the record if the policy is actually out of line.

# Testing

1. Create a drift template with an Intune template (e.g. Config Refresh) for a test tenant
2. Ensure the policy does **not** exist in the tenant's Intune
3. Run drift. Should show as a deviation (policy missing)
4. Mark the deviation as "Denied" (DeniedRemediate), this triggers a one-off remediation task
5. Wait for the one-off task to complete and confirm the policy is deployed in Intune
6. Run drift again. Deviation should no longer appear as "Denied" (this is the bug fix, previously it stayed "Denied" forever)
7. Delete the policy from Intune and run drift again and it should show as a new deviation (verifies no false-positive from the optimistic update)
8. Test with a policy that cannot succeed (e.g. missing license/capability, impossible assignment): DeniedRemediate fires, deployment fails, deviation correctly (I think) stays "Denied" since remediation was never actually applied