### PR TITLE
Fix handling of non-catalog null results in comparison function

### DIFF
--- a/Modules/CIPPCore/Public/Compare-CIPPIntuneObject.ps1
+++ b/Modules/CIPPCore/Public/Compare-CIPPIntuneObject.ps1
@@ -12,7 +12,7 @@ function Compare-CIPPIntuneObject {
         [Parameter(Mandatory = $false)]
         [string[]]$CompareType = @()
     )
-    if ($CompareType -ne 'Catalog') {
+    if ($CompareType -notcontains 'Catalog') {
         $defaultExcludeProperties = @(
             'id',
             'createdDateTime',

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ExecCompareIntunePolicy.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ExecCompareIntunePolicy.ps1
@@ -157,7 +157,8 @@ function Invoke-ExecCompareIntunePolicy {
         }
 
         # Run the comparison
-        $ComparisonResults = @(Compare-CIPPIntuneObject @CompareParams)
+        $CompareResult = Compare-CIPPIntuneObject @CompareParams
+        $ComparisonResults = if ($null -eq $CompareResult) { @() } else { @($CompareResult) }
 
         $ResultBody = @{
             Results      = $ComparisonResults


### PR DESCRIPTION
Adjust the comparison logic to properly handle cases where the result is null when the CompareType is not 'Catalog'. This ensures that the comparison results are always returned as an array, preventing potential errors.
Fixes "Failed to compare policies: Index operation failed; the array index evaluated to null." error on the compare policy page