### PR TITLE
fix: multi-tenant support for Scripted CIPP Alerts

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Alerts/Invoke-AddScriptedAlert.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Alerts/Invoke-AddScriptedAlert.ps1
@@ -1,0 +1,80 @@
+function Invoke-AddScriptedAlert {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        CIPP.Alert.ReadWrite
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $tenantsJsonForStorage = $null
+
+    if ($Request.Body.tenantFilter -is [array] -and @($Request.Body.tenantFilter).Count -eq 1) {
+        $Request.Body | Add-Member -MemberType NoteProperty -Name 'tenantFilter' -Value $Request.Body.tenantFilter[0] -Force
+    }
+
+    if ($Request.Body.tenantFilter -is [array] -and @($Request.Body.tenantFilter).Count -gt 1) {
+        try {
+            $originalSelection = @($Request.Body.tenantFilter)
+            $tenantsJsonForStorage = $originalSelection | ConvertTo-Json -Compress -Depth 10
+
+            $hasAllTenants = @($originalSelection | Where-Object { $_.value -eq 'AllTenants' }).Count -gt 0
+
+            if (-not $hasAllTenants) {
+                $ExpandedSelection = Expand-CIPPTenantGroups -TenantFilter $originalSelection
+                $targetDomains = @($ExpandedSelection | ForEach-Object { $_.value })
+
+                $AllTenantsList = Get-Tenants -IncludeErrors
+                $computedExcluded = @($AllTenantsList.defaultDomainName | Where-Object { $_ -notin $targetDomains })
+
+                $existingExcluded = @()
+                if ($Request.Body.PSObject.Properties['excludedTenants'] -and $Request.Body.excludedTenants) {
+                    $existingExcluded = @($Request.Body.excludedTenants | ForEach-Object { $_.value ?? $_ })
+                }
+                $mergedExcluded = @($existingExcluded + $computedExcluded) | Where-Object { $_ } | Select-Object -Unique
+
+                $excludedValue = @($mergedExcluded | ForEach-Object {
+                        [PSCustomObject]@{ value = $_; label = $_ }
+                    })
+                $Request.Body | Add-Member -MemberType NoteProperty -Name 'excludedTenants' -Value $excludedValue -Force
+            }
+
+            if (-not $Request.Body.PSObject.Properties['RowKey'] -or -not $Request.Body.RowKey) {
+                $Request.Body | Add-Member -MemberType NoteProperty -Name 'RowKey' -Value ((New-Guid).Guid) -Force
+            }
+
+            $tenantFilterValue = [PSCustomObject]@{
+                value = 'AllTenants'
+                label = '*All Tenants'
+                type  = 'Tenant'
+            }
+            $Request.Body | Add-Member -MemberType NoteProperty -Name 'tenantFilter' -Value $tenantFilterValue -Force
+        } catch {
+            Write-Warning "Failed to process multi-tenant alert selection: $($_.Exception.Message)"
+            $tenantsJsonForStorage = $null
+        }
+    }
+
+    $ForwardRequest = @{
+        Query   = @{ hidden = 'true' }
+        Body    = $Request.Body
+        Headers = $Request.Headers
+    }
+    $Response = Invoke-AddScheduledItem -Request $ForwardRequest -TriggerMetadata $TriggerMetadata
+
+    if ($tenantsJsonForStorage) {
+        try {
+            $Table = Get-CIPPTable -TableName 'ScheduledTasks'
+            $null = Update-AzDataTableEntity -Force @Table -Entity @{
+                PartitionKey = 'ScheduledTask'
+                RowKey       = [string]$Request.Body.RowKey
+                Tenants      = [string]$tenantsJsonForStorage
+            }
+        } catch {
+            Write-Warning "Failed to persist multi-tenant selection for alert: $($_.Exception.Message)"
+        }
+    }
+
+    return $Response
+}

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Alerts/Invoke-ListAlertsQueue.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Alerts/Invoke-ListAlertsQueue.ps1
@@ -65,9 +65,29 @@ function Invoke-ListAlertsQueue {
             $ExcludedTenants = @()
         }
 
-        # Handle tenant group display information for alerts
+        # Handle tenant display information for alerts
         $TenantsForDisplay = @()
-        if ($Task.TenantGroup) {
+        if ($Task.Tenants) {
+            # Multi tenant alert
+            try {
+                $TenantsParsed = $Task.Tenants | ConvertFrom-Json -Depth 10 -ErrorAction Stop
+                $TenantsForDisplay = @($TenantsParsed | ForEach-Object {
+                        [PSCustomObject]@{
+                            label = $_.label ?? $_.value
+                            value = $_.value
+                            type  = $_.type ?? 'Tenant'
+                        }
+                    })
+                $ExcludedTenants = @()
+            } catch {
+                Write-Warning "Failed to parse Tenants for alert task $($Task.RowKey): $($_.Exception.Message)"
+                $TenantsForDisplay = @([PSCustomObject]@{
+                        label = $Task.Tenant
+                        value = $Task.Tenant
+                        type  = 'Tenant'
+                    })
+            }
+        } elseif ($Task.TenantGroup) {
             try {
                 $TenantGroupObject = $Task.TenantGroup | ConvertFrom-Json -ErrorAction SilentlyContinue
                 if ($TenantGroupObject) {


### PR DESCRIPTION
- Add a alert entrypoint `Invoke-AddScriptedAlert.ps1` that handles multi-tenant and tenant group selections for Scripted CIPP Alerts
- Expands any tenant groups via `Expand-CIPPTenantGroups` and merges them with individually selected tenants into a target domain list
- Resolves KelvinTegelaar/CIPP#5833