### PR TITLE
Fix log severity levels from 'Warn' to 'Warning'

### DIFF
--- a/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-UpdatePermissionsQueue.ps1
+++ b/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-UpdatePermissionsQueue.ps1
@@ -19,7 +19,7 @@ function Push-UpdatePermissionsQueue {
         $Tenant = Get-Tenants -TenantFilter $Item.customerId -IncludeErrors
 
         if ((!$CPVRows -or $env:ApplicationID -notin $CPVRows.applicationId) -and $Tenant.delegatedPrivilegeStatus -ne 'directTenant') {
-            Write-LogMessage -tenant $Item.defaultDomainName -tenantId $Item.customerId -message 'A New tenant has been added, or a new CIPP-SAM Application is in use' -Sev 'Warn' -API 'NewTenant'
+            Write-LogMessage -tenant $Item.defaultDomainName -tenantId $Item.customerId -message 'A New tenant has been added, or a new CIPP-SAM Application is in use' -Sev 'Warning' -API 'NewTenant'
             Write-Information 'Adding CPV permissions'
             Set-CIPPCPVConsent -Tenantfilter $Item.customerId
             $DomainRefreshRequired = $true
@@ -38,7 +38,7 @@ function Push-UpdatePermissionsQueue {
         if ($PermissionFailures) {
             $Status = 'Failed'
             $FailureMessage = ($PermissionFailures -join '; ')
-            Write-LogMessage -tenant $Item.defaultDomainName -tenantId $Item.customerId -message "Permission update completed with failures for $($Item.displayName): $FailureMessage" -Sev 'Warn' -API 'UpdatePermissionsQueue'
+            Write-LogMessage -tenant $Item.defaultDomainName -tenantId $Item.customerId -message "Permission update completed with failures for $($Item.displayName): $FailureMessage" -Sev 'Warning' -API 'UpdatePermissionsQueue'
         } else {
             $Status = 'Success'
             Write-LogMessage -tenant $Item.defaultDomainName -tenantId $Item.customerId -message "Updated permissions for $($Item.displayName)" -Sev 'Info' -API 'UpdatePermissionsQueue'

--- a/Modules/CIPPCore/Public/Add-CIPPWin32LobAppContent.ps1
+++ b/Modules/CIPPCore/Public/Add-CIPPWin32LobAppContent.ps1
@@ -138,7 +138,7 @@ function Add-CIPPWin32LobAppContent {
         if ($CommitStateReq.uploadState -like '*fail*') {
             $errorMsg = "Commit failed. Upload state: $($CommitStateReq.uploadState)"
             if ($Headers) {
-                Write-LogMessage -Headers $Headers -API $APIName -message $errorMsg -sev 'Warn' -tenant $TenantFilter
+                Write-LogMessage -Headers $Headers -API $APIName -message $errorMsg -sev 'Warning' -tenant $TenantFilter
             }
             throw $errorMsg
         }

--- a/Modules/CIPPCore/Public/Entrypoints/Timer Functions/Start-BackupRetentionCleanup.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Timer Functions/Start-BackupRetentionCleanup.ps1
@@ -67,7 +67,7 @@ function Start-BackupRetentionCleanup {
                             $BlobDeletedCount++
                             Write-Host "Deleted blob: $BlobPath"
                         } catch {
-                            Write-LogMessage -API 'BackupRetentionCleanup' -message "Failed to delete blob $($Backup.Backup): $($_.Exception.Message)" -sev 'Warn'
+                            Write-LogMessage -API 'BackupRetentionCleanup' -message "Failed to delete blob $($Backup.Backup): $($_.Exception.Message)" -sev 'Warning'
                         }
                     }
                 }
@@ -127,7 +127,7 @@ function Start-BackupRetentionCleanup {
                             $BlobDeletedCount++
                             Write-Host "Deleted blob: $BlobPath"
                         } catch {
-                            Write-LogMessage -API 'BackupRetentionCleanup' -message "Failed to delete blob $($Backup.Backup): $($_.Exception.Message)" -sev 'Warn'
+                            Write-LogMessage -API 'BackupRetentionCleanup' -message "Failed to delete blob $($Backup.Backup): $($_.Exception.Message)" -sev 'Warning'
                         }
                     }
                 }

--- a/Modules/CIPPCore/Public/Get-CIPPReusableSettingsFromPolicy.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPReusableSettingsFromPolicy.ps1
@@ -17,7 +17,7 @@ function Get-CIPPReusableSettingsFromPolicy {
     try {
         $policyObject = $PolicyJson | ConvertFrom-Json -Depth 300 -ErrorAction Stop
     } catch {
-        Write-LogMessage -headers $Headers -API $APIName -message "Reusable settings discovery failed: policy JSON invalid ($($_.Exception.Message))" -Sev 'Warn'
+        Write-LogMessage -headers $Headers -API $APIName -message "Reusable settings discovery failed: policy JSON invalid ($($_.Exception.Message))" -Sev 'Warning'
         return $result
     }
 
@@ -101,7 +101,7 @@ function Get-CIPPReusableSettingsFromPolicy {
         try {
             $setting = New-GraphGETRequest -Uri "https://graph.microsoft.com/beta/deviceManagement/reusablePolicySettings/$settingId" -tenantid $Tenant
             if ($null -eq $setting) {
-                Write-LogMessage -headers $Headers -API $APIName -message "Reusable setting $settingId not returned from Graph" -Sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -message "Reusable setting $settingId not returned from Graph" -Sev 'Warning'
                 continue
             }
 
@@ -121,7 +121,7 @@ function Get-CIPPReusableSettingsFromPolicy {
 
             $settingDisplayName = $setting.displayName ?? $settingNormalized.displayName
             if (-not $settingDisplayName) {
-                Write-LogMessage -headers $Headers -API $APIName -message "Reusable setting $settingId missing displayName" -Sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -message "Reusable setting $settingId missing displayName" -Sev 'Warning'
                 continue
             }
 
@@ -208,7 +208,7 @@ function Get-CIPPReusableSettingsFromPolicy {
                     sourceId    = $settingId
                 })
         } catch {
-            Write-LogMessage -headers $Headers -API $APIName -message "Failed to link reusable setting $settingId for template creation: $($_.Exception.Message)" -Sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -message "Failed to link reusable setting $settingId for template creation: $($_.Exception.Message)" -Sev 'Warning'
         }
     }
 

--- a/Modules/CIPPCore/Public/New-CIPPCAPolicy.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPCAPolicy.ps1
@@ -30,7 +30,7 @@ function New-CIPPCAPolicy {
                 if ($groupId) {
                     if ($matchedGroups.Count -gt 1) {
                         Write-Warning "Multiple groups found with display name '$_'. Using the first match: $($matchedGroups[0].id). IDs found: $($groupId -join ', ')"
-                        $null = Write-LogMessage -Headers $Headers -API $APIName -message "Multiple groups found with display name '$_'. Using first match: $($matchedGroups[0].id)" -Sev 'Warn'
+                        $null = Write-LogMessage -Headers $Headers -API $APIName -message "Multiple groups found with display name '$_'. Using first match: $($matchedGroups[0].id)" -Sev 'Warning'
                         $groupId = @($matchedGroups[0].id)
                     }
                     foreach ($gid in $groupId) {
@@ -230,7 +230,7 @@ function New-CIPPCAPolicy {
                 $ExistingLocation = @($AllNamedLocations | Where-Object -Property displayName -EQ $Location.displayName)
                 if ($ExistingLocation.Count -gt 1) {
                     Write-Warning "Multiple named locations found with display name '$($Location.displayName)'. Using the first match: $($ExistingLocation[0].id). IDs found: $($ExistingLocation.id -join ', ')"
-                    Write-LogMessage -Tenant $TenantFilter -Headers $Headers -API $APIName -message "Multiple named locations found with display name '$($Location.displayName)'. Using first match: $($ExistingLocation[0].id)" -Sev 'Warn'
+                    Write-LogMessage -Tenant $TenantFilter -Headers $Headers -API $APIName -message "Multiple named locations found with display name '$($Location.displayName)'. Using first match: $($ExistingLocation[0].id)" -Sev 'Warning'
                 }
                 $ExistingLocation = $ExistingLocation[0]
                 if ($Overwrite) {
@@ -243,7 +243,7 @@ function New-CIPPCAPolicy {
                     } catch {
                         $ErrorMessage = Get-CippException -Exception $_
                         Write-Information "Error updating named location: $($ErrorMessage | ConvertTo-Json -Depth 10 -Compress)"
-                        Write-LogMessage -Tenant $TenantFilter -Headers $Headers -API $APIName -message "Named Location '$($location.displayName)' (id: $($ExistingLocation.id)) could not be updated — it may have been deleted. Will attempt to create it. Error: $($ErrorMessage.NormalizedError)" -Sev 'Warn' -LogData $ErrorMessage
+                        Write-LogMessage -Tenant $TenantFilter -Headers $Headers -API $APIName -message "Named Location '$($location.displayName)' (id: $($ExistingLocation.id)) could not be updated — it may have been deleted. Will attempt to create it. Error: $($ErrorMessage.NormalizedError)" -Sev 'Warning' -LogData $ErrorMessage
                         $locationExistsInCache = $false
                     }
                 } else {

--- a/Modules/CIPPCore/Public/New-CIPPRestoreTask.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPRestoreTask.ps1
@@ -103,7 +103,7 @@ function New-CIPPRestoreTask {
                         }
                     } catch {
                         $restorationStats['CustomVariables'].failed++
-                        Write-LogMessage -message "Failed to restore custom variable $($variable.RowKey): $($_.Exception.Message)" -sev 'Warn'
+                        Write-LogMessage -message "Failed to restore custom variable $($variable.RowKey): $($_.Exception.Message)" -sev 'Warning'
                         $RestoreData.Add("Failed to restore custom variable $($variable.RowKey)")
                     }
                 }

--- a/Modules/CIPPCore/Public/Remove-CIPPCalendarPermissions.ps1
+++ b/Modules/CIPPCore/Public/Remove-CIPPCalendarPermissions.ps1
@@ -114,7 +114,7 @@ function Remove-CIPPCalendarPermissions {
                         }
 
                         $ErrorMsg = "Failed to remove $UserToRemove from calendar $($CalPermEntry.CalendarUPN): $($_.Exception.Message)"
-                        Write-LogMessage -headers $Headers -API $APIName -message $ErrorMsg -sev 'Warn' -tenant $TenantFilter
+                        Write-LogMessage -headers $Headers -API $APIName -message $ErrorMsg -sev 'Warning' -tenant $TenantFilter
                         $Results.Add($ErrorMsg)
                     }
                 }

--- a/Modules/CIPPCore/Public/Remove-CIPPGroups.ps1
+++ b/Modules/CIPPCore/Public/Remove-CIPPGroups.ps1
@@ -71,10 +71,10 @@ function Remove-CIPPGroups {
                 Write-LogMessage -headers $Headers -API $APIName -message "Skipping removal of $Username from group '$GroupName' because it has assigned licenses. This group will be handled during the license removal step." -sev 'Info' -tenant $TenantFilter
             } elseif ($IsDynamic) {
                 $Results.Add("Error: Could not remove $Username from group '$GroupName' because it is a Dynamic Group.")
-                Write-LogMessage -headers $Headers -API $APIName -message "Could not remove $Username from group '$GroupName' because it is a Dynamic Group." -sev 'Warn' -tenant $TenantFilter
+                Write-LogMessage -headers $Headers -API $APIName -message "Could not remove $Username from group '$GroupName' because it is a Dynamic Group." -sev 'Warning' -tenant $TenantFilter
             } elseif ($GroupInfo.onPremisesSyncEnabled) {
                 $Results.Add("Error: Could not remove $Username from group '$GroupName' because it is synced with Active Directory.")
-                Write-LogMessage -headers $Headers -API $APIName -message "Could not remove $Username from group '$GroupName' because it is synced with Active Directory." -sev 'Warn' -tenant $TenantFilter
+                Write-LogMessage -headers $Headers -API $APIName -message "Could not remove $Username from group '$GroupName' because it is synced with Active Directory." -sev 'Warning' -tenant $TenantFilter
             } else {
                 if ($IsM365Group -or (-not $IsMailEnabled)) {
                     # Use Graph API for M365 Groups and Security Groups

--- a/Modules/CIPPCore/Public/Remove-CIPPMailboxPermissions.ps1
+++ b/Modules/CIPPCore/Public/Remove-CIPPMailboxPermissions.ps1
@@ -43,7 +43,7 @@ function Remove-CIPPMailboxPermissions {
                     }
                 } catch {
                     $ErrorMsg = "Failed to remove permissions from $MailboxUPN for $AccessUser : $($_.Exception.Message)"
-                    Write-LogMessage -headers $Headers -API $APIName -message $ErrorMsg -sev 'Warn' -tenant $TenantFilter
+                    Write-LogMessage -headers $Headers -API $APIName -message $ErrorMsg -sev 'Warning' -tenant $TenantFilter
                     $Results.Add($ErrorMsg)
                 }
             }

--- a/Modules/CIPPCore/Public/Remove-CIPPMailboxRule.ps1
+++ b/Modules/CIPPCore/Public/Remove-CIPPMailboxRule.ps1
@@ -46,7 +46,7 @@ function Remove-CIPPMailboxRule {
             try {
                 Remove-CIPPDbItem -TenantFilter $TenantFilter -Type 'MailboxRules' -ItemId $RuleId
             } catch {
-                Write-LogMessage -headers $Headers -API $APIName -message "Rule deleted but failed to remove from cache: $($_.Exception.Message)" -sev 'Warn' -tenant $TenantFilter
+                Write-LogMessage -headers $Headers -API $APIName -message "Rule deleted but failed to remove from cache: $($_.Exception.Message)" -sev 'Warning' -tenant $TenantFilter
             }
 
             return $Message

--- a/Modules/CIPPCore/Public/Repair-CIPPIntuneTemplateNesting.ps1
+++ b/Modules/CIPPCore/Public/Repair-CIPPIntuneTemplateNesting.ps1
@@ -57,7 +57,7 @@ function Repair-CIPPIntuneTemplateNesting {
         } -Force
 
         $Template.RAWJson = $currentRawJson
-        Write-LogMessage -API 'IntuneTemplate' -message "Repaired double-nested RAWJson for template '$($Template.Displayname)' ($($Template.GUID))" -Sev 'Warn'
+        Write-LogMessage -API 'IntuneTemplate' -message "Repaired double-nested RAWJson for template '$($Template.Displayname)' ($($Template.GUID))" -Sev 'Warning'
     }
 
     return $Template

--- a/Modules/CIPPCore/Public/Set-CIPPAssignedApplication.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPAssignedApplication.ps1
@@ -27,7 +27,7 @@ function Set-CIPPAssignedApplication {
                 Write-Host "Found assignment filter: $($MatchingFilter.displayName) with ID: $ResolvedFilterId"
             } else {
                 $ErrorMessage = "No assignment filter found matching the name: $AssignmentFilterName. Application assigned without filter."
-                Write-LogMessage -headers $Headers -API $APIName -message $ErrorMessage -sev 'Warn' -tenant $TenantFilter
+                Write-LogMessage -headers $Headers -API $APIName -message $ErrorMessage -sev 'Warning' -tenant $TenantFilter
                 Write-Host $ErrorMessage
             }
         }

--- a/Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1
@@ -31,7 +31,7 @@ function Set-CIPPAssignedPolicy {
                 Write-Host "Found assignment filter: $($MatchingFilter.displayName) with ID: $ResolvedFilterId"
             } else {
                 $ErrorMessage = "No assignment filter found matching the name: $AssignmentFilterName. Policy assigned without filter."
-                Write-LogMessage -headers $Headers -API $APIName -message $ErrorMessage -sev 'Warn' -tenant $TenantFilter
+                Write-LogMessage -headers $Headers -API $APIName -message $ErrorMessage -sev 'Warning' -tenant $TenantFilter
                 Write-Host $ErrorMessage
             }
         }
@@ -95,7 +95,7 @@ function Set-CIPPAssignedPolicy {
 
                 if (-not $resolvedGroupIds -or $resolvedGroupIds.Count -eq 0) {
                     $ErrorMessage = "No groups found matching the specified name(s): $GroupName. Policy not assigned."
-                    Write-LogMessage -headers $Headers -API $APIName -message $ErrorMessage -sev 'Warn' -tenant $TenantFilter
+                    Write-LogMessage -headers $Headers -API $APIName -message $ErrorMessage -sev 'Warning' -tenant $TenantFilter
                     throw $ErrorMessage
                 }
 

--- a/Modules/CIPPCore/Public/Set-CIPPMailboxRule.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPMailboxRule.ps1
@@ -1,4 +1,4 @@
-﻿function Set-CIPPMailboxRule {
+function Set-CIPPMailboxRule {
     [CmdletBinding()]
     param (
         $UserId,
@@ -32,7 +32,7 @@
                 Enabled = $EnabledValue
             }
         } catch {
-            Write-LogMessage -headers $Headers -API $APIName -message "Rule updated but failed to update cache: $($_.Exception.Message)" -sev 'Warn' -tenant $TenantFilter
+            Write-LogMessage -headers $Headers -API $APIName -message "Rule updated but failed to update cache: $($_.Exception.Message)" -sev 'Warning' -tenant $TenantFilter
         }
 
         return "Successfully set mailbox rule $($RuleName) for $($Username) to $($State)d"

--- a/Modules/CIPPCore/Public/Set-CIPPResetPassword.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPResetPassword.ps1
@@ -30,7 +30,7 @@ function Set-CIPPResetPassword {
             }
         }
         catch {
-            Write-LogMessage -headers $Headers -API $APIName -message "Failed to create PwPush link, using plain password. Error: $($_.Exception.Message)" -sev 'Warn' -tenant $TenantFilter
+            Write-LogMessage -headers $Headers -API $APIName -message "Failed to create PwPush link, using plain password. Error: $($_.Exception.Message)" -sev 'Warning' -tenant $TenantFilter
         }
         Write-LogMessage -headers $Headers -API $APIName -message "Successfully reset the password for $DisplayName, $($UserID). User must change password is set to $forceChangePasswordNextSignIn" -Sev 'Info' -tenant $TenantFilter
 

--- a/Modules/CIPPCore/Public/Test-CIPPAccessTenant.ps1
+++ b/Modules/CIPPCore/Public/Test-CIPPAccessTenant.ps1
@@ -119,7 +119,7 @@ function Test-CIPPAccessTenant {
             $ExchangeLicenseCapable = Test-CIPPStandardLicense -StandardName 'ExchangeAccessCheck' -TenantFilter $Tenant.customerId -RequiredCapabilities @('EXCHANGE_S_STANDARD', 'EXCHANGE_S_ENTERPRISE', 'EXCHANGE_S_STANDARD_GOV', 'EXCHANGE_S_ENTERPRISE_GOV', 'EXCHANGE_LITE') -SkipLog
         } catch {
             $ErrorMessage = Get-CippException -Exception $_
-            Write-LogMessage -headers $Headers -API $APINAME -tenant $tenant.defaultDomainName -message "Exchange license capability check failed. Continuing with Exchange access validation. Error: $($ErrorMessage.NormalizedError)" -Sev 'Warn' -LogData $ErrorMessage
+            Write-LogMessage -headers $Headers -API $APINAME -tenant $tenant.defaultDomainName -message "Exchange license capability check failed. Continuing with Exchange access validation. Error: $($ErrorMessage.NormalizedError)" -Sev 'Warning' -LogData $ErrorMessage
             $ExchangeLicenseCapable = $true
         }
 
@@ -150,7 +150,7 @@ function Test-CIPPAccessTenant {
                     Write-Warning "Found $($MissingRoles.Count) missing Organization Management roles in Exchange"
                     $ExchangeStatus = $false
                     $ExchangeTest = 'Connected to Exchange but missing permissions in Organization Management. This may impact the ability to manage Exchange features'
-                    Write-LogMessage -headers $Headers -API $APINAME -tenant $tenant.defaultDomainName -message 'Tenant access check for Exchange failed: Missing Organization Management roles' -sev 'Warn' -LogData $MissingOrgMgmtRoles
+                    Write-LogMessage -headers $Headers -API $APINAME -tenant $tenant.defaultDomainName -message 'Tenant access check for Exchange failed: Missing Organization Management roles' -sev 'Warning' -LogData $MissingOrgMgmtRoles
                 } else {
                     Write-Warning 'All available Organization Management roles are present in Exchange'
                     $ExchangeStatus = $true

--- a/Modules/CIPPCore/Public/Webhooks/Invoke-CIPPGraphWebhookRenewal.ps1
+++ b/Modules/CIPPCore/Public/Webhooks/Invoke-CIPPGraphWebhookRenewal.ps1
@@ -19,7 +19,7 @@ function Invoke-CippGraphWebhookRenewal {
             try {
                 $TenantFilter = $UpdateSub.PartitionKey
                 if ($Tenants.defaultDomainName -notcontains $TenantFilter -and $Tenants.customerId -notcontains $TenantFilter) {
-                    Write-LogMessage -API 'Renew_Graph_Subscriptions' -message "Removing Subscription Renewal for $($UpdateSub.SubscriptionID) as tenant $TenantFilter is not in the tenant list." -sev 'Warn' -tenant $TenantFilter
+                    Write-LogMessage -API 'Renew_Graph_Subscriptions' -message "Removing Subscription Renewal for $($UpdateSub.SubscriptionID) as tenant $TenantFilter is not in the tenant list." -sev 'Warning' -tenant $TenantFilter
                     Remove-AzDataTableEntity -Force @WebhookTable -Entity $UpdateSub
                     continue
                 }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Scheduler/Invoke-ListScheduledItemDetails.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Scheduler/Invoke-ListScheduledItemDetails.ps1
@@ -119,7 +119,7 @@ function Invoke-ListScheduledItemDetails {
                     }
                 } catch {
                     # If JSON parsing fails, use raw value
-                    Write-LogMessage -API $APIName -message "Error parsing Task.Results as JSON: $_" -sev 'Warn'
+                    Write-LogMessage -API $APIName -message "Error parsing Task.Results as JSON: $_" -sev 'Warning'
                     $ResultData = $Task.Results
                 }
             } else {
@@ -155,7 +155,7 @@ function Invoke-ListScheduledItemDetails {
                         try {
                             $ParsedResults = $Result.Results | ConvertFrom-Json -ErrorAction Stop
                         } catch {
-                            Write-LogMessage -API $APIName -message "Failed to parse result as JSON: $_" -sev 'Warn'
+                            Write-LogMessage -API $APIName -message "Failed to parse result as JSON: $_" -sev 'Warning'
                             # On failure, keep as string
                             $ParsedResults = $Result.Results
                         }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecApiClient.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecApiClient.ps1
@@ -231,7 +231,7 @@ function Invoke-ExecApiClient {
                     $Body = @{ Results = "API client $ClientId not found or not a valid CIPP-API application" }
                 }
             } catch {
-                Write-LogMessage -headers $Request.Headers -API 'ExecApiClient' -message "Failed to remove app registration for $ClientId" -sev 'Warn'
+                Write-LogMessage -headers $Request.Headers -API 'ExecApiClient' -message "Failed to remove app registration for $ClientId" -sev 'Warning'
             }
         }
         default {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecGDAPTrace.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecGDAPTrace.ps1
@@ -163,7 +163,7 @@ function Invoke-ExecGDAPTrace {
             # Filter didn't work, try direct lookup by UPN (works if UPN is unique identifier)
             $User = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users/$UPN" -tenantid $env:TenantID -NoAuthCheck $true
         } catch {
-            Write-LogMessage -Headers $Headers -API $APIName -message "Could not find user $UPN in partner tenant: $($_.Exception.Message)" -sev 'Warn'
+            Write-LogMessage -Headers $Headers -API $APIName -message "Could not find user $UPN in partner tenant: $($_.Exception.Message)" -sev 'Warning'
         }
 
         # If user not found, return error
@@ -212,7 +212,7 @@ function Invoke-ExecGDAPTrace {
                 }
             }
         } catch {
-            Write-LogMessage -Headers $Headers -API $APIName -message "Could not get user group memberships: $($_.Exception.Message)" -sev 'Warn'
+            Write-LogMessage -Headers $Headers -API $APIName -message "Could not get user group memberships: $($_.Exception.Message)" -sev 'Warning'
         }
 
         # ============================================================================
@@ -394,7 +394,7 @@ function Invoke-ExecGDAPTrace {
                     })
                 }
             } catch {
-                Write-LogMessage -Headers $Headers -API $APIName -message "Could not get access assignments for relationship ${RelationshipName}: $($_.Exception.Message)" -sev 'Warn'
+                Write-LogMessage -Headers $Headers -API $APIName -message "Could not get access assignments for relationship ${RelationshipName}: $($_.Exception.Message)" -sev 'Warning'
             }
         }
 
