### PR TITLE
Fix : Last Sync Attempt Time & Last Sync Success fields blank in ActiveSync Devices #5860

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListActiveSyncDevices.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Reports/Invoke-ListActiveSyncDevices.ps1
@@ -12,21 +12,23 @@ function Invoke-ListActiveSyncDevices {
 
     try {
         $GraphRequest = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-MobileDevice' -cmdParams @{ ResultSize = 'Unlimited' } |
-        Select-Object @{ Name = 'userDisplayName'; Expression = { $_.UserDisplayName } },
-        @{ Name = 'userPrincipalName'; Expression = { ($_.Identity -split '\\')[0] } },
-        @{ Name = 'deviceFriendlyName'; Expression = { if ([string]::IsNullOrEmpty($_.FriendlyName)) { 'Unknown' } else { $_.FriendlyName } } },
-        @{ Name = 'deviceModel'; Expression = { $_.DeviceModel } },
-        @{ Name = 'deviceOS'; Expression = { $_.DeviceOS } },
-        @{ Name = 'deviceType'; Expression = { $_.DeviceType } },
-        @{ Name = 'clientType'; Expression = { $_.ClientType } },
-        @{ Name = 'clientVersion'; Expression = { $_.ClientVersion } },
-        @{ Name = 'deviceAccessState'; Expression = { $_.DeviceAccessState } },
-        @{ Name = 'firstSyncTime'; Expression = { if ($_.FirstSyncTime) { $_.FirstSyncTime.ToString('yyyy-MM-ddTHH:mm:ssZ') } else { '' } } },
-        @{ Name = 'lastSyncAttemptTime'; Expression = { if ($_.LastSyncAttemptTime) { $_.LastSyncAttemptTime.ToString('yyyy-MM-ddTHH:mm:ssZ') } else { '' } } },
-        @{ Name = 'lastSuccessSync'; Expression = { if ($_.LastSuccessSync) { $_.LastSuccessSync.ToString('yyyy-MM-ddTHH:mm:ssZ') } else { '' } } },
-        @{ Name = 'deviceID'; Expression = { $_.DeviceId } },
-        @{ Name = 'identity'; Expression = { $_.Identity } },
-        @{ Name = 'Guid'; Expression = { $_.Guid } }
+		Select-Object @{ Name = 'userDisplayName'; Expression = { $_.UserDisplayName } },
+		@{ Name = 'userPrincipalName'; Expression = { ($_.Identity -split '\\')[0] } },
+		@{ Name = 'deviceFriendlyName'; Expression = { if ([string]::IsNullOrEmpty($_.FriendlyName)) { 'Unknown' } else { $_.FriendlyName } } },
+		@{ Name = 'deviceModel'; Expression = { $_.DeviceModel } },
+		@{ Name = 'deviceOS'; Expression = { $_.DeviceOS } },
+		@{ Name = 'deviceType'; Expression = { $_.DeviceType } },
+		@{ Name = 'clientType'; Expression = { $_.ClientType } },
+		@{ Name = 'clientVersion'; Expression = { $_.ClientVersion } },
+		@{ Name = 'deviceAccessState'; Expression = { $_.DeviceAccessState } },
+		@{ Name = 'firstSyncTime'; Expression = {if ($_.FirstSyncTime) {$_.FirstSyncTime.ToString('yyyy-MM-ddTHH:mm:ssZ')} else {$null}}},
+		@{ Name = 'lastSyncAttemptTime'; Expression = {if ($_.LastSyncAttemptTime) {$_.LastSyncAttemptTime.ToString('yyyy-MM-ddTHH:mm:ssZ')} else {$null}}},
+		@{ Name = 'lastSuccessSync'; Expression = {if ($_.LastSuccessSync) {$_.LastSuccessSync.ToString('yyyy-MM-ddTHH:mm:ssZ')} else {$null}}},
+		@{ Name = 'syncInfoNote'; Expression = {if ($_.DeviceModel -match 'Outlook' -or $_.DeviceType  -eq 'Outlook' -or $_.ClientType  -eq 'Outlook') {'Outlook for iOS and Android uses modern authentication and does not report ActiveSync sync times.'} else {$null}}},
+		@{ Name = 'deviceID'; Expression = { $_.DeviceId } },
+		@{ Name = 'identity'; Expression = { $_.Identity } },
+		@{ Name = 'Guid'; Expression = { $_.Guid } }
+		)
         $StatusCode = [HttpStatusCode]::OK
     } catch {
         $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message


### PR DESCRIPTION
Outlook for iOS/Android devices always show empty values for:
lastSyncAttemptTime
lastSuccessSync

This is expected Exchange behavior, but:
- The UI provides no explanation
- Empty strings are indistinguishable from missing or broken data
- Sorting and exporting these fields behaves inconsistently

This PR :
- Normalizes missing sync timestamps to null instead of empty strings.
- Add a new informational field, syncInfoNote, for Outlook mobile devices explaining why ActiveSync sync times are not reported.
- Detection is based on existing device properties (DeviceModel, DeviceType, ClientType) and does not introduce new protocol assumptions.

Resolves - https://github.com/KelvinTegelaar/CIPP/issues/5860