### PR TITLE
feat: add better logging and some "already" checks to standards missing it

### DIFF
--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAutopilotStatusPage.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardAutopilotStatusPage.ps1
@@ -93,22 +93,29 @@ function Invoke-CIPPStandardAutopilotStatusPage {
 
     # Remediate if the state is not correct
     if ($Settings.remediate -eq $true) {
-        try {
-            $Parameters = @{
-                TenantFilter          = $Tenant
-                ShowProgress          = $Settings.ShowProgress
-                BlockDevice           = $Settings.BlockDevice
-                InstallWindowsUpdates = $InstallWindowsUpdates
-                AllowReset            = $Settings.AllowReset
-                EnableLog             = $Settings.EnableLog
-                ErrorMessage          = $Settings.ErrorMessage
-                TimeOutInMinutes      = $Settings.TimeOutInMinutes
-                AllowFail             = $Settings.AllowFail
-                OBEEOnly              = $Settings.OBEEOnly
-            }
+        if ($StateIsCorrect -eq $true) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Autopilot Enrollment Status Page is already configured correctly.' -sev Info
+        } else {
+            try {
+                $Parameters = @{
+                    TenantFilter          = $Tenant
+                    ShowProgress          = $Settings.ShowProgress
+                    BlockDevice           = $Settings.BlockDevice
+                    InstallWindowsUpdates = $InstallWindowsUpdates
+                    AllowReset            = $Settings.AllowReset
+                    EnableLog             = $Settings.EnableLog
+                    ErrorMessage          = $Settings.ErrorMessage
+                    TimeOutInMinutes      = $Settings.TimeOutInMinutes
+                    AllowFail             = $Settings.AllowFail
+                    OBEEOnly              = $Settings.OBEEOnly
+                }
 
-            Set-CIPPDefaultAPEnrollment @Parameters
-        } catch {
+                Set-CIPPDefaultAPEnrollment @Parameters
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Autopilot Enrollment Status Page settings have been updated.' -sev Info
+            } catch {
+                $ErrorMessage = Get-CippException -Exception $_
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update Autopilot Enrollment Status Page: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+            }
         }
     }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
@@ -121,7 +121,7 @@ function Invoke-CIPPStandardDisableGuests {
                 Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to process bulk disable guests request: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
             }
         } else {
-            Write-LogMessage -API 'Standards' -tenant $tenant -message "No guests accounts with a login longer than $checkDays days ago." -sev Info
+            Write-LogMessage -API 'Standards' -tenant $tenant -message "No guests accounts with a login longer than $checkDays days ago - all guest accounts are already compliant." -sev Info
         }
     }
     if ($Settings.alert -eq $true) {

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardEXODisableAutoForwarding.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardEXODisableAutoForwarding.ps1
@@ -45,8 +45,7 @@ function Invoke-CIPPStandardEXODisableAutoForwarding {
 
     try {
         $CurrentInfo = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-HostedOutboundSpamFilterPolicy' -cmdParams @{Identity = 'Default' } -useSystemMailbox $true
-    }
-    catch {
+    } catch {
         $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
         Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the EXODisableAutoForwarding state for $Tenant. Error: $ErrorMessage" -Sev Error
         return
@@ -54,12 +53,16 @@ function Invoke-CIPPStandardEXODisableAutoForwarding {
     $StateIsCorrect = $CurrentInfo.AutoForwardingMode -eq 'Off'
 
     if ($Settings.remediate -eq $true) {
-        try {
-            New-ExoRequest -tenantid $tenant -cmdlet 'Set-HostedOutboundSpamFilterPolicy' -cmdParams @{ Identity = 'Default'; AutoForwardingMode = 'Off' } -useSystemMailbox $true
-            Write-LogMessage -API 'Standards' -tenant $tenant -message 'Disabled auto forwarding' -sev Info
-        } catch {
-            $ErrorMessage = Get-CippException -Exception $_
-            Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not disable auto forwarding. $($ErrorMessage.NormalizedError)" -sev Error
+        if ($StateIsCorrect -eq $true) {
+            Write-LogMessage -API 'Standards' -tenant $tenant -message 'Auto forwarding is already disabled.' -sev Info
+        } else {
+            try {
+                New-ExoRequest -tenantid $tenant -cmdlet 'Set-HostedOutboundSpamFilterPolicy' -cmdParams @{ Identity = 'Default'; AutoForwardingMode = 'Off' } -useSystemMailbox $true
+                Write-LogMessage -API 'Standards' -tenant $tenant -message 'Disabled auto forwarding' -sev Info
+            } catch {
+                $ErrorMessage = Get-CippException -Exception $_
+                Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not disable auto forwarding. $($ErrorMessage.NormalizedError)" -sev Error
+            }
         }
     }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardNudgeMFA.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardNudgeMFA.ps1
@@ -48,30 +48,34 @@ function Invoke-CIPPStandardNudgeMFA {
 
     if ($Settings.remediate -eq $true) {
         $StateName = $State.Substring(0, 1).ToUpper() + $State.Substring(1)
-        try {
-            $GraphRequest = @{
-                tenantid    = $Tenant
-                uri         = 'https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy'
-                AsApp       = $false
-                Type        = 'PATCH'
-                ContentType = 'application/json'
-                Body        = @{
-                    registrationEnforcement = @{
-                        authenticationMethodsRegistrationCampaign = @{
-                            state                                  = $State
-                            snoozeDurationInDays                   = $Settings.snoozeDurationInDays
-                            enforceRegistrationAfterAllowedSnoozes = $true
-                            includeTargets                         = $CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.includeTargets
-                            excludeTargets                         = $CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.excludeTargets
+        if ($StateIsCorrect -eq $true) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Authenticator App Nudge is already set to $State with a snooze duration of $($Settings.snoozeDurationInDays)." -sev Info
+        } else {
+            try {
+                $GraphRequest = @{
+                    tenantid    = $Tenant
+                    uri         = 'https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy'
+                    AsApp       = $false
+                    Type        = 'PATCH'
+                    ContentType = 'application/json'
+                    Body        = @{
+                        registrationEnforcement = @{
+                            authenticationMethodsRegistrationCampaign = @{
+                                state                                  = $State
+                                snoozeDurationInDays                   = $Settings.snoozeDurationInDays
+                                enforceRegistrationAfterAllowedSnoozes = $true
+                                includeTargets                         = $CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.includeTargets
+                                excludeTargets                         = $CurrentState.registrationEnforcement.authenticationMethodsRegistrationCampaign.excludeTargets
+                            }
                         }
-                    }
-                } | ConvertTo-Json -Depth 10 -Compress
+                    } | ConvertTo-Json -Depth 10 -Compress
+                }
+                New-GraphPostRequest @GraphRequest
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "$StateName Authenticator App Nudge with a snooze duration of $($Settings.snoozeDurationInDays)" -sev Info
+            } catch {
+                $ErrorMessage = Get-CippException -Exception $_
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to set Authenticator App Nudge to $State. Error: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
             }
-            New-GraphPostRequest @GraphRequest
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "$StateName Authenticator App Nudge with a snooze duration of $($Settings.snoozeDurationInDays)" -sev Info
-        } catch {
-            $ErrorMessage = Get-CippException -Exception $_
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to set Authenticator App Nudge to $State. Error: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
         }
     }
 

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardPerUserMFA.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardPerUserMFA.ps1
@@ -58,7 +58,7 @@ function Invoke-CIPPStandardPerUserMFA {
         $UpdateDB = $false
         if (($UsersWithoutMFA | Measure-Object).Count -gt 0) {
             try {
-                $MFAMessage = Set-CIPPPerUserMFA -TenantFilter $Tenant -userId @($UsersWithoutMFA.userPrincipalName) -State 'enforced'
+                $MFAMessage = Set-CIPPPerUserMFA -TenantFilter $Tenant -UserId @($UsersWithoutMFA.userPrincipalName) -State 'enforced'
                 Write-LogMessage -API 'Standards' -tenant $tenant -message $MFAMessage -sev Info
                 $UpdateDB = $true
             } catch {
@@ -74,6 +74,8 @@ function Invoke-CIPPStandardPerUserMFA {
                     Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to refresh user cache after remediation: $($_.Exception.Message)" -sev Warning
                 }
             }
+        } else {
+            Write-LogMessage -API 'Standards' -tenant $tenant -message 'All users already have Legacy MFA enforced.' -sev Info
         }
     }
     if ($Settings.alert -eq $true) {

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineRequestAlert.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardQuarantineRequestAlert.ps1
@@ -50,7 +50,7 @@ function Invoke-CIPPStandardQuarantineRequestAlert {
 
     if ($Settings.remediate -eq $true) {
         if ($StateIsCorrect -eq $true) {
-            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message 'Quarantine Request Alert is configured correctly' -sev Info
+            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message 'Quarantine Request Alert is already configured correctly.' -sev Info
         } else {
             $cmdParams = @{
                 'NotifyUser'      = $Settings.NotifyUser

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSharePointMassDeletionAlert.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardSharePointMassDeletionAlert.ps1
@@ -66,7 +66,7 @@ function Invoke-CIPPStandardSharePointMassDeletionAlert {
 
     if ($Settings.remediate -eq $true) {
         if ($StateIsCorrect -eq $true) {
-            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message 'SharePoint mass deletion of files alert is configured correctly' -sev Info
+            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message 'SharePoint mass deletion of files alert is already configured correctly.' -sev Info
         } else {
             $cmdParams = @{
                 'NotifyUser'      = $Settings.NotifyUser.value

--- a/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardUserPreferredLanguage.ps1
+++ b/Modules/CIPPCore/Public/Standards/Invoke-CIPPStandardUserPreferredLanguage.ps1
@@ -77,6 +77,8 @@ function Invoke-CIPPStandardUserPreferredLanguage {
                     Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to refresh user cache after remediation: $($_.Exception.Message)" -sev Warning
                 }
             }
+        } else {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "All users already have the preferred language set to $preferredLanguage." -sev Info
         }
     }
 


### PR DESCRIPTION
Enhance logging messages to clarify the status of settings and improve error handling during remediation processes across various standards. This should remove some unnecessary graph calls