@@ -444,7 +444,7 @@ function Invoke-ExecGDAPTrace {
 
             Write-LogMessage -Headers $Headers -API $APIName -message "Fetched $($AllGroups.Count) total groups, $($GroupLookup.Count) in lookup" -Sev 'Debug'
         } catch {
-            Write-LogMessage -Headers $Headers -API $APIName -message "Could not fetch all groups: $($_.Exception.Message). Will use fallback for missing groups." -sev 'Warn'
+            Write-LogMessage -Headers $Headers -API $APIName -message "Could not fetch all groups: $($_.Exception.Message). Will use fallback for missing groups." -sev 'Warning'
         }
 
         # ========================================================================
@@ -485,12 +485,12 @@ function Invoke-ExecGDAPTrace {
                     $GroupId = $Assignment.value.accessContainer.accessContainerId
                     $Assignment = $Assignment.value
                 } else {
-                    Write-LogMessage -Headers $Headers -API $APIName -message "Access assignment missing accessContainer: $($Assignment | ConvertTo-Json -Compress)" -sev 'Warn'
+                    Write-LogMessage -Headers $Headers -API $APIName -message "Access assignment missing accessContainer: $($Assignment | ConvertTo-Json -Compress)" -sev 'Warning'
                     continue
                 }
 
                 if ([string]::IsNullOrWhiteSpace($GroupId)) {
-                    Write-LogMessage -Headers $Headers -API $APIName -message "Access assignment has empty accessContainerId: $($Assignment | ConvertTo-Json -Compress)" -sev 'Warn'
+                    Write-LogMessage -Headers $Headers -API $APIName -message "Access assignment has empty accessContainerId: $($Assignment | ConvertTo-Json -Compress)" -sev 'Warning'
                     continue
                 }
 
