### PR TITLE
Fix token retrieval issue in development environment initialization

### DIFF
--- a/Tools/Initialize-DevEnvironment.ps1
+++ b/Tools/Initialize-DevEnvironment.ps1
@@ -1,5 +1,6 @@
 Write-Host 'Initializing development environment...' -ForegroundColor Green
 $CippRoot = (Get-Item $PSScriptRoot).Parent.FullName
+$env:CIPPRootPath = $CippRoot
 ### Read the local.settings.json file and convert to a PowerShell object.
 $CIPPSettings = Get-Content (Join-Path $CippRoot 'local.settings.json') | ConvertFrom-Json | Select-Object -ExpandProperty Values
 ### Loop through the settings and set environment variables for each.
@@ -17,6 +18,11 @@ if ($IsWindows) {
         Write-Information "Loading PowerShell Worker from $PowerShellWorkerRoot"
         Add-Type -Path $PowerShellWorkerRoot
     }
+}
+
+$CIPPHttpDllPath = Join-Path $CippRoot 'Shared\CIPPHttp\bin\CIPPHttp.dll'
+if ((Test-Path $CIPPHttpDllPath) -and !('CIPP.CIPPRestClient' -as [type])) {
+    [Reflection.Assembly]::LoadFile($CIPPHttpDllPath) | Out-Null
 }
 
 # Remove previously loaded modules to force reloading if new code changes were made


### PR DESCRIPTION
Fixes Could not get token: Unable to find type [CIPP.CIPPRestClient]. error when running commands after running Initialize-DevEnvironment