### PR TITLE
fix: Update duration validation message for snooze alert

### DIFF
--- a/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ExecSnoozeAlert.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ExecSnoozeAlert.ps1
@@ -27,10 +27,10 @@ function Invoke-ExecSnoozeAlert {
                 })
         }
 
-        if ($Duration -notin @(7, 14, 30, -1)) {
+        if ($Duration -notin @(7, 14, 30, 90)) {
             return ([HttpResponseContext]@{
                     StatusCode = [HttpStatusCode]::BadRequest
-                    Body       = @{ Results = 'Duration must be 7, 14, 30, or -1 (forever).' }
+                    Body       = @{ Results = 'Duration must be 7, 14, 30, or 90 days.' }
                 })
         }
 


### PR DESCRIPTION
Update the validation message for the snooze alert duration to reflect the new valid option of 90 days thats in the frontend.