@@ -503,7 +503,7 @@ function Invoke-ExecGDAPTrace {
                 }
 
                 if (-not $Roles -or $Roles.Count -eq 0) {
-                    Write-LogMessage -Headers $Headers -API $APIName -message "Access assignment for group $GroupId has no roles assigned" -sev 'Warn'
+                    Write-LogMessage -Headers $Headers -API $APIName -message "Access assignment for group $GroupId has no roles assigned" -sev 'Warning'
                     $Roles = @()
                 }
 
@@ -518,7 +518,7 @@ function Invoke-ExecGDAPTrace {
                         id          = $GroupId
                         displayName = "Unknown Group ($GroupId)"
                     }
-                    Write-LogMessage -Headers $Headers -API $APIName -message "Group $GroupId not found in lookup, using fallback" -sev 'Warn'
+                    Write-LogMessage -Headers $Headers -API $APIName -message "Group $GroupId not found in lookup, using fallback" -sev 'Warning'
                 }
 
                 # Process the assignment even if group lookup failed - we still have the group ID and roles
@@ -654,12 +654,12 @@ function Invoke-ExecGDAPTrace {
                             } elseif ($Role -is [string]) {
                                 $RoleId = $Role
                             } else {
-                                Write-LogMessage -Headers $Headers -API $APIName -message "Role object missing roleDefinitionId: $($Role | ConvertTo-Json -Compress)" -sev 'Warn'
+                                Write-LogMessage -Headers $Headers -API $APIName -message "Role object missing roleDefinitionId: $($Role | ConvertTo-Json -Compress)" -sev 'Warning'
                                 continue
                             }
 
                             if ([string]::IsNullOrWhiteSpace($RoleId)) {
-                                Write-LogMessage -Headers $Headers -API $APIName -message "Role has empty roleDefinitionId for group $GroupId" -sev 'Warn'
+                                Write-LogMessage -Headers $Headers -API $APIName -message "Role has empty roleDefinitionId for group $GroupId" -sev 'Warning'
                                 continue
                             }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ListCustomVariables.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ListCustomVariables.ps1
@@ -242,7 +242,7 @@ function Invoke-ListCustomVariables {
                     }
                 }
             } catch {
-                Write-LogMessage -API $APIName -message "Could not retrieve tenant-specific variables for $TenantFilter : $($_.Exception.Message)" -sev 'Warn'
+                Write-LogMessage -API $APIName -message "Could not retrieve tenant-specific variables for $TenantFilter : $($_.Exception.Message)" -sev 'Warning'
             }
         }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Contacts/Invoke-DeployContactTemplates.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Contacts/Invoke-DeployContactTemplates.ps1
@@ -24,7 +24,7 @@ Function Invoke-DeployContactTemplates {
             if ($TenantItem.value) {
                 $SelectedTenants.Add($TenantItem.value)
             } else {
-                Write-LogMessage -headers $Headers -API $APIName -message "Tenant item missing value property: $($TenantItem | ConvertTo-Json -Compress)" -sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -message "Tenant item missing value property: $($TenantItem | ConvertTo-Json -Compress)" -sev 'Warning'
             }
         }
 
@@ -46,7 +46,7 @@ Function Invoke-DeployContactTemplates {
                 if ($TemplateItem.value) {
                     $ContactTemplates.Add($TemplateItem.value)
                 } else {
-                    Write-LogMessage -headers $Headers -API $APIName -message "Template item missing value property: $($TemplateItem | ConvertTo-Json -Compress)" -sev 'Warn'
+                    Write-LogMessage -headers $Headers -API $APIName -message "Template item missing value property: $($TemplateItem | ConvertTo-Json -Compress)" -sev 'Warning'
                 }
             }
         } else {
@@ -74,7 +74,7 @@ Function Invoke-DeployContactTemplates {
                     $ContactExists = $ExistingContacts | Where-Object { $_.ExternalEmailAddress -eq $ContactTemplate.email }
 
                     if ($ContactExists) {
-                        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Contact with email '$($ContactTemplate.email)' already exists in tenant $TenantFilter" -sev 'Warn'
+                        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Contact with email '$($ContactTemplate.email)' already exists in tenant $TenantFilter" -sev 'Warning'
                         "Contact '$($ContactTemplate.displayName)' with email '$($ContactTemplate.email)' already exists in tenant $TenantFilter"
                         continue
                     }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Contacts/Invoke-ListContactTemplates.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Contacts/Invoke-ListContactTemplates.ps1
@@ -38,7 +38,7 @@ function Invoke-ListContactTemplates {
         }
 
         if (-not $Templates) {
-            Write-LogMessage -headers $Headers -API $APIName -message "Template with ID $RequestedID not found" -sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -message "Template with ID $RequestedID not found" -sev 'Warning'
             return ([HttpResponseContext]@{
                     StatusCode = [HttpStatusCode]::NotFound
                     Body       = @{ Error = "Template with ID $RequestedID not found" }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecHVEUser.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecHVEUser.ps1
@@ -75,7 +75,7 @@ function Invoke-ExecHVEUser {
                     } catch {
                         $ErrorMessage = Get-CippException -Exception $_
                         $Message = "Failed to exclude from CA policy '$($Policy.displayName)': $($ErrorMessage.NormalizedError)"
-                        Write-LogMessage -Headers $Headers -API $APIName -tenant $Tenant -message $Message -sev 'Warn' -LogData $ErrorMessage
+                        Write-LogMessage -Headers $Headers -API $APIName -tenant $Tenant -message $Message -sev 'Warning' -LogData $ErrorMessage
                         $Results.Add($Message)
                     }
                 }
@@ -85,7 +85,7 @@ function Invoke-ExecHVEUser {
         } catch {
             $ErrorMessage = Get-CippException -Exception $_
             $Message = "Failed to check/update Conditional Access policies: $($ErrorMessage.NormalizedError)"
-            Write-LogMessage -Headers $Headers -API $APIName -tenant $Tenant -message $Message -sev 'Warn' -LogData $ErrorMessage
+            Write-LogMessage -Headers $Headers -API $APIName -tenant $Tenant -message $Message -sev 'Warning' -LogData $ErrorMessage
             $Results.Add($Message)
         }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyCalPerms.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyCalPerms.ps1
@@ -105,7 +105,7 @@ function Invoke-ExecModifyCalPerms {
     }
 
     if ($Results.Count -eq 0) {
-        Write-LogMessage -headers $Headers -API $APIName -message 'No results were generated from the operation' -sev 'Warn'
+        Write-LogMessage -headers $Headers -API $APIName -message 'No results were generated from the operation' -sev 'Warning'
         $Results.Add('No results were generated from the operation. Please check the logs for more details.')
         $HasErrors = $true
     }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyContactPerms.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyContactPerms.ps1
@@ -104,7 +104,7 @@ function Invoke-ExecModifyContactPerms {
     }
 
     if ($Results.Count -eq 0) {
-        Write-LogMessage -headers $Headers -API $APIName -message 'No results were generated from the operation' -sev 'Warn'
+        Write-LogMessage -headers $Headers -API $APIName -message 'No results were generated from the operation' -sev 'Warning'
         $Results.Add('No results were generated from the operation. Please check the logs for more details.')
         $HasErrors = $true
     }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyMBPerms.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyMBPerms.ps1
@@ -293,7 +293,7 @@ Function Invoke-ExecModifyMBPerms {
     }
 
     if ($CmdletArray.Count -eq 0) {
-        Write-LogMessage -headers $Request.Headers -API $APINAME -message 'No valid cmdlets to process' -sev 'Warn' -tenant $TenantFilter
+        Write-LogMessage -headers $Request.Headers -API $APINAME -message 'No valid cmdlets to process' -sev 'Warning' -tenant $TenantFilter
         $body = [pscustomobject]@{'Results' = @("No valid permission changes to process") }
         return ([HttpResponseContext]@{
             StatusCode = [HttpStatusCode]::OK
@@ -327,7 +327,7 @@ Function Invoke-ExecModifyMBPerms {
                                 Write-LogMessage -headers $Request.Headers -API $APINAME -message "Success for operation $operationGuid`: $($metadata.ExpectedResult)" -Sev 'Info' -tenant $TenantFilter
                             }
                         } else {
-                            Write-LogMessage -headers $Request.Headers -API $APINAME -message "Could not map result to operation. GUID: $operationGuid, Available GUIDs: $($GuidToMetadataMap.Keys -join ', ')" -sev 'Warn' -tenant $TenantFilter
+                            Write-LogMessage -headers $Request.Headers -API $APINAME -message "Could not map result to operation. GUID: $operationGuid, Available GUIDs: $($GuidToMetadataMap.Keys -join ', ')" -sev 'Warning' -tenant $TenantFilter
 
                             # Fallback for unmapped results
                             if ($result.error) {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddJITAdminTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddJITAdminTemplate.ps1
@@ -61,7 +61,7 @@ function Invoke-AddJITAdminTemplate {
                         Write-LogMessage -headers $Headers -API $APIName -message "Unset default flag for existing template: $($data.templateName)" -Sev 'Info'
                     }
                 } catch {
-                    Write-LogMessage -headers $Headers -API $APIName -message "Failed to update existing template: $($_.Exception.Message)" -sev 'Warn'
+                    Write-LogMessage -headers $Headers -API $APIName -message "Failed to update existing template: $($_.Exception.Message)" -sev 'Warning'
                 }
             }
         }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditJITAdminTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditJITAdminTemplate.ps1
@@ -77,7 +77,7 @@ function Invoke-EditJITAdminTemplate {
                         Write-LogMessage -headers $Headers -API $APIName -message "Unset default flag for existing template: $($data.templateName)" -Sev 'Info'
                     }
                 } catch {
-                    Write-LogMessage -headers $Headers -API $APIName -message "Failed to update existing template: $($_.Exception.Message)" -sev 'Warn'
+                    Write-LogMessage -headers $Headers -API $APIName -message "Failed to update existing template: $($_.Exception.Message)" -sev 'Warning'
                 }
             }
         }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListJITAdminTemplates.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListJITAdminTemplates.ps1
@@ -34,7 +34,7 @@ function Invoke-ListJITAdminTemplates {
             $data | Add-Member -NotePropertyName 'RowKey' -NotePropertyValue $row.RowKey -Force
             $data
         } catch {
-            Write-LogMessage -headers $Headers -API $APIName -message "Failed to process JIT Admin template: $($row.RowKey) - $($_.Exception.Message)" -sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -message "Failed to process JIT Admin template: $($row.RowKey) - $($_.Exception.Message)" -sev 'Warning'
         }
     }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-RemoveJITAdminTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-RemoveJITAdminTemplate.ps1
@@ -30,7 +30,7 @@ function Invoke-RemoveJITAdminTemplate {
             $StatusCode = [HttpStatusCode]::OK
         } else {
             $Result = "JIT Admin Template with ID $ID not found"
-            Write-LogMessage -headers $Headers -API $APIName -message $Result -sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -message $Result -sev 'Warning'
             $StatusCode = [HttpStatusCode]::NotFound
         }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-RemoveUserDefaultTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-RemoveUserDefaultTemplate.ps1
@@ -25,7 +25,7 @@ function Invoke-RemoveUserDefaultTemplate {
             $StatusCode = [HttpStatusCode]::OK
         } else {
             $Result = "User Default Template with ID $ID not found"
-            Write-LogMessage -headers $Headers -API $APIName -message $Result -sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -message $Result -sev 'Warning'
             $StatusCode = [HttpStatusCode]::NotFound
         }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Invoke-ExecListAppId.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Invoke-ExecListAppId.ps1
@@ -83,13 +83,13 @@ function Invoke-ExecListAppId {
                         Invoke-GraphRequest -Method PATCH -Url "https://graph.microsoft.com/v1.0/applications/$($AppResponse.body.id)" -Body $AppUpdateBody -tenantid $env:TenantID -NoAuthCheck $true
                         Write-LogMessage -message "Updated redirect URIs for application $($env:ApplicationID) to include $NewRedirectUri" -Sev 'Info'
                     } catch {
-                        Write-LogMessage -message "Failed to update redirect URIs for application $($env:ApplicationID)" -LogData (Get-CippException -Exception $_) -sev 'Warn'
+                        Write-LogMessage -message "Failed to update redirect URIs for application $($env:ApplicationID)" -LogData (Get-CippException -Exception $_) -sev 'Warning'
                     }
                 }
             }
         }
     } catch {
-        Write-LogMessage -message 'Failed to retrieve organization info and authenticated user' -LogData (Get-CippException -Exception $_) -sev 'Warn'
+        Write-LogMessage -message 'Failed to retrieve organization info and authenticated user' -LogData (Get-CippException -Exception $_) -sev 'Warning'
     }
 
     $Results = @{

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-AddSafeLinksPolicyFromTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-AddSafeLinksPolicyFromTemplate.ps1
@@ -82,13 +82,13 @@ Function Invoke-AddSafeLinksPolicyFromTemplate {
 
             # Check if policy already exists
             if (Test-PolicyExists -TenantFilter $TenantFilter -PolicyName $PolicyName) {
-                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Policy '$PolicyName' already exists" -sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Policy '$PolicyName' already exists" -sev 'Warning'
                 return "Policy '$PolicyName' already exists in tenant $TenantFilter"
             }
 
             # Check if rule already exists
             if (Test-RuleExists -TenantFilter $TenantFilter -RuleName $RuleName) {
-                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Rule '$RuleName' already exists" -sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Rule '$RuleName' already exists" -sev 'Warning'
                 return "Rule '$RuleName' already exists in tenant $TenantFilter"
             }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-ExecDeleteSafeLinksPolicy.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-ExecDeleteSafeLinksPolicy.ps1
@@ -39,7 +39,7 @@ function Invoke-ExecDeleteSafeLinksPolicy {
             catch {
                 $ErrorMessage = Get-CippException -Exception $_
                 $ResultMessages.Add("Failed to delete SafeLinks rule '$RuleName'. Error: $($ErrorMessage.NormalizedError)") | Out-Null
-                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to delete SafeLinks rule '$RuleName'. Error: $($ErrorMessage.NormalizedError)" -sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to delete SafeLinks rule '$RuleName'. Error: $($ErrorMessage.NormalizedError)" -sev 'Warning'
             }
         }
         else {
@@ -66,7 +66,7 @@ function Invoke-ExecDeleteSafeLinksPolicy {
             catch {
                 $ErrorMessage = Get-CippException -Exception $_
                 $ResultMessages.Add("Failed to delete SafeLinks policy '$PolicyName'. Error: $($ErrorMessage.NormalizedError)") | Out-Null
-                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to delete SafeLinks policy '$PolicyName'. Error: $($ErrorMessage.NormalizedError)" -sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to delete SafeLinks policy '$PolicyName'. Error: $($ErrorMessage.NormalizedError)" -sev 'Warning'
             }
         }
         else {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-ExecNewSafeLinksPolicy.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-ExecNewSafeLinksPolicy.ps1
@@ -124,13 +124,13 @@ function Invoke-ExecNewSafeLinksPolicy {
     try {
         # Check if policy already exists
         if (Test-PolicyExists -TenantFilter $TenantFilter -PolicyName $PolicyName) {
-            Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Policy '$PolicyName' already exists" -sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Policy '$PolicyName' already exists" -sev 'Warning'
             return "Policy '$PolicyName' already exists in tenant $TenantFilter"
         }
 
         # Check if rule already exists
         if (Test-RuleExists -TenantFilter $TenantFilter -RuleName $RuleName) {
-            Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Rule '$RuleName' already exists" -sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Rule '$RuleName' already exists" -sev 'Warning'
             return "Rule '$RuleName' already exists in tenant $TenantFilter"
         }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-ListSafeLinksPolicy.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-ListSafeLinksPolicy.ps1
@@ -179,7 +179,7 @@ Function Invoke-ListSafeLinksPolicy {
         $BuiltInOnlyConfigs = ($SortedOutput | Where-Object { $_.ConfigurationStatus -like "*Built-In Rule Only*" }).Count
 
         if ($PolicyOnlyConfigs -gt 0 -or $RuleOnlyConfigs -gt 0) {
-            Write-LogMessage -headers $Headers -API $APIName -message "Found $($PolicyOnlyConfigs + $RuleOnlyConfigs) orphaned SafeLinks configurations that may need attention" -sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -message "Found $($PolicyOnlyConfigs + $RuleOnlyConfigs) orphaned SafeLinks configurations that may need attention" -sev 'Warning'
         }
 
         $StatusCode = [HttpStatusCode]::OK

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-ListSafeLinksPolicyDetails.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Safe-Links-Policy/Invoke-ListSafeLinksPolicyDetails.ps1
@@ -43,7 +43,7 @@ function Invoke-ListSafeLinksPolicyDetails {
             catch {
                 $ErrorMessage = Get-CippException -Exception $_
                 $LogMessages.Add("Failed to retrieve details for SafeLinks policy '$PolicyName'. Error: $($ErrorMessage.NormalizedError)") | Out-Null
-                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to retrieve details for SafeLinks policy '$PolicyName'. Error: $($ErrorMessage.NormalizedError)" -sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to retrieve details for SafeLinks policy '$PolicyName'. Error: $($ErrorMessage.NormalizedError)" -sev 'Warning'
                 $Result.PolicyError = "Failed to retrieve: $($ErrorMessage.NormalizedError)"
             }
         }
@@ -72,7 +72,7 @@ function Invoke-ListSafeLinksPolicyDetails {
             catch {
                 $ErrorMessage = Get-CippException -Exception $_
                 $LogMessages.Add("Failed to retrieve details for SafeLinks rule '$RuleName'. Error: $($ErrorMessage.NormalizedError)") | Out-Null
-                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to retrieve details for SafeLinks rule '$RuleName'. Error: $($ErrorMessage.NormalizedError)" -sev 'Warn'
+                Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to retrieve details for SafeLinks rule '$RuleName'. Error: $($ErrorMessage.NormalizedError)" -sev 'Warning'
                 $Result.RuleError = "Failed to retrieve: $($ErrorMessage.NormalizedError)"
             }
         }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Application Approval/Invoke-ExecCreateAppTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Application Approval/Invoke-ExecCreateAppTemplate.ps1
@@ -123,7 +123,7 @@ function Invoke-ExecCreateAppTemplate {
                 $Permissions = @($DelegateResourceAccess) + @($ApplicationResourceAccess) | Where-Object { $_ -ne $null }
 
                 if ($Permissions.Count -eq 0) {
-                    Write-LogMessage -headers $Request.headers -API $APINAME -message "No permissions found for $AppId via any method" -sev 'Warn'
+                    Write-LogMessage -headers $Request.headers -API $APINAME -message "No permissions found for $AppId via any method" -sev 'Warning'
                 } else {
                     Write-LogMessage -headers $Request.headers -API $APINAME -message "Extracted $($Permissions.Count) resource permission(s) from service principal grants" -Sev 'Info'
                 }
@@ -246,7 +246,7 @@ function Invoke-ExecCreateAppTemplate {
                         })
                     $RequestIndex++
                 } else {
-                    Write-LogMessage -headers $Request.headers -API $APINAME -message "Service principal not found in tenant for appId: $ResourceAppId" -sev 'Warn'
+                    Write-LogMessage -headers $Request.headers -API $APINAME -message "Service principal not found in tenant for appId: $ResourceAppId" -sev 'Warning'
                 }
             }
 
@@ -275,7 +275,7 @@ function Invoke-ExecCreateAppTemplate {
                 $ResourceSP = $SPLookup[$ResourceAppId]
 
                 if (!$ResourceSP) {
-                    Write-LogMessage -headers $Request.headers -API $APINAME -message "Service principal not found for appId: $ResourceAppId - skipping permission translation" -sev 'Warn'
+                    Write-LogMessage -headers $Request.headers -API $APINAME -message "Service principal not found for appId: $ResourceAppId - skipping permission translation" -sev 'Warning'
                     continue
                 }
 
@@ -292,7 +292,7 @@ function Invoke-ExecCreateAppTemplate {
                             }
                             [void]$AppPerms.Add($PermObj)
                         } else {
-                            Write-LogMessage -headers $Request.headers -API $APINAME -message "Application permission $($Access.id) not found in $ResourceAppId appRoles" -sev 'Warn'
+                            Write-LogMessage -headers $Request.headers -API $APINAME -message "Application permission $($Access.id) not found in $ResourceAppId appRoles" -sev 'Warning'
                         }
                     } elseif ($Access.type -eq 'Scope') {
                         Write-Information "Processing delegated permission with id $($Access.id) for resource appId $ResourceAppId"
@@ -365,14 +365,14 @@ function Invoke-ExecCreateAppTemplate {
                             $PermissionSetId = $TemplateData.PermissionSetId
                             Write-LogMessage -headers $Request.headers -API $APINAME -message "Found existing permission set ID: $PermissionSetId in template" -Sev 'Info'
                         } else {
-                            Write-LogMessage -headers $Request.headers -API $APINAME -message 'Existing template found but has no PermissionSetId' -sev 'Warn'
+                            Write-LogMessage -headers $Request.headers -API $APINAME -message 'Existing template found but has no PermissionSetId' -sev 'Warning'
                         }
                         break
                     }
                 }
             } catch {
                 # Ignore lookup errors
-                Write-LogMessage -headers $Request.headers -API $APINAME -message "Error during template lookup: $($_.Exception.Message)" -sev 'Warn'
+                Write-LogMessage -headers $Request.headers -API $APINAME -message "Error during template lookup: $($_.Exception.Message)" -sev 'Warning'
             }
         }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-ListTenants.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-ListTenants.ps1
@@ -97,7 +97,7 @@ function Invoke-ListTenants {
                     try {
                         $Tenant | Add-Member -MemberType NoteProperty -Name 'offboardingDefaults' -Value ($TenantDefaults.Value | ConvertFrom-Json) -Force
                     } catch {
-                        Write-LogMessage -headers $Headers -API $APIName -message "Failed to parse offboarding defaults for tenant $($Tenant.defaultDomainName): $($_.Exception.Message)" -sev 'Warn'
+                        Write-LogMessage -headers $Headers -API $APIName -message "Failed to parse offboarding defaults for tenant $($Tenant.defaultDomainName): $($_.Exception.Message)" -sev 'Warning'
                         $Tenant | Add-Member -MemberType NoteProperty -Name 'offboardingDefaults' -Value $null -Force
                     }
                 } else {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/GDAP/Invoke-ExecGDAPRoleTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/GDAP/Invoke-ExecGDAPRoleTemplate.ps1
@@ -18,7 +18,7 @@ function Invoke-ExecGDAPRoleTemplate {
     if ($Request.Query.TemplateId) {
         $Template = $Templates | Where-Object -Property RowKey -EQ $Request.Query.TemplateId
         if (!$Template) {
-            Write-LogMessage -headers $Headers -API $APIName -message "GDAP role template '$($Request.Query.TemplateId)' not found" -sev 'Warn'
+            Write-LogMessage -headers $Headers -API $APIName -message "GDAP role template '$($Request.Query.TemplateId)' not found" -sev 'Warning'
             $Body = @{}
         } else {
             Write-LogMessage -headers $Headers -API $APIName -message "Retrieved GDAP role template '$($Request.Query.TemplateId)'" -Sev 'Info'
@@ -68,7 +68,7 @@ function Invoke-ExecGDAPRoleTemplate {
                         }
                     }
                 } else {
-                    Write-LogMessage -headers $Headers -API $APIName -message "GDAP role template '$OriginalRowKey' not found for editing" -sev 'Warn'
+                    Write-LogMessage -headers $Headers -API $APIName -message "GDAP role template '$OriginalRowKey' not found for editing" -sev 'Warning'
                     $Body = @{
                         Results = "Template $OriginalRowKey not found"
                     }
@@ -84,7 +84,7 @@ function Invoke-ExecGDAPRoleTemplate {
                         Results = "Deleted template $RowKey"
                     }
                 } else {
-                    Write-LogMessage -headers $Headers -API $APIName -message "GDAP role template '$RowKey' not found for deletion" -sev 'Warn'
+                    Write-LogMessage -headers $Headers -API $APIName -message "GDAP role template '$RowKey' not found for deletion" -sev 'Warning'
                     $Body = @{
                         Results = "Template $RowKey not found"
                     }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ExecUpdateDriftDeviation.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ExecUpdateDriftDeviation.ps1
@@ -62,7 +62,7 @@ function Invoke-ExecUpdateDriftDeviation {
                                 }
                             }
                             if (-not $MatchedTemplate) {
-                                Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Could not find IntuneTemplate $TemplateId in drift standard settings for remediation" -Sev 'Warn'
+                                Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Could not find IntuneTemplate $TemplateId in drift standard settings for remediation" -Sev 'Warning'
                             } else {
                                 $MatchedTemplate | Add-Member -MemberType NoteProperty -Name 'remediate' -Value $true -Force
                                 $MatchedTemplate | Add-Member -MemberType NoteProperty -Name 'report' -Value $true -Force
@@ -151,7 +151,7 @@ function Invoke-ExecUpdateDriftDeviation {
                             Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Deleted Policy with ID $($ID)" -Sev 'Info'
                         } else {
                             "could not find policy with ID $($ID)"
-                            Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Could not find Policy with ID $($ID) to delete for remediation" -sev 'Warn'
+                            Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Could not find Policy with ID $($ID) to delete for remediation" -sev 'Warning'
                         }
 
 

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeployCheckChromeExtension.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeployCheckChromeExtension.ps1
@@ -391,7 +391,7 @@ exit 0
                     if ($Result.status -match '^2') {
                         Write-LogMessage -API 'Standards' -tenant $Tenant -message "Removed legacy OMA-URI policy: $($Policy.displayName)" -sev Info
                     } else {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to remove legacy OMA-URI policy: $($Policy.displayName) - $($Result.body.error.message)" -sev Warn
+                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to remove legacy OMA-URI policy: $($Policy.displayName) - $($Result.body.error.message)" -sev Warning
                     }
                 }
             }

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardReusableSettingsTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardReusableSettingsTemplate.ps1
@@ -69,7 +69,7 @@ function Invoke-CIPPStandardReusableSettingsTemplate {
             $MissingLicenseMessage = "This tenant is missing one or more required licenses for this standard: $($RequiredCapabilities -join ', ')."
             Set-CIPPStandardsCompareField -FieldName "standards.ReusableSettingsTemplate.$($_.value)" -FieldValue $MissingLicenseMessage -Tenant $Tenant
         }
-        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Exiting as the correct license is not present for this standard. Missing: $($RequiredCapabilities -join ', ')" -sev 'Warn'
+        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Exiting as the correct license is not present for this standard. Missing: $($RequiredCapabilities -join ', ')" -sev 'Warning'
         return $true
     }
 
@@ -79,7 +79,7 @@ function Invoke-CIPPStandardReusableSettingsTemplate {
     # Align with other template standards by resolving all selected templates upfront
     $SelectedTemplateIds = @($Settings.TemplateList.value)
     if (-not $SelectedTemplateIds) {
-        Write-LogMessage -API 'Standards' -tenant $Tenant -message 'No reusable settings templates were selected.' -sev 'Warn'
+        Write-LogMessage -API 'Standards' -tenant $Tenant -message 'No reusable settings templates were selected.' -sev 'Warning'
         return $true
     }
 

--- a/Modules/CippExtensions/Public/PwPush/New-PwPushLink.ps1
+++ b/Modules/CippExtensions/Public/PwPush/New-PwPushLink.ps1
@@ -56,7 +56,7 @@ function New-PwPushLink {
                 'Exception' = Get-CippException -Exception $_
             }
             Write-LogMessage -API PwPush -Message "Failed to create a new PwPush link: $($_.Exception.Message)" -Sev 'Error' -LogData $LogData
-            Write-LogMessage -API PwPush -Message "Continuing without PwPush link due to error" -sev 'Warn'
+            Write-LogMessage -API PwPush -Message "Continuing without PwPush link due to error" -sev 'Warning'
             return $false
         }
     } catch {


### PR DESCRIPTION
Incorrect severity labels placed on logbook entries have been causing them not to send when configured on the Notifications tab