### PR TITLE
feat: show full MDE connector details

### DIFF
--- a/Modules/CIPPCore/Public/Get-CIPPMDEOnboardingReport.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPMDEOnboardingReport.ps1
@@ -19,6 +19,10 @@ function Get-CIPPMDEOnboardingReport {
             $TenantList = Get-Tenants -IncludeErrors
             $Tenants = $Tenants | Where-Object { $TenantList.defaultDomainName -contains $_ }
 
+            if (-not $Tenants) {
+                throw 'No MDE onboarding data found in reporting database for any tenant. Sync the report data first.'
+            }
+
             $AllResults = [System.Collections.Generic.List[PSCustomObject]]::new()
             foreach ($Tenant in $Tenants) {
                 try {

--- a/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheMDEOnboarding.ps1
+++ b/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheMDEOnboarding.ps1
@@ -21,19 +21,21 @@ function Set-CIPPDBCacheMDEOnboarding {
         $ConnectorUri = "https://graph.microsoft.com/beta/deviceManagement/mobileThreatDefenseConnectors/$ConnectorId"
         try {
             $ConnectorState = New-GraphGetRequest -uri $ConnectorUri -tenantid $TenantFilter
-            $PartnerState = $ConnectorState.partnerState
+            $Connector = $ConnectorState | Select-Object -ExcludeProperty '@odata.context'
+            $Connector | Add-Member -NotePropertyName 'Tenant'       -NotePropertyValue $TenantFilter -Force
+            $Connector | Add-Member -NotePropertyName 'RowKey'       -NotePropertyValue 'MDEOnboarding' -Force
+            $Connector | Add-Member -NotePropertyName 'PartitionKey' -NotePropertyValue $TenantFilter -Force
+            $Result = @($Connector)
         } catch {
-            $PartnerState = 'unavailable'
+            $Result = @(
+                [PSCustomObject]@{
+                    Tenant       = $TenantFilter
+                    partnerState = 'unavailable'
+                    RowKey       = 'MDEOnboarding'
+                    PartitionKey = $TenantFilter
+                }
+            )
         }
-
-        $Result = @(
-            [PSCustomObject]@{
-                Tenant       = $TenantFilter
-                partnerState = $PartnerState
-                RowKey       = 'MDEOnboarding'
-                PartitionKey = $TenantFilter
-            }
-        )
 
         Add-CIPPDbItem -TenantFilter $TenantFilter -Type 'MDEOnboarding' -Data @($Result)
         Add-CIPPDbItem -TenantFilter $TenantFilter -Type 'MDEOnboarding' -Data @($Result) -Count

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Invoke-ListMDEOnboarding.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Security/Invoke-ListMDEOnboarding.ps1
@@ -10,6 +10,10 @@ function Invoke-ListMDEOnboarding {
     $TenantFilter = $Request.Query.tenantFilter
     $UseReportDB = $Request.Query.UseReportDB
 
+    if ($TenantFilter -eq 'AllTenants') {
+        $UseReportDB = 'true'
+    }
+
     try {
         if ($UseReportDB -eq 'true') {
             try {
@@ -22,23 +26,22 @@ function Invoke-ListMDEOnboarding {
             }
 
             return ([HttpResponseContext]@{
-                StatusCode = $StatusCode
-                Body       = @($GraphRequest)
-            })
+                    StatusCode = $StatusCode
+                    Body       = @($GraphRequest)
+                })
         }
 
         $ConnectorId = 'fc780465-2017-40d4-a0c5-307022471b92'
         $ConnectorUri = "https://graph.microsoft.com/beta/deviceManagement/mobileThreatDefenseConnectors/$ConnectorId"
         try {
             $ConnectorState = New-GraphGetRequest -uri $ConnectorUri -tenantid $TenantFilter
-            $PartnerState = $ConnectorState.partnerState
+            $GraphRequest = $ConnectorState | Select-Object -ExcludeProperty '@odata.context'
+            $GraphRequest | Add-Member -NotePropertyName 'Tenant' -NotePropertyValue $TenantFilter -Force
         } catch {
-            $PartnerState = 'unavailable'
-        }
-
-        $GraphRequest = [PSCustomObject]@{
-            Tenant       = $TenantFilter
-            partnerState = $PartnerState
+            $GraphRequest = [PSCustomObject]@{
+                Tenant       = $TenantFilter
+                partnerState = 'unavailable'
+            }
         }
         $StatusCode = [HttpStatusCode]::OK
     } catch {
@@ -48,7 +51,7 @@ function Invoke-ListMDEOnboarding {
     }
 
     return ([HttpResponseContext]@{
-        StatusCode = $StatusCode
-        Body       = @($GraphRequest)
-    })
+            StatusCode = $StatusCode
+            Body       = @($GraphRequest)
+        })
 }


### PR DESCRIPTION
## Summary
- Cache writer and live endpoint now return the full `mobileThreatDefenseConnectors` Graph object instead of only `partnerState`.
- Failed Graph calls still write a `partnerState=unavailable` row so AllTenants keeps the tenant.

> Frontend counterpart: KelvinTegelaar/CIPP#5929.