### PR TITLE
fix: correct version_latest.txt path in remote API version check

### DIFF
--- a/Modules/CIPPCore/Public/Assert-CippVersion.ps1
+++ b/Modules/CIPPCore/Public/Assert-CippVersion.ps1
@@ -13,7 +13,7 @@ function Assert-CippVersion {
     param($CIPPVersion)
     $APIVersion = (Get-Content -Path (Join-Path $env:CIPPRootPath 'Config\version_latest.txt')).trim()
 
-    $RemoteAPIVersion = (Invoke-CIPPRestMethod -Uri 'https://raw.githubusercontent.com/KelvinTegelaar/CIPP-API/master/Config/version_latest.txt').trim()
+    $RemoteAPIVersion = (Invoke-CIPPRestMethod -Uri 'https://raw.githubusercontent.com/KelvinTegelaar/CIPP-API/master/version_latest.txt').trim()
     $RemoteCIPPVersion = (Invoke-CIPPRestMethod -Uri 'https://raw.githubusercontent.com/KelvinTegelaar/CIPP/main/public/version.json').version
 
     [PSCustomObject]@{


### PR DESCRIPTION
The remote URL in Assert-CippVersion was pointing to a path that no longer exists on KelvinTegelaar/CIPP-API:master after the master branch was restructured. The file lives at the repo root on master, not under Config/.

Returning a 404 from this endpoint causes Invoke-CIPPRestMethod to throw inside Assert-CippVersion, which exits before returning. The HTTP function returns no body and the frontend's Backend version field renders empty.

Path change only — no logic changes.