### PR TITLE
Fix: Intune bundle drift remediation

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ExecUpdateDriftDeviation.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ExecUpdateDriftDeviation.ps1
@@ -46,10 +46,28 @@ function Invoke-ExecUpdateDriftDeviation {
                         if ($Setting -like '*IntuneTemplate*') {
                             $Setting = 'IntuneTemplate'
                             $TemplateId = $Deviation.standardName.split('.') | Select-Object -Index 2
-                            $StandardTemplate = $StandardTemplate.standardSettings.IntuneTemplate | Where-Object { $_.TemplateList.value -like "*$TemplateId*" }
-                            $StandardTemplate | Add-Member -MemberType NoteProperty -Name 'remediate' -Value $true -Force
-                            $StandardTemplate | Add-Member -MemberType NoteProperty -Name 'report' -Value $true -Force
-                            $Settings = $StandardTemplate
+                            $MatchedTemplate = $StandardTemplate.standardSettings.IntuneTemplate | Where-Object { $_.TemplateList.value -like "*$TemplateId*" } | Select-Object -First 1
+                            if (-not $MatchedTemplate) {
+                                # Template may be inside a TemplateList-Tags bundle, expand it
+                                $BundleEntry = $StandardTemplate.standardSettings.IntuneTemplate | Where-Object {
+                                    $_.'TemplateList-Tags'.rawData.templates | Where-Object { $_.GUID -like "*$TemplateId*" }
+                                } | Select-Object -First 1
+                                if ($BundleEntry) {
+                                    $MatchedTemplate = $BundleEntry.PSObject.Copy()
+                                    $MatchedTemplate.PSObject.Properties.Remove('TemplateList-Tags')
+                                    $MatchedTemplate | Add-Member -NotePropertyName TemplateList -NotePropertyValue ([pscustomobject]@{
+                                        label = $TemplateId
+                                        value = $TemplateId
+                                    }) -Force
+                                }
+                            }
+                            if (-not $MatchedTemplate) {
+                                Write-LogMessage -tenant $TenantFilter -user $request.headers.'x-ms-client-principal' -API $APINAME -message "Could not find IntuneTemplate $TemplateId in drift standard settings for remediation" -Sev 'Warn'
+                            } else {
+                                $MatchedTemplate | Add-Member -MemberType NoteProperty -Name 'remediate' -Value $true -Force
+                                $MatchedTemplate | Add-Member -MemberType NoteProperty -Name 'report' -Value $true -Force
+                                $Settings = $MatchedTemplate
+                            }
                         } elseif ($Setting -like '*ConditionalAccessTemplate*') {
                             $Setting = 'ConditionalAccessTemplate'
                             $TemplateId = $Deviation.standardName.split('.') | Select-Object -Index 2
@@ -91,7 +109,7 @@ function Invoke-ExecUpdateDriftDeviation {
                             }
                         }
                         Add-CIPPScheduledTask -Task $TaskBody -hidden $false
-                        Write-LogMessage -tenant $TenantFilter -user $request.headers.'x-ms-client-principal' -API $APINAME -message "Scheduled drift remediation task for $Setting" -Sev 'Info'
+                        Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Scheduled drift remediation task for $Setting" -Sev 'Info'
 
                         if ($PersistentDeny) {
                             $PersistentTaskBody = @{


### PR DESCRIPTION
# Summary

Fixes DeniedRemediate one-off drift remediation silently doing nothing for IntuneTemplate policies added via tag bundles (TemplateList-Tags). The scheduled task would complete "successfully" but the policy was never deployed to Intune.

# Description

`Invoke-ExecUpdateDriftDeviation` resolves the template settings for a DeniedRemediate one-off by filtering `standardSettings.IntuneTemplate` on `TemplateList.value`. For templates added individually this works, but for templates added via a tag bundle (e.g. "Core Policies (4 Templates)"), `TemplateList` is null and the templates live under `TemplateList Tags.rawData.templates` instead. The `Where-Object` returns nothing, `$Settings` ends up null, and the scheduled task calls `Invoke-CIPPStandardIntuneTemplate` with no settings. The function then wildcard-matches every template in the table and processes them as a single blob, which doesn't match anything in Graph.

The fix adds a fallback that searches `TemplateList-Tags.rawData.templates` for the template GUID when the `TemplateList.value` lookup returns nothing. When found, it expands the bundle entry into a proper `TemplateList` with the individual GUID, matching the pattern `Get-CIPPStandards` already uses for bundle expansion during normal standards runs. Also added a warning log when neither path finds the template.

# Testing

1. Create a drift template with a **tag bundle** containing multiple Intune templates (e.g. "Core Policies" with Config Refresh, LAPS, etc.)
2. Assign to a test tenant and run drift. Bundled policies should show as deviations if they don't exist in the tenant
3. Mark a bundled template deviation as "Denied" (DeniedRemediate)
4. Wait for the one-off scheduled task to complete (or force it to /w timer run)
5. Verify the policy is actually deployed in Intune (this is the bug fix, previously it silently did nothing)
6. Verify the policy has the correct assignments from the bundle entry
7. Also test an **individual** (non-bundled) template DeniedRemediate to confirm no regression on the original code path