### PR TITLE
Fix/standards run errors

### DIFF
--- a/.github/instructions/standards.instructions.md
+++ b/.github/instructions/standards.instructions.md
@@ -57,7 +57,7 @@ function Invoke-CIPPStandard<Name> {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param(

--- a/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheExoPresetSecurityPolicy.ps1
+++ b/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheExoPresetSecurityPolicy.ps1
@@ -19,6 +19,12 @@ function Set-CIPPDBCacheExoPresetSecurityPolicy {
     try {
         Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Caching Exchange Preset Security Policies' -sev Debug
 
+        $MDOTestResult = Test-CIPPStandardLicense -StandardName 'ExoPresetSecurityPolicy' -TenantFilter $TenantFilter -RequiredCapabilities @('ATP_ENTERPRISE', 'ATP_ENTERPRISE_GOV', 'THREAT_INTELLIGENCE') -SkipLog
+        if ($MDOTestResult -eq $false) {
+            Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Skipping Preset Security Policy cache: tenant lacks Microsoft Defender for Office 365' -sev Debug
+            return
+        }
+
         $EOPRules = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-EOPProtectionPolicyRule'
         $ATPRules = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-ATPProtectionPolicyRule'
 

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardActivityBasedTimeout.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardActivityBasedTimeout.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardActivityBasedTimeout {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAddDKIM.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAddDKIM.ps1
@@ -37,7 +37,7 @@ function Invoke-CIPPStandardAddDKIM {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAddDMARCToMOERA.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAddDMARCToMOERA.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardAddDMARCToMOERA {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAdminSSPR.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAdminSSPR.ps1
@@ -31,7 +31,7 @@
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAnonReportDisable.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAnonReportDisable.ps1
@@ -27,7 +27,7 @@ function Invoke-CIPPStandardAnonReportDisable {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAntiPhishPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAntiPhishPolicy.ps1
@@ -77,7 +77,7 @@ function Invoke-CIPPStandardAntiPhishPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAntiSpamSafeList.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAntiSpamSafeList.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardAntiSpamSafeList {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAppDeploy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAppDeploy.ps1
@@ -29,7 +29,7 @@ function Invoke-CIPPStandardAppDeploy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAppManagementPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAppManagementPolicy.ps1
@@ -30,7 +30,7 @@ function Invoke-CIPPStandardAppManagementPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAssignmentFilterTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAssignmentFilterTemplate.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardAssignmentFilterTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
 

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAtpPolicyForO365.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAtpPolicyForO365.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardAtpPolicyForO365 {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAtpPolicyForO365.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAtpPolicyForO365.ps1
@@ -46,6 +46,13 @@ function Invoke-CIPPStandardAtpPolicyForO365 {
     if ($TestResult -eq $false) {
         return $true
     } #we're done.
+
+    $MDOTestResult = Test-CIPPStandardLicense -StandardName 'AtpPolicyForO365' -TenantFilter $Tenant -RequiredCapabilities @('ATP_ENTERPRISE', 'ATP_ENTERPRISE_GOV', 'THREAT_INTELLIGENCE')
+
+    if ($MDOTestResult -eq $false) {
+        return $true
+    } #tenant lacks Microsoft Defender for Office 365 — Test-CIPPStandardLicense logs and sets LicenseAvailable=false.
+
     try {
         $CurrentState = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AtpPolicyForO365' |
             Select-Object EnableATPForSPOTeamsODB, EnableSafeDocs, AllowSafeDocsOpen

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAuditLog.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAuditLog.ps1
@@ -39,7 +39,7 @@ function Invoke-CIPPStandardAuditLog {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAuthMethodsPolicyMigration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAuthMethodsPolicyMigration.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardAuthMethodsPolicyMigration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAuthMethodsSettings.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAuthMethodsSettings.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardAuthMethodsSettings {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutoAddProxy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutoAddProxy.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardAutoAddProxy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param(
         $Tenant,

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutoArchive.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutoArchive.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardAutoArchive {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutoArchiveMailbox.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutoArchiveMailbox.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardAutoArchiveMailbox {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutoExpandArchive.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutoExpandArchive.ps1
@@ -32,7 +32,7 @@ function Invoke-CIPPStandardAutoExpandArchive {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutopilotProfile.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutopilotProfile.ps1
@@ -43,7 +43,7 @@ function Invoke-CIPPStandardAutopilotProfile {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
     $TestResult = Test-CIPPStandardLicense -StandardName 'AutopilotProfile' -TenantFilter $Tenant -RequiredCapabilities @('INTUNE_A', 'MDM_Services', 'EMS', 'SCCM', 'MICROSOFTINTUNEPLAN1')

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutopilotStatusPage.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardAutopilotStatusPage.ps1
@@ -41,7 +41,7 @@ function Invoke-CIPPStandardAutopilotStatusPage {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
     $TestResult = Test-CIPPStandardLicense -StandardName 'AutopilotStatusPage' -TenantFilter $Tenant -RequiredCapabilities @('INTUNE_A', 'MDM_Services', 'EMS', 'SCCM', 'MICROSOFTINTUNEPLAN1')

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardBitLockerKeysForOwnedDevice.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardBitLockerKeysForOwnedDevice.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardBitLockerKeysForOwnedDevice {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardBookings.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardBookings.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardBookings {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardBranding.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardBranding.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardBranding {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardCloudMessageRecall.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardCloudMessageRecall.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardCloudMessageRecall {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardColleagueImpersonationAlert.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardColleagueImpersonationAlert.ps1
@@ -41,7 +41,7 @@ function Invoke-CIPPStandardColleagueImpersonationAlert {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardConditionalAccessTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardConditionalAccessTemplate.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardConditionalAccessTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
 

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardCustomBannedPasswordList.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardCustomBannedPasswordList.ps1
@@ -38,7 +38,7 @@ function Invoke-CIPPStandardCustomBannedPasswordList {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefaultPlatformRestrictions.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefaultPlatformRestrictions.ps1
@@ -43,7 +43,7 @@ function Invoke-CIPPStandardDefaultPlatformRestrictions {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefaultSharingLink.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefaultSharingLink.ps1
@@ -42,7 +42,7 @@ function Invoke-CIPPStandardDefaultSharingLink {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderASRPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderASRPolicy.ps1
@@ -48,7 +48,7 @@ function Invoke-CIPPStandardDefenderASRPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderAVPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderAVPolicy.ps1
@@ -56,7 +56,7 @@ function Invoke-CIPPStandardDefenderAVPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderCompliancePolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderCompliancePolicy.ps1
@@ -44,7 +44,7 @@ function Invoke-CIPPStandardDefenderCompliancePolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderEDRPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderEDRPolicy.ps1
@@ -30,7 +30,7 @@ function Invoke-CIPPStandardDefenderEDRPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderExclusionPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderExclusionPolicy.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardDefenderExclusionPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDelegateSentItems.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDelegateSentItems.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardDelegateSentItems {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeletedUserRentention.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeletedUserRentention.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardDeletedUserRentention {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeployCheckChromeExtension.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeployCheckChromeExtension.ps1
@@ -57,7 +57,7 @@ function Invoke-CIPPStandardDeployCheckChromeExtension {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeployContactTemplates.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeployContactTemplates.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardDeployContactTemplates {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeployMailContact.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDeployMailContact.ps1
@@ -37,7 +37,7 @@ function Invoke-CIPPStandardDeployMailContact {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableAddShortcutsToOneDrive.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableAddShortcutsToOneDrive.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardDisableAddShortcutsToOneDrive {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableAdditionalStorageProviders.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableAdditionalStorageProviders.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardDisableAdditionalStorageProviders {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableAppCreation.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableAppCreation.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardDisableAppCreation {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableBasicAuthSMTP.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableBasicAuthSMTP.ps1
@@ -38,7 +38,7 @@ function Invoke-CIPPStandardDisableBasicAuthSMTP {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableEWS.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableEWS.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardDisableEWS {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableEmail.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableEmail.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardDisableEmail {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableEntraPortal.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableEntraPortal.ps1
@@ -6,7 +6,7 @@ function Invoke-CIPPStandardDisableEntraPortal {
         (APIName) DisableEntraPortal
     .SYNOPSIS
         (Label) Disables the Entra Portal for standard users
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableExchangeOnlinePowerShell.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableExchangeOnlinePowerShell.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardDisableExchangeOnlinePowerShell {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableExternalCalendarSharing.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableExternalCalendarSharing.ps1
@@ -37,7 +37,7 @@ function Invoke-CIPPStandardDisableExternalCalendarSharing {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableGuestDirectory.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableGuestDirectory.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardDisableGuestDirectory {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableGuests.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardDisableGuests {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableM365GroupUsers.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableM365GroupUsers.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardDisableM365GroupUsers {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableOutlookAddins.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableOutlookAddins.ps1
@@ -38,7 +38,7 @@ function Invoke-CIPPStandardDisableOutlookAddins {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableQRCodePin.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableQRCodePin.ps1
@@ -26,7 +26,7 @@ function Invoke-CIPPStandardDisableQRCodePin {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableReshare.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableReshare.ps1
@@ -41,7 +41,7 @@ function Invoke-CIPPStandardDisableReshare {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableResourceMailbox.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableResourceMailbox.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardDisableResourceMailbox {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSMS.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSMS.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardDisableSMS {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSecurityGroupUsers.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSecurityGroupUsers.ps1
@@ -29,7 +29,7 @@ function Invoke-CIPPStandardDisableSecurityGroupUsers {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSelfServiceLicenses.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSelfServiceLicenses.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardDisableSelfServiceLicenses {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSharePointLegacyAuth.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSharePointLegacyAuth.ps1
@@ -43,7 +43,7 @@ function Invoke-CIPPStandardDisableSharePointLegacyAuth {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSharedMailbox.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSharedMailbox.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardDisableSharedMailbox {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableTNEF.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableTNEF.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardDisableTNEF {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param ($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableTenantCreation.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableTenantCreation.ps1
@@ -32,7 +32,7 @@ function Invoke-CIPPStandardDisableTenantCreation {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableUserSiteCreate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableUserSiteCreate.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardDisableUserSiteCreate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableViva.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableViva.ps1
@@ -26,7 +26,7 @@ function Invoke-CIPPStandardDisableViva {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableVoice.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableVoice.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardDisableVoice {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisablex509Certificate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisablex509Certificate.ps1
@@ -26,7 +26,7 @@ function Invoke-CIPPStandardDisablex509Certificate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEXODirectSend.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEXODirectSend.ps1
@@ -27,7 +27,7 @@ function Invoke-CIPPStandardEXODirectSend {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param ($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEXODisableAutoForwarding.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEXODisableAutoForwarding.ps1
@@ -39,7 +39,7 @@ function Invoke-CIPPStandardEXODisableAutoForwarding {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEXOOutboundSpamLimits.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEXOOutboundSpamLimits.ps1
@@ -39,7 +39,7 @@ function Invoke-CIPPStandardEXOOutboundSpamLimits {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableAppConsentRequests.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableAppConsentRequests.ps1
@@ -42,7 +42,7 @@ function Invoke-CIPPStandardEnableAppConsentRequests {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableCustomerLockbox.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableCustomerLockbox.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardEnableCustomerLockbox {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableExchangeCloudManagement.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableExchangeCloudManagement.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardEnableExchangeCloudManagement {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableFIDO2.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableFIDO2.ps1
@@ -40,7 +40,7 @@ function Invoke-CIPPStandardEnableFIDO2 {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableHardwareOAuth.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableHardwareOAuth.ps1
@@ -26,7 +26,7 @@ function Invoke-CIPPStandardEnableHardwareOAuth {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableLitigationHold.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableLitigationHold.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardEnableLitigationHold {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableMailTips.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableMailTips.ps1
@@ -37,7 +37,7 @@ function Invoke-CIPPStandardEnableMailTips {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableMailboxAuditing.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableMailboxAuditing.ps1
@@ -42,7 +42,7 @@ function Invoke-CIPPStandardEnableMailboxAuditing {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableNamePronunciation.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableNamePronunciation.ps1
@@ -25,7 +25,7 @@ function Invoke-CIPPStandardEnableNamePronunciation {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param ($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableOnlineArchiving.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnableOnlineArchiving.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardEnableOnlineArchiving {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnablePronouns.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnablePronouns.ps1
@@ -26,7 +26,7 @@ function Invoke-CIPPStandardEnablePronouns {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param ($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnrollmentWindowsHelloForBusinessConfiguration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardEnrollmentWindowsHelloForBusinessConfiguration.ps1
@@ -44,7 +44,7 @@ function Invoke-CIPPStandardEnrollmentWindowsHelloForBusinessConfiguration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExchangeConnectorTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExchangeConnectorTemplate.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardExchangeConnectorTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
     $TestResult = Test-CIPPStandardLicense -StandardName 'ExConnector' -TenantFilter $Tenant -RequiredCapabilities @('EXCHANGE_S_STANDARD', 'EXCHANGE_S_ENTERPRISE', 'EXCHANGE_S_STANDARD_GOV', 'EXCHANGE_S_ENTERPRISE_GOV', 'EXCHANGE_LITE') #No Foundation because that does not allow powershell access

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExcludedfileExt.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExcludedfileExt.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardExcludedfileExt {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExternalMFATrusted.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExternalMFATrusted.ps1
@@ -29,7 +29,7 @@ function Invoke-CIPPStandardExternalMFATrusted {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardFocusedInbox.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardFocusedInbox.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardFocusedInbox {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardFormsPhishingProtection.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardFormsPhishingProtection.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardFormsPhishingProtection {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param ($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardGlobalQuarantineNotifications.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardGlobalQuarantineNotifications.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardGlobalQuarantineNotifications {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param ($Tenant, $Settings)
     $TestResult = Test-CIPPStandardLicense -StandardName 'GlobalQuarantineNotifications' -TenantFilter $Tenant -RequiredCapabilities @('EXCHANGE_S_STANDARD', 'EXCHANGE_S_ENTERPRISE', 'EXCHANGE_S_STANDARD_GOV', 'EXCHANGE_S_ENTERPRISE_GOV', 'EXCHANGE_LITE') #No Foundation because that does not allow powershell access

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardGlobalQuarantineSettings.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardGlobalQuarantineSettings.ps1
@@ -37,7 +37,7 @@ function Invoke-CIPPStandardGlobalQuarantineSettings {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
     $TestResult = Test-CIPPStandardLicense -StandardName 'QuarantineTemplate' -TenantFilter $Tenant -RequiredCapabilities @('EXCHANGE_S_STANDARD', 'EXCHANGE_S_ENTERPRISE', 'EXCHANGE_S_STANDARD_GOV', 'EXCHANGE_S_ENTERPRISE_GOV', 'EXCHANGE_LITE') #No Foundation because that does not allow powershell access

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardGroupTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardGroupTemplate.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardGroupTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
 

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardGuestInvite.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardGuestInvite.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardGuestInvite {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardIntuneComplianceSettings.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardIntuneComplianceSettings.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardIntuneComplianceSettings {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardIntuneTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardIntuneTemplate.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardIntuneTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
 

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardIntuneWindowsDiagnostic.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardIntuneWindowsDiagnostic.ps1
@@ -34,7 +34,7 @@ Function Invoke-CIPPStandardIntuneWindowsDiagnostic {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     [CmdletBinding()]
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardLegacyEmailReportAddins.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardLegacyEmailReportAddins.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardLegacyEmailReportAddins {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardLegacyMFACleanup.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardLegacyMFACleanup.ps1
@@ -26,7 +26,7 @@ function Invoke-CIPPStandardLegacyMFACleanup {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMDMEnrollmentDuringRegistration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMDMEnrollmentDuringRegistration.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardMDMEnrollmentDuringRegistration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMDMScope.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMDMScope.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardMDMScope {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMailContacts.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMailContacts.ps1
@@ -30,7 +30,7 @@ function Invoke-CIPPStandardMailContacts {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMailboxRecipientLimits.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMailboxRecipientLimits.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardMailboxRecipientLimits {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMalwareFilterPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMalwareFilterPolicy.ps1
@@ -54,7 +54,7 @@ function Invoke-CIPPStandardMalwareFilterPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMessageExpiration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMessageExpiration.ps1
@@ -30,7 +30,7 @@ function Invoke-CIPPStandardMessageExpiration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardNudgeMFA.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardNudgeMFA.ps1
@@ -29,7 +29,7 @@ function Invoke-CIPPStandardNudgeMFA {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOMEBranding.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOMEBranding.ps1
@@ -37,7 +37,7 @@ function Invoke-CIPPStandardOMEBranding {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>      
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOWAAttachmentRestrictions.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOWAAttachmentRestrictions.ps1
@@ -38,7 +38,7 @@ function Invoke-CIPPStandardOWAAttachmentRestrictions {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOauthConsent.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOauthConsent.ps1
@@ -43,7 +43,7 @@ function Invoke-CIPPStandardOauthConsent {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($tenant, $settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOauthConsentLowSec.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOauthConsentLowSec.ps1
@@ -26,7 +26,7 @@ function Invoke-CIPPStandardOauthConsentLowSec {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOutBoundSpamAlert.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardOutBoundSpamAlert.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardOutBoundSpamAlert {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPWcompanionAppAllowedState.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPWcompanionAppAllowedState.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardPWcompanionAppAllowedState {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPWdisplayAppInformationRequiredState.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPWdisplayAppInformationRequiredState.ps1
@@ -42,7 +42,7 @@ function Invoke-CIPPStandardPWdisplayAppInformationRequiredState {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPasswordExpireDisabled.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPasswordExpireDisabled.ps1
@@ -30,7 +30,7 @@ function Invoke-CIPPStandardPasswordExpireDisabled {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPerUserMFA.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPerUserMFA.ps1
@@ -38,7 +38,7 @@ function Invoke-CIPPStandardPerUserMFA {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPhishProtection.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPhishProtection.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardPhishProtection {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPhishSimSpoofIntelligence.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPhishSimSpoofIntelligence.ps1
@@ -32,7 +32,7 @@ function Invoke-CIPPStandardPhishSimSpoofIntelligence {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPhishingSimulations.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPhishingSimulations.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardPhishingSimulations {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardProfilePhotos.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardProfilePhotos.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardProfilePhotos {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardQuarantineRequestAlert.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardQuarantineRequestAlert.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardQuarantineRequestAlert {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param ($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardQuarantineTemplate.ps1
@@ -44,7 +44,7 @@ function Invoke-CIPPStandardQuarantineTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardRestrictThirdPartyStorageServices.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardRestrictThirdPartyStorageServices.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardRestrictThirdPartyStorageServices {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param ($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardRetentionPolicyTag.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardRetentionPolicyTag.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardRetentionPolicyTag {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardRetentionPolicyTag.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardRetentionPolicyTag.ps1
@@ -58,7 +58,9 @@ function Invoke-CIPPStandardRetentionPolicyTag {
         return
     }
 
-    $CurrentAgeLimitForRetention = ([timespan]$CurrentState.AgeLimitForRetention).TotalDays
+    $CurrentAgeLimitForRetention = if ($CurrentState.AgeLimitForRetention) {
+        ([timespan]$CurrentState.AgeLimitForRetention).TotalDays
+    }
 
     $StateIsCorrect = ($CurrentState.Name -eq $PolicyName) -and
     ($CurrentState.RetentionEnabled -eq $true) -and

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardReusableSettingsTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardReusableSettingsTemplate.ps1
@@ -30,7 +30,7 @@ function Invoke-CIPPStandardReusableSettingsTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
 

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardRotateDKIM.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardRotateDKIM.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardRotateDKIM {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPAzureB2B.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPAzureB2B.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardSPAzureB2B {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDirectSharing.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDirectSharing.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardSPDirectSharing {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDisableCustomScripts.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDisableCustomScripts.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardSPDisableCustomScripts {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDisableLegacyWorkflows.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDisableLegacyWorkflows.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardSPDisableLegacyWorkflows {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
     $TestResult = Test-CIPPStandardLicense -StandardName 'SPDisableLegacyWorkflows' -TenantFilter $Tenant -RequiredCapabilities @('SHAREPOINTWAC', 'SHAREPOINTSTANDARD', 'SHAREPOINTENTERPRISE', 'SHAREPOINTENTERPRISE_EDU', 'SHAREPOINTENTERPRISE_GOV', 'ONEDRIVE_BASIC', 'ONEDRIVE_ENTERPRISE')

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDisableStoreAccess.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDisableStoreAccess.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardSPDisableStoreAccess {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDisallowInfectedFiles.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPDisallowInfectedFiles.ps1
@@ -40,7 +40,7 @@ function Invoke-CIPPStandardSPDisallowInfectedFiles {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPEmailAttestation.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPEmailAttestation.ps1
@@ -41,7 +41,7 @@ function Invoke-CIPPStandardSPEmailAttestation {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPExternalUserExpiration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPExternalUserExpiration.ps1
@@ -41,7 +41,7 @@ function Invoke-CIPPStandardSPExternalUserExpiration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPFileRequests.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPFileRequests.ps1
@@ -37,7 +37,7 @@ function Invoke-CIPPStandardSPFileRequests {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPSyncButtonState.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPSyncButtonState.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardSPSyncButtonState {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeAttachmentPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeAttachmentPolicy.ps1
@@ -53,180 +53,166 @@ function Invoke-CIPPStandardSafeAttachmentPolicy {
         return $true
     } #we're done.
 
-    $TenantCapabilities = Get-CIPPTenantCapabilities -TenantFilter $Tenant
-    $MDOLicensed = $TenantCapabilities.ATP_ENTERPRISE -eq $true
+    $MDOTestResult = Test-CIPPStandardLicense -StandardName 'SafeAttachmentPolicy' -TenantFilter $Tenant -RequiredCapabilities @('ATP_ENTERPRISE', 'ATP_ENTERPRISE_GOV', 'THREAT_INTELLIGENCE')
 
-    if ($MDOLicensed) {
-        # Cache all Safe Attachment Policies to avoid duplicate API calls
-        try {
-            $AllSafeAttachmentPolicies = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeAttachmentPolicy'
-        } catch {
-            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the SafeAttachmentPolicy state for $Tenant. Error: $ErrorMessage" -Sev Error
-            return
-        }
-        # Cache all Safe Attachment Rules to avoid duplicate API calls
-        try {
-            $AllSafeAttachmentRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeAttachmentRule'
-        } catch {
-            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the SafeAttachmentRule state for $Tenant. Error: $ErrorMessage" -Sev Error
-            return
-        }
+    if ($MDOTestResult -eq $false) {
+        return $true
+    } #tenant lacks Microsoft Defender for Office 365 — Test-CIPPStandardLicense logs and sets LicenseAvailable=false.
 
-        # Use custom name if provided, otherwise use default for backward compatibility
+    # Cache all Safe Attachment Policies to avoid duplicate API calls
+    try {
+        $AllSafeAttachmentPolicies = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeAttachmentPolicy'
+    } catch {
+        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the SafeAttachmentPolicy state for $Tenant. Error: $ErrorMessage" -Sev Error
+        return
+    }
+    # Cache all Safe Attachment Rules to avoid duplicate API calls
+    try {
+        $AllSafeAttachmentRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeAttachmentRule'
+    } catch {
+        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the SafeAttachmentRule state for $Tenant. Error: $ErrorMessage" -Sev Error
+        return
+    }
+
+    # Use custom name if provided, otherwise use default for backward compatibility
+    $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default Safe Attachment Policy' }
+    $PolicyList = @($PolicyName, 'CIPP Default Safe Attachment Policy', 'Default Safe Attachment Policy')
+    $ExistingPolicy = $AllSafeAttachmentPolicies | Where-Object -Property Name -In $PolicyList | Select-Object -First 1
+    if ($null -eq $ExistingPolicy.Name) {
+        # No existing policy - use the configured/default name
         $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default Safe Attachment Policy' }
-        $PolicyList = @($PolicyName, 'CIPP Default Safe Attachment Policy', 'Default Safe Attachment Policy')
-        $ExistingPolicy = $AllSafeAttachmentPolicies | Where-Object -Property Name -In $PolicyList | Select-Object -First 1
-        if ($null -eq $ExistingPolicy.Name) {
-            # No existing policy - use the configured/default name
-            $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default Safe Attachment Policy' }
-        } else {
-            # Use existing policy name if found
-            $PolicyName = $ExistingPolicy.Name
-        }
-        # Derive rule name from policy name, but check for old names for backward compatibility
-        $DesiredRuleName = "$PolicyName Rule"
-        $RuleList = @($DesiredRuleName, 'CIPP Default Safe Attachment Rule', 'CIPP Default Safe Attachment Policy')
-        $ExistingRule = $AllSafeAttachmentRule | Where-Object -Property Name -In $RuleList | Select-Object -First 1
-        if ($null -eq $ExistingRule.Name) {
-            # No existing rule - use the derived name
-            $RuleName = $DesiredRuleName
-        } else {
-            # Use existing rule name if found
-            $RuleName = $ExistingRule.Name
-        }
-
-        $CurrentState = $AllSafeAttachmentPolicies |
-            Where-Object -Property Name -EQ $PolicyName |
-            Select-Object Name, Enable, Action, QuarantineTag, Redirect, RedirectAddress
-
-        $StateIsCorrect = ($CurrentState.Name -eq $PolicyName) -and
-        ($CurrentState.Enable -eq $true) -and
-        ($CurrentState.Action -eq $Settings.SafeAttachmentAction) -and
-        ($CurrentState.QuarantineTag -eq $Settings.QuarantineTag) -and
-        ($CurrentState.Redirect -eq $Settings.Redirect) -and
-        (($null -eq $Settings.RedirectAddress) -or ($CurrentState.RedirectAddress -eq $Settings.RedirectAddress))
-
-        $AcceptedDomains = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AcceptedDomain'
-
-        $RuleState = $AllSafeAttachmentRule |
-        Where-Object -Property Name -EQ $RuleName |
-        Select-Object Name, SafeAttachmentPolicy, Priority, RecipientDomainIs
-
-        $RuleStateIsCorrect = ($RuleState.Name -eq $RuleName) -and
-        ($RuleState.SafeAttachmentPolicy -eq $PolicyName) -and
-        ($RuleState.Priority -eq 0) -and
-        (!(Compare-Object -ReferenceObject $RuleState.RecipientDomainIs -DifferenceObject $AcceptedDomains.Name))
-
-        if ($Settings.remediate -eq $true) {
-
-            if ($StateIsCorrect -eq $true) {
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Safe Attachment Policy already correctly configured' -sev Info
-            } else {
-                $cmdParams = @{
-                    Enable          = $true
-                    Action          = $Settings.SafeAttachmentAction
-                    QuarantineTag   = $Settings.QuarantineTag
-                    Redirect        = $Settings.Redirect
-                    RedirectAddress = $Settings.RedirectAddress
-                }
-
-                if ($CurrentState.Name -eq $PolicyName) {
-                    try {
-                        $cmdParams.Add('Identity', $PolicyName)
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'Set-SafeAttachmentPolicy' -cmdParams $cmdParams -UseSystemMailbox $true
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated Safe Attachment policy $PolicyName." -sev Info
-                    } catch {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update Safe Attachment policy $PolicyName." -sev Error -LogData $_
-                    }
-                } else {
-                    try {
-                        $cmdParams.Add('Name', $PolicyName)
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'New-SafeAttachmentPolicy' -cmdParams $cmdParams -UseSystemMailbox $true
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created Safe Attachment policy $PolicyName." -sev Info
-                    } catch {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to create Safe Attachment policy $PolicyName." -sev Error -LogData $_
-                    }
-                }
-            }
-
-            if ($RuleStateIsCorrect -eq $false) {
-                $cmdParams = @{
-                    Priority          = 0
-                    RecipientDomainIs = ConvertTo-SafeArray -Field $AcceptedDomains.Name
-                }
-
-                if ($RuleState.SafeAttachmentPolicy -ne $PolicyName) {
-                    $cmdParams.Add('SafeAttachmentPolicy', $PolicyName)
-                }
-
-                if ($RuleState.Name -eq $RuleName) {
-                    try {
-                        $cmdParams.Add('Identity', $RuleName)
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'Set-SafeAttachmentRule' -cmdParams $cmdParams -UseSystemMailbox $true
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated Safe Attachment rule $RuleName." -sev Info
-                    } catch {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update Safe Attachment rule $RuleName." -sev Error -LogData $_
-                    }
-                } else {
-                    try {
-                        $cmdParams.Add('Name', $RuleName)
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'New-SafeAttachmentRule' -cmdParams $cmdParams -UseSystemMailbox $true
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created Safe Attachment rule $RuleName." -sev Info
-                    } catch {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to create Safe Attachment rule $RuleName." -sev Error -LogData $_
-                    }
-                }
-            }
-        }
-
-        if ($Settings.alert -eq $true) {
-
-            if ($StateIsCorrect -eq $true) {
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Safe Attachment Policy is enabled' -sev Info
-            } else {
-                Write-StandardsAlert -message 'Safe Attachment Policy is not enabled' -object $CurrentState -tenant $Tenant -standardName 'SafeAttachmentPolicy' -standardId $Settings.standardId
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Safe Attachment Policy is not enabled' -sev Info
-            }
-        }
-
-        if ($Settings.report -eq $true) {
-            Add-CIPPBPAField -FieldName 'SafeAttachmentPolicy' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $tenant
-
-            $CurrentValue = @{
-                name            = $CurrentState.Name
-                enable          = $CurrentState.Enable
-                action          = $CurrentState.Action
-                quarantineTag   = $CurrentState.QuarantineTag
-                redirect        = $CurrentState.Redirect
-                redirectAddress = $CurrentState.RedirectAddress
-            }
-
-            $ExpectedValue = @{
-                name            = $PolicyName
-                enable          = $true
-                action          = $Settings.SafeAttachmentAction
-                quarantineTag   = $Settings.QuarantineTag
-                redirect        = $Settings.Redirect
-                redirectAddress = "$($Settings.RedirectAddress)"
-            }
-            Set-CIPPStandardsCompareField -FieldName 'standards.SafeAttachmentPolicy' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -Tenant $Tenant
-        }
     } else {
-        if ($Settings.remediate -eq $true) {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Failed to create Safe Attachment policy: Tenant does not have Microsoft Defender for Office 365 license' -sev Error
+        # Use existing policy name if found
+        $PolicyName = $ExistingPolicy.Name
+    }
+    # Derive rule name from policy name, but check for old names for backward compatibility
+    $DesiredRuleName = "$PolicyName Rule"
+    $RuleList = @($DesiredRuleName, 'CIPP Default Safe Attachment Rule', 'CIPP Default Safe Attachment Policy')
+    $ExistingRule = $AllSafeAttachmentRule | Where-Object -Property Name -In $RuleList | Select-Object -First 1
+    if ($null -eq $ExistingRule.Name) {
+        # No existing rule - use the derived name
+        $RuleName = $DesiredRuleName
+    } else {
+        # Use existing rule name if found
+        $RuleName = $ExistingRule.Name
+    }
+
+    $CurrentState = $AllSafeAttachmentPolicies |
+        Where-Object -Property Name -EQ $PolicyName |
+        Select-Object Name, Enable, Action, QuarantineTag, Redirect, RedirectAddress
+
+    $StateIsCorrect = ($CurrentState.Name -eq $PolicyName) -and
+    ($CurrentState.Enable -eq $true) -and
+    ($CurrentState.Action -eq $Settings.SafeAttachmentAction) -and
+    ($CurrentState.QuarantineTag -eq $Settings.QuarantineTag) -and
+    ($CurrentState.Redirect -eq $Settings.Redirect) -and
+    (($null -eq $Settings.RedirectAddress) -or ($CurrentState.RedirectAddress -eq $Settings.RedirectAddress))
+
+    $AcceptedDomains = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AcceptedDomain'
+
+    $RuleState = $AllSafeAttachmentRule |
+    Where-Object -Property Name -EQ $RuleName |
+    Select-Object Name, SafeAttachmentPolicy, Priority, RecipientDomainIs
+
+    $RuleStateIsCorrect = ($RuleState.Name -eq $RuleName) -and
+    ($RuleState.SafeAttachmentPolicy -eq $PolicyName) -and
+    ($RuleState.Priority -eq 0) -and
+    (!(Compare-Object -ReferenceObject $RuleState.RecipientDomainIs -DifferenceObject $AcceptedDomains.Name))
+
+    if ($Settings.remediate -eq $true) {
+
+        if ($StateIsCorrect -eq $true) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Safe Attachment Policy already correctly configured' -sev Info
+        } else {
+            $cmdParams = @{
+                Enable          = $true
+                Action          = $Settings.SafeAttachmentAction
+                QuarantineTag   = $Settings.QuarantineTag
+                Redirect        = $Settings.Redirect
+                RedirectAddress = $Settings.RedirectAddress
+            }
+
+            if ($CurrentState.Name -eq $PolicyName) {
+                try {
+                    $cmdParams.Add('Identity', $PolicyName)
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'Set-SafeAttachmentPolicy' -cmdParams $cmdParams -UseSystemMailbox $true
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated Safe Attachment policy $PolicyName." -sev Info
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update Safe Attachment policy $PolicyName." -sev Error -LogData $_
+                }
+            } else {
+                try {
+                    $cmdParams.Add('Name', $PolicyName)
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'New-SafeAttachmentPolicy' -cmdParams $cmdParams -UseSystemMailbox $true
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created Safe Attachment policy $PolicyName." -sev Info
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to create Safe Attachment policy $PolicyName." -sev Error -LogData $_
+                }
+            }
         }
 
-        if ($Settings.alert -eq $true) {
-            Write-StandardsAlert -message 'Safe Attachment Policy is not enabled: Tenant does not have Microsoft Defender for Office 365 license' -object $MDOLicensed -tenant $Tenant -standardName 'SafeAttachmentPolicy' -standardId $Settings.standardId
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Safe Attachment Policy is not enabled: Tenant does not have Microsoft Defender for Office 365 license' -sev Info
+        if ($RuleStateIsCorrect -eq $false) {
+            $cmdParams = @{
+                Priority          = 0
+                RecipientDomainIs = ConvertTo-SafeArray -Field $AcceptedDomains.Name
+            }
+
+            if ($RuleState.SafeAttachmentPolicy -ne $PolicyName) {
+                $cmdParams.Add('SafeAttachmentPolicy', $PolicyName)
+            }
+
+            if ($RuleState.Name -eq $RuleName) {
+                try {
+                    $cmdParams.Add('Identity', $RuleName)
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'Set-SafeAttachmentRule' -cmdParams $cmdParams -UseSystemMailbox $true
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated Safe Attachment rule $RuleName." -sev Info
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update Safe Attachment rule $RuleName." -sev Error -LogData $_
+                }
+            } else {
+                try {
+                    $cmdParams.Add('Name', $RuleName)
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'New-SafeAttachmentRule' -cmdParams $cmdParams -UseSystemMailbox $true
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created Safe Attachment rule $RuleName." -sev Info
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to create Safe Attachment rule $RuleName." -sev Error -LogData $_
+                }
+            }
+        }
+    }
+
+    if ($Settings.alert -eq $true) {
+
+        if ($StateIsCorrect -eq $true) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Safe Attachment Policy is enabled' -sev Info
+        } else {
+            Write-StandardsAlert -message 'Safe Attachment Policy is not enabled' -object $CurrentState -tenant $Tenant -standardName 'SafeAttachmentPolicy' -standardId $Settings.standardId
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Safe Attachment Policy is not enabled' -sev Info
+        }
+    }
+
+    if ($Settings.report -eq $true) {
+        Add-CIPPBPAField -FieldName 'SafeAttachmentPolicy' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $tenant
+
+        $CurrentValue = @{
+            name            = $CurrentState.Name
+            enable          = $CurrentState.Enable
+            action          = $CurrentState.Action
+            quarantineTag   = $CurrentState.QuarantineTag
+            redirect        = $CurrentState.Redirect
+            redirectAddress = $CurrentState.RedirectAddress
         }
 
-        if ($Settings.report -eq $true) {
-            $state = @{ License = 'Failed to set policy: This tenant might not be licensed for this feature' }
-            Add-CIPPBPAField -FieldName 'SafeAttachmentPolicy' -FieldValue $false -StoreAs bool -Tenant $tenant
-            Set-CIPPStandardsCompareField -FieldName 'standards.SafeAttachmentPolicy' -FieldValue $state -Tenant $Tenant
+        $ExpectedValue = @{
+            name            = $PolicyName
+            enable          = $true
+            action          = $Settings.SafeAttachmentAction
+            quarantineTag   = $Settings.QuarantineTag
+            redirect        = $Settings.Redirect
+            redirectAddress = "$($Settings.RedirectAddress)"
         }
+        Set-CIPPStandardsCompareField -FieldName 'standards.SafeAttachmentPolicy' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -Tenant $Tenant
     }
 }

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeAttachmentPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeAttachmentPolicy.ps1
@@ -43,7 +43,7 @@ function Invoke-CIPPStandardSafeAttachmentPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
@@ -57,7 +57,7 @@ function Invoke-CIPPStandardSafeLinksPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
@@ -67,201 +67,188 @@ function Invoke-CIPPStandardSafeLinksPolicy {
         return $true
     } #we're done.
 
-    $TenantCapabilities = Get-CIPPTenantCapabilities -TenantFilter $Tenant
-    $MDOLicensed = $TenantCapabilities.ATP_ENTERPRISE -eq $true
+    $MDOTestResult = Test-CIPPStandardLicense -StandardName 'SafeLinksPolicy' -TenantFilter $Tenant -RequiredCapabilities @('ATP_ENTERPRISE', 'ATP_ENTERPRISE_GOV', 'THREAT_INTELLIGENCE')
 
-    if ($MDOLicensed) {
-        # Single data retrieval calls with error handling
-        try {
-            $AllSafeLinksPolicy = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksPolicy'
-        } catch {
-            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the SafeLinksPolicy state for $Tenant. Error: $ErrorMessage" -Sev Error
-            return
-        }
-        try {
-            $AllSafeLinksRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksRule'
-        } catch {
-            $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
-            Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the SafeLinksRule state for $Tenant. Error: $ErrorMessage" -Sev Error
-            return
-        }
+    if ($MDOTestResult -eq $false) {
+        return $true
+    } #tenant lacks Microsoft Defender for Office 365 — Test-CIPPStandardLicense logs and sets LicenseAvailable=false.
 
-        # Use custom name if provided, otherwise use default for backward compatibility
+    # Single data retrieval calls with error handling
+    try {
+        $AllSafeLinksPolicy = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksPolicy'
+    } catch {
+        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the SafeLinksPolicy state for $Tenant. Error: $ErrorMessage" -Sev Error
+        return
+    }
+    try {
+        $AllSafeLinksRule = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-SafeLinksRule'
+    } catch {
+        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the SafeLinksRule state for $Tenant. Error: $ErrorMessage" -Sev Error
+        return
+    }
+
+    # Use custom name if provided, otherwise use default for backward compatibility
+    $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default SafeLinks Policy' }
+    $PolicyList = @($PolicyName, 'CIPP Default SafeLinks Policy', 'Default SafeLinks Policy')
+    $ExistingPolicy = $AllSafeLinksPolicy | Where-Object -Property Name -In $PolicyList | Select-Object -First 1
+    if ($null -eq $ExistingPolicy.Name) {
+        # No existing policy - use the configured/default name
         $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default SafeLinks Policy' }
-        $PolicyList = @($PolicyName, 'CIPP Default SafeLinks Policy', 'Default SafeLinks Policy')
-        $ExistingPolicy = $AllSafeLinksPolicy | Where-Object -Property Name -In $PolicyList | Select-Object -First 1
-        if ($null -eq $ExistingPolicy.Name) {
-            # No existing policy - use the configured/default name
-            $PolicyName = if ($Settings.name) { $Settings.name } else { 'CIPP Default SafeLinks Policy' }
+    } else {
+        # Use existing policy name if found
+        $PolicyName = $ExistingPolicy.Name
+    }
+    # Derive rule name from policy name, but check for old names for backward compatibility
+    $DesiredRuleName = "$PolicyName Rule"
+    $RuleList = @($DesiredRuleName, 'CIPP Default SafeLinks Rule', 'CIPP Default SafeLinks Policy')
+    $ExistingRule = $AllSafeLinksRule | Where-Object -Property Name -In $RuleList | Select-Object -First 1
+    if ($null -eq $ExistingRule.Name) {
+        # No existing rule - use the derived name
+        $RuleName = $DesiredRuleName
+    } else {
+        # Use existing rule name if found
+        $RuleName = $ExistingRule.Name
+    }
+
+    $CurrentState = $AllSafeLinksPolicy |
+        Where-Object -Property Name -EQ $PolicyName |
+        Select-Object Name, EnableSafeLinksForEmail, EnableSafeLinksForTeams, EnableSafeLinksForOffice, TrackClicks, AllowClickThrough, ScanUrls, EnableForInternalSenders, DeliverMessageAfterScan, DisableUrlRewrite, EnableOrganizationBranding, DoNotRewriteUrls
+
+    $StateIsCorrect = ($CurrentState.Name -eq $PolicyName) -and
+    ($CurrentState.EnableSafeLinksForEmail -eq $true) -and
+    ($CurrentState.EnableSafeLinksForTeams -eq $true) -and
+    ($CurrentState.EnableSafeLinksForOffice -eq $true) -and
+    ($CurrentState.TrackClicks -eq $true) -and
+    ($CurrentState.ScanUrls -eq $true) -and
+    ($CurrentState.EnableForInternalSenders -eq $true) -and
+    ($CurrentState.DeliverMessageAfterScan -eq $true) -and
+    ($CurrentState.AllowClickThrough -eq $Settings.AllowClickThrough) -and
+    ($CurrentState.DisableUrlRewrite -eq $Settings.DisableUrlRewrite) -and
+    ($CurrentState.EnableOrganizationBranding -eq $Settings.EnableOrganizationBranding) -and
+    (!(Compare-Object -ReferenceObject $CurrentState.DoNotRewriteUrls -DifferenceObject ($Settings.DoNotRewriteUrls.value ?? $Settings.DoNotRewriteUrls ?? @())))
+
+    $AcceptedDomains = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AcceptedDomain'
+
+    $RuleState = $AllSafeLinksRule |
+        Where-Object -Property Name -EQ $RuleName |
+        Select-Object Name, SafeLinksPolicy, Priority, RecipientDomainIs
+
+    $RuleStateIsCorrect = ($RuleState.Name -eq $RuleName) -and
+    ($RuleState.SafeLinksPolicy -eq $PolicyName) -and
+    ($RuleState.Priority -eq 0) -and
+    (!(Compare-Object -ReferenceObject $RuleState.RecipientDomainIs -DifferenceObject $AcceptedDomains.Name))
+
+    if ($Settings.remediate -eq $true) {
+
+        if ($StateIsCorrect -eq $true) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'SafeLink Policy already correctly configured' -sev Info
         } else {
-            # Use existing policy name if found
-            $PolicyName = $ExistingPolicy.Name
-        }
-        # Derive rule name from policy name, but check for old names for backward compatibility
-        $DesiredRuleName = "$PolicyName Rule"
-        $RuleList = @($DesiredRuleName, 'CIPP Default SafeLinks Rule', 'CIPP Default SafeLinks Policy')
-        $ExistingRule = $AllSafeLinksRule | Where-Object -Property Name -In $RuleList | Select-Object -First 1
-        if ($null -eq $ExistingRule.Name) {
-            # No existing rule - use the derived name
-            $RuleName = $DesiredRuleName
-        } else {
-            # Use existing rule name if found
-            $RuleName = $ExistingRule.Name
-        }
-
-        $CurrentState = $AllSafeLinksPolicy |
-            Where-Object -Property Name -EQ $PolicyName |
-            Select-Object Name, EnableSafeLinksForEmail, EnableSafeLinksForTeams, EnableSafeLinksForOffice, TrackClicks, AllowClickThrough, ScanUrls, EnableForInternalSenders, DeliverMessageAfterScan, DisableUrlRewrite, EnableOrganizationBranding, DoNotRewriteUrls
-
-        $StateIsCorrect = ($CurrentState.Name -eq $PolicyName) -and
-        ($CurrentState.EnableSafeLinksForEmail -eq $true) -and
-        ($CurrentState.EnableSafeLinksForTeams -eq $true) -and
-        ($CurrentState.EnableSafeLinksForOffice -eq $true) -and
-        ($CurrentState.TrackClicks -eq $true) -and
-        ($CurrentState.ScanUrls -eq $true) -and
-        ($CurrentState.EnableForInternalSenders -eq $true) -and
-        ($CurrentState.DeliverMessageAfterScan -eq $true) -and
-        ($CurrentState.AllowClickThrough -eq $Settings.AllowClickThrough) -and
-        ($CurrentState.DisableUrlRewrite -eq $Settings.DisableUrlRewrite) -and
-        ($CurrentState.EnableOrganizationBranding -eq $Settings.EnableOrganizationBranding) -and
-        (!(Compare-Object -ReferenceObject $CurrentState.DoNotRewriteUrls -DifferenceObject ($Settings.DoNotRewriteUrls.value ?? $Settings.DoNotRewriteUrls ?? @())))
-
-        $AcceptedDomains = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-AcceptedDomain'
-
-        $RuleState = $AllSafeLinksRule |
-            Where-Object -Property Name -EQ $RuleName |
-            Select-Object Name, SafeLinksPolicy, Priority, RecipientDomainIs
-
-        $RuleStateIsCorrect = ($RuleState.Name -eq $RuleName) -and
-        ($RuleState.SafeLinksPolicy -eq $PolicyName) -and
-        ($RuleState.Priority -eq 0) -and
-        (!(Compare-Object -ReferenceObject $RuleState.RecipientDomainIs -DifferenceObject $AcceptedDomains.Name))
-
-        if ($Settings.remediate -eq $true) {
-
-            if ($StateIsCorrect -eq $true) {
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'SafeLink Policy already correctly configured' -sev Info
-            } else {
-                $cmdParams = @{
-                    EnableSafeLinksForEmail    = $true
-                    EnableSafeLinksForTeams    = $true
-                    EnableSafeLinksForOffice   = $true
-                    TrackClicks                = $true
-                    ScanUrls                   = $true
-                    EnableForInternalSenders   = $true
-                    DeliverMessageAfterScan    = $true
-                    AllowClickThrough          = $Settings.AllowClickThrough
-                    DisableUrlRewrite          = $Settings.DisableUrlRewrite
-                    EnableOrganizationBranding = $Settings.EnableOrganizationBranding
-                    DoNotRewriteUrls           = $Settings.DoNotRewriteUrls.value ?? @{'@odata.type' = '#Exchange.GenericHashTable' }
-                }
-
-                if ($CurrentState.Name -eq $Policyname) {
-                    try {
-                        $cmdParams.Add('Identity', $PolicyName)
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'Set-SafeLinksPolicy' -cmdParams $cmdParams -UseSystemMailbox $true
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated SafeLink policy $PolicyName." -sev Info
-                    } catch {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update SafeLink policy $PolicyName." -sev Error -LogData $_
-                    }
-                } else {
-                    try {
-                        $cmdParams.Add('Name', $PolicyName)
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'New-SafeLinksPolicy' -cmdParams $cmdParams -UseSystemMailbox $true
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created SafeLink policy $PolicyName." -sev Info
-                    } catch {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to create SafeLink policy $PolicyName." -sev Error -LogData $_
-                    }
-                }
-            }
-
-            if ($RuleStateIsCorrect -eq $false) {
-                $cmdParams = @{
-                    Priority          = 0
-                    RecipientDomainIs = ConvertTo-SafeArray -Field $AcceptedDomains.Name
-                }
-
-                if ($RuleState.SafeLinksPolicy -ne $PolicyName) {
-                    $cmdParams.Add('SafeLinksPolicy', $PolicyName)
-                }
-
-                if ($RuleState.Name -eq $RuleName) {
-                    try {
-                        $cmdParams.Add('Identity', $RuleName)
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'Set-SafeLinksRule' -cmdParams $cmdParams -UseSystemMailbox $true
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated SafeLink rule $RuleName." -sev Info
-                    } catch {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update SafeLink rule $RuleName." -sev Error -LogData $_
-                    }
-                } else {
-                    try {
-                        $cmdParams.Add('Name', $RuleName)
-                        New-ExoRequest -tenantid $Tenant -cmdlet 'New-SafeLinksRule' -cmdParams $cmdParams -UseSystemMailbox $true
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created SafeLink rule $RuleName." -sev Info
-                    } catch {
-                        Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to create SafeLink rule $RuleName." -sev Error -LogData $_
-                    }
-                }
-            }
-        }
-
-        if ($Settings.alert -eq $true) {
-
-            if ($StateIsCorrect -eq $true) {
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'SafeLink Policy is enabled' -sev Info
-            } else {
-                Write-StandardsAlert -message 'SafeLink Policy is not enabled' -object $CurrentState -tenant $Tenant -standardName 'SafeLinksPolicy' -standardId $Settings.standardId
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'SafeLink Policy is not enabled' -sev Info
-            }
-        }
-
-        if ($Settings.report -eq $true) {
-            Add-CIPPBPAField -FieldName 'SafeLinksPolicy' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $tenant
-
-            $CurrentValue = @{
-                Name                       = $CurrentState.Name
-                EnableSafeLinksForEmail    = $CurrentState.EnableSafeLinksForEmail
-                EnableSafeLinksForTeams    = $CurrentState.EnableSafeLinksForTeams
-                EnableSafeLinksForOffice   = $CurrentState.EnableSafeLinksForOffice
-                TrackClicks                = $CurrentState.TrackClicks
-                AllowClickThrough          = $CurrentState.AllowClickThrough
-                ScanUrls                   = $CurrentState.ScanUrls
-                EnableForInternalSenders   = $CurrentState.EnableForInternalSenders
-                DeliverMessageAfterScan    = $CurrentState.DeliverMessageAfterScan
-                DisableUrlRewrite          = $CurrentState.DisableUrlRewrite
-                EnableOrganizationBranding = $CurrentState.EnableOrganizationBranding
-                DoNotRewriteUrls           = @($CurrentState.DoNotRewriteUrls | Sort-Object)
-            }
-            $ExpectedValue = @{
-                Name                       = $PolicyName
+            $cmdParams = @{
                 EnableSafeLinksForEmail    = $true
                 EnableSafeLinksForTeams    = $true
                 EnableSafeLinksForOffice   = $true
                 TrackClicks                = $true
-                AllowClickThrough          = $Settings.AllowClickThrough
                 ScanUrls                   = $true
                 EnableForInternalSenders   = $true
                 DeliverMessageAfterScan    = $true
+                AllowClickThrough          = $Settings.AllowClickThrough
                 DisableUrlRewrite          = $Settings.DisableUrlRewrite
                 EnableOrganizationBranding = $Settings.EnableOrganizationBranding
-                DoNotRewriteUrls           = @(($Settings.DoNotRewriteUrls.value ?? @()) | Sort-Object)
+                DoNotRewriteUrls           = $Settings.DoNotRewriteUrls.value ?? @{'@odata.type' = '#Exchange.GenericHashTable' }
             }
-            Set-CIPPStandardsCompareField -FieldName 'standards.SafeLinksPolicy' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -Tenant $Tenant
-        }
-    } else {
-        if ($Settings.remediate -eq $true) {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Failed to create SafeLink policy: Tenant does not have Microsoft Defender for Office 365 license' -sev Error
+
+            if ($CurrentState.Name -eq $Policyname) {
+                try {
+                    $cmdParams.Add('Identity', $PolicyName)
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'Set-SafeLinksPolicy' -cmdParams $cmdParams -UseSystemMailbox $true
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated SafeLink policy $PolicyName." -sev Info
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update SafeLink policy $PolicyName." -sev Error -LogData $_
+                }
+            } else {
+                try {
+                    $cmdParams.Add('Name', $PolicyName)
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'New-SafeLinksPolicy' -cmdParams $cmdParams -UseSystemMailbox $true
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created SafeLink policy $PolicyName." -sev Info
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to create SafeLink policy $PolicyName." -sev Error -LogData $_
+                }
+            }
         }
 
-        if ($Settings.alert -eq $true) {
-            Write-StandardsAlert -message 'SafeLink Policy is not enabled: Tenant does not have Microsoft Defender for Office 365 license' -object $MDOLicensed -tenant $Tenant -standardName 'SafeLinksPolicy' -standardId $Settings.standardId
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'SafeLink Policy is not enabled: Tenant does not have Microsoft Defender for Office 365 license' -sev Info
-        }
+        if ($RuleStateIsCorrect -eq $false) {
+            $cmdParams = @{
+                Priority          = 0
+                RecipientDomainIs = ConvertTo-SafeArray -Field $AcceptedDomains.Name
+            }
 
-        if ($Settings.report -eq $true) {
-            Add-CIPPBPAField -FieldName 'SafeLinksPolicy' -FieldValue $false -StoreAs bool -Tenant $tenant
-            Set-CIPPStandardsCompareField -FieldName 'standards.SafeLinksPolicy' -FieldValue $false -Tenant $Tenant
+            if ($RuleState.SafeLinksPolicy -ne $PolicyName) {
+                $cmdParams.Add('SafeLinksPolicy', $PolicyName)
+            }
+
+            if ($RuleState.Name -eq $RuleName) {
+                try {
+                    $cmdParams.Add('Identity', $RuleName)
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'Set-SafeLinksRule' -cmdParams $cmdParams -UseSystemMailbox $true
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Updated SafeLink rule $RuleName." -sev Info
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to update SafeLink rule $RuleName." -sev Error -LogData $_
+                }
+            } else {
+                try {
+                    $cmdParams.Add('Name', $RuleName)
+                    New-ExoRequest -tenantid $Tenant -cmdlet 'New-SafeLinksRule' -cmdParams $cmdParams -UseSystemMailbox $true
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Created SafeLink rule $RuleName." -sev Info
+                } catch {
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to create SafeLink rule $RuleName." -sev Error -LogData $_
+                }
+            }
         }
+    }
+
+    if ($Settings.alert -eq $true) {
+
+        if ($StateIsCorrect -eq $true) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'SafeLink Policy is enabled' -sev Info
+        } else {
+            Write-StandardsAlert -message 'SafeLink Policy is not enabled' -object $CurrentState -tenant $Tenant -standardName 'SafeLinksPolicy' -standardId $Settings.standardId
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'SafeLink Policy is not enabled' -sev Info
+        }
+    }
+
+    if ($Settings.report -eq $true) {
+        Add-CIPPBPAField -FieldName 'SafeLinksPolicy' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $tenant
+
+        $CurrentValue = @{
+            Name                       = $CurrentState.Name
+            EnableSafeLinksForEmail    = $CurrentState.EnableSafeLinksForEmail
+            EnableSafeLinksForTeams    = $CurrentState.EnableSafeLinksForTeams
+            EnableSafeLinksForOffice   = $CurrentState.EnableSafeLinksForOffice
+            TrackClicks                = $CurrentState.TrackClicks
+            AllowClickThrough          = $CurrentState.AllowClickThrough
+            ScanUrls                   = $CurrentState.ScanUrls
+            EnableForInternalSenders   = $CurrentState.EnableForInternalSenders
+            DeliverMessageAfterScan    = $CurrentState.DeliverMessageAfterScan
+            DisableUrlRewrite          = $CurrentState.DisableUrlRewrite
+            EnableOrganizationBranding = $CurrentState.EnableOrganizationBranding
+            DoNotRewriteUrls           = @($CurrentState.DoNotRewriteUrls | Sort-Object)
+        }
+        $ExpectedValue = @{
+            Name                       = $PolicyName
+            EnableSafeLinksForEmail    = $true
+            EnableSafeLinksForTeams    = $true
+            EnableSafeLinksForOffice   = $true
+            TrackClicks                = $true
+            AllowClickThrough          = $Settings.AllowClickThrough
+            ScanUrls                   = $true
+            EnableForInternalSenders   = $true
+            DeliverMessageAfterScan    = $true
+            DisableUrlRewrite          = $Settings.DisableUrlRewrite
+            EnableOrganizationBranding = $Settings.EnableOrganizationBranding
+            DoNotRewriteUrls           = @(($Settings.DoNotRewriteUrls.value ?? @()) | Sort-Object)
+        }
+        Set-CIPPStandardsCompareField -FieldName 'standards.SafeLinksPolicy' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -Tenant $Tenant
     }
 }

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksTemplatePolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksTemplatePolicy.ps1
@@ -45,10 +45,10 @@ function Invoke-CIPPStandardSafeLinksTemplatePolicy {
 
     Write-LogMessage -API 'Standards' -tenant $Tenant -message "Processing SafeLinks template with settings: $($Settings | ConvertTo-Json -Compress)" -sev Debug
 
-    # Verify tenant has necessary license
-    if (-not (Test-MDOLicense -Tenant $Tenant -Settings $Settings)) {
+    $MDOTestResult = Test-CIPPStandardLicense -StandardName 'SafeLinksTemplatePolicy' -TenantFilter $Tenant -RequiredCapabilities @('ATP_ENTERPRISE', 'ATP_ENTERPRISE_GOV', 'THREAT_INTELLIGENCE')
+    if ($MDOTestResult -eq $false) {
         return
-    }
+    } #tenant lacks Microsoft Defender for Office 365 — Test-CIPPStandardLicense logs and sets LicenseAvailable=false.
 
     # Normalize template list property
     $TemplateList = Get-NormalizedTemplateList -Settings $Settings
@@ -69,35 +69,6 @@ function Invoke-CIPPStandardSafeLinksTemplatePolicy {
             Invoke-SafeLinksReport -Tenant $Tenant -TemplateList $TemplateList -Settings $Settings
         }
     }
-}
-
-function Test-MDOLicense {
-    param($Tenant, $Settings)
-
-    $TenantCapabilities = Get-CIPPTenantCapabilities -TenantFilter $Tenant
-    $MDOLicensed = $TenantCapabilities.ATP_ENTERPRISE -eq $true
-
-    if (-not $MDOLicensed) {
-        $Message = 'Tenant does not have Microsoft Defender for Office 365 license'
-
-        if ($Settings.remediate -eq $true) {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to apply SafeLinks templates: $Message" -sev Error
-        }
-
-        if ($Settings.alert -eq $true) {
-            Write-StandardsAlert -message "SafeLinks templates could not be applied: $Message" -object $MDOLicensed -tenant $Tenant -standardName 'SafeLinksTemplatePolicy' -standardId $Settings.standardId
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message "SafeLinks templates could not be applied: $Message" -sev Info
-        }
-
-        if ($Settings.report -eq $true) {
-            Add-CIPPBPAField -FieldName 'SafeLinksTemplatePolicy' -FieldValue $false -StoreAs bool -Tenant $Tenant
-            Set-CIPPStandardsCompareField -FieldName 'standards.SafeLinksTemplatePolicy' -FieldValue $false -Tenant $Tenant
-        }
-
-        return $false
-    }
-
-    return $true
 }
 
 function Get-NormalizedTemplateList {

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksTemplatePolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksTemplatePolicy.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardSafeLinksTemplatePolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeSendersDisable.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeSendersDisable.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardSafeSendersDisable {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSecureScoreRemediation.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSecureScoreRemediation.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardSecureScoreRemediation {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSecurityDefaults.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSecurityDefaults.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardSecurityDefaults {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSendFromAlias.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSendFromAlias.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardSendFromAlias {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSendReceiveLimitTenant.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSendReceiveLimitTenant.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardSendReceiveLimitTenant {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSharePointMassDeletionAlert.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSharePointMassDeletionAlert.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardSharePointMassDeletionAlert {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param ($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardShortenMeetings.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardShortenMeetings.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardShortenMeetings {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSpamFilterPolicy.ps1
@@ -71,7 +71,7 @@ function Invoke-CIPPStandardSpamFilterPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSpoofWarn.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSpoofWarn.ps1
@@ -40,7 +40,7 @@ function Invoke-CIPPStandardSpoofWarn {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardStaleEntraDevices.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardStaleEntraDevices.ps1
@@ -38,7 +38,7 @@ function Invoke-CIPPStandardStaleEntraDevices {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTAP.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTAP.ps1
@@ -32,7 +32,7 @@ function Invoke-CIPPStandardTAP {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsChatProtection.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsChatProtection.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardTeamsChatProtection {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsEmailIntegration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsEmailIntegration.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardTeamsEmailIntegration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsEnrollUser.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsEnrollUser.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardTeamsEnrollUser {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsExternalAccessPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsExternalAccessPolicy.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardTeamsExternalAccessPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsExternalChatWithAnyone.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsExternalChatWithAnyone.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardTeamsExternalChatWithAnyone {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsExternalFileSharing.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsExternalFileSharing.ps1
@@ -39,7 +39,7 @@ function Invoke-CIPPStandardTeamsExternalFileSharing {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsFederationConfiguration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsFederationConfiguration.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardTeamsFederationConfiguration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsGlobalMeetingPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsGlobalMeetingPolicy.ps1
@@ -47,7 +47,7 @@ function Invoke-CIPPStandardTeamsGlobalMeetingPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
     $TestResult = Test-CIPPStandardLicense -StandardName 'TeamsGlobalMeetingPolicy' -TenantFilter $Tenant -RequiredCapabilities @('MCOSTANDARD', 'MCOEV', 'MCOIMP', 'TEAMS1', 'Teams_Room_Standard')

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsGuestAccess.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsGuestAccess.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardTeamsGuestAccess {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMeetingRecordingExpiration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMeetingRecordingExpiration.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardTeamsMeetingRecordingExpiration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMeetingVerification.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMeetingVerification.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardTeamsMeetingVerification {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMeetingsByDefault.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMeetingsByDefault.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardTeamsMeetingsByDefault {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMessagingPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMessagingPolicy.ps1
@@ -41,7 +41,7 @@ function Invoke-CIPPStandardTeamsMessagingPolicy {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTenantAllowBlockListTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTenantAllowBlockListTemplate.ps1
@@ -31,7 +31,7 @@ function Invoke-CIPPStandardTenantAllowBlockListTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
 

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTenantDefaultTimezone.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTenantDefaultTimezone.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardTenantDefaultTimezone {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTransportRuleTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTransportRuleTemplate.ps1
@@ -32,7 +32,7 @@ function Invoke-CIPPStandardTransportRuleTemplate {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
     param($Tenant, $Settings)
     $TestResult = Test-CIPPStandardLicense -StandardName 'TransportRuleTemplate' -TenantFilter $Tenant -RequiredCapabilities @('EXCHANGE_S_STANDARD', 'EXCHANGE_S_ENTERPRISE', 'EXCHANGE_S_STANDARD_GOV', 'EXCHANGE_S_ENTERPRISE_GOV', 'EXCHANGE_LITE') #No Foundation because that does not allow powershell access

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTwoClickEmailProtection.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTwoClickEmailProtection.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardTwoClickEmailProtection {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardUndoOauth.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardUndoOauth.ps1
@@ -26,7 +26,7 @@ function Invoke-CIPPStandardUndoOauth {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardUserPreferredLanguage.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardUserPreferredLanguage.ps1
@@ -25,7 +25,7 @@ function Invoke-CIPPStandardUserPreferredLanguage {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardUserSubmissions.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardUserSubmissions.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardUserSubmissions {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardWindowsBackupRestore.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardWindowsBackupRestore.ps1
@@ -33,7 +33,7 @@ function Invoke-CIPPStandardWindowsBackupRestore {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     [CmdletBinding()]

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardallowOAuthTokens.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardallowOAuthTokens.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardallowOAuthTokens {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardallowOTPTokens.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardallowOTPTokens.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardallowOTPTokens {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
@@ -35,7 +35,7 @@ function Invoke-CIPPStandardcalDefault {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings, $QueueItem)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandarddisableMacSync.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandarddisableMacSync.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandarddisableMacSync {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneBrandingProfile.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneBrandingProfile.ps1
@@ -42,7 +42,7 @@ function Invoke-CIPPStandardintuneBrandingProfile {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneDeviceReg.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneDeviceReg.ps1
@@ -36,7 +36,7 @@ function Invoke-CIPPStandardintuneDeviceReg {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneDeviceRegLocalAdmins.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneDeviceRegLocalAdmins.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardintuneDeviceRegLocalAdmins {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneDeviceRetirementDays.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneDeviceRetirementDays.ps1
@@ -34,7 +34,7 @@ function Invoke-CIPPStandardintuneDeviceRetirementDays {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneRequireMFA.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneRequireMFA.ps1
@@ -28,7 +28,7 @@ function Invoke-CIPPStandardintuneRequireMFA {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneRestrictUserDeviceRegistration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardintuneRestrictUserDeviceRegistration.ps1
@@ -27,7 +27,7 @@ function Invoke-CIPPStandardintuneRestrictUserDeviceRegistration {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardlaps.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardlaps.ps1
@@ -30,7 +30,7 @@ function Invoke-CIPPStandardlaps {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardsharingCapability.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardsharingCapability.ps1
@@ -42,7 +42,7 @@ function Invoke-CIPPStandardsharingCapability {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardsharingDomainRestriction.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardsharingDomainRestriction.ps1
@@ -41,7 +41,7 @@ function Invoke-CIPPStandardsharingDomainRestriction {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardunmanagedSync.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardunmanagedSync.ps1
@@ -38,7 +38,7 @@ function Invoke-CIPPStandardunmanagedSync {
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
-        https://docs.cipp.app/user-documentation/tenant/standards/list-standards
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)

--- a/Tools/Update-StandardsComments.ps1
+++ b/Tools/Update-StandardsComments.ps1
@@ -146,7 +146,7 @@ foreach ($Standard in $StandardsInfo) {
         $NewComment.Add("           Run the Tools\Update-StandardsComments.ps1 script to update this comment block`n")
         # -Online help link
         $NewComment.Add("   .LINK`n")
-        $DocsLink = 'https://docs.cipp.app/user-documentation/tenant/standards/list-standards'
+        $DocsLink = 'https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards'
 
         $NewComment.Add("       $DocsLink`n")
         $NewComment.Add('   #>')


### PR DESCRIPTION
This pull request updates documentation links across multiple standard-related PowerShell scripts to point to the new location for the available standards documentation. It also adds license capability checks for Microsoft Defender for Office 365 (MDO) to two standards, ensuring that actions are only performed if the appropriate licenses are present.

**Documentation updates:**

* Updated `.LINK` URLs in all `Invoke-CIPPStandard*` scripts and related documentation to reference `https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards` instead of the old `list-standards` path. [[1]](diffhunk://#diff-6daa4e29aad7a00f121ba5678948d750ab0b9b9df1feaf114333ba49be7ae567L60-R60) [[2]](diffhunk://#diff-42f2b422b0841f984d62f15d6127b01eb7894af88906ff550f0778301fbd4c72L37-R37) [[3]](diffhunk://#diff-246347952c1150b0fdecaf288c287097af3cf5144b6901c7cf5dd27a8c811b41L40-R40) [[4]](diffhunk://#diff-b3057df1a79ca4124310da51cf8501ff96b72ff0c91b336e318dfeaf232404d8L37-R37) [[5]](diffhunk://#diff-6c5620a829da87e51a159ce94e1a4c624b3432b2b390e973034a8d07b72e1848L34-R34) [[6]](diffhunk://#diff-c5f5d9af3e66f961e641a83f09943dec87365ed75882b101836c973e074876abL30-R30) [[7]](diffhunk://#diff-2f951a1a9bd1ff01e312c33110405a68bb9a4e7dbaf28ece29ca01008bd22f8dL80-R80) [[8]](diffhunk://#diff-1b07267454b4235396ce7177b6b10524e4ff1e49693ed80997a9041f7183e738L37-R37) [[9]](diffhunk://#diff-1b6ab7fea4c88490866d12d51aac5ca75f0e6486340ffa4834f13a59ff3137d9L32-R32) [[10]](diffhunk://#diff-fbe15d270bbc5c739da1cd611e54a08c5e7eae921eb67f1e223d2599789d4851L33-R33) [[11]](diffhunk://#diff-9765f25907237f01c5702aea22e8b0b81581ce74509859dc44ca2e1169e2121eL36-R36) [[12]](diffhunk://#diff-82b2436f655f10ab49a873863460fbfeeaebef3302e05e98c66689b4d0e6408eL39-R39) [[13]](diffhunk://#diff-833db7ae85a554092b17dc78ae82532e6d4d108ecc136d81fd078842fee768caL42-R42) [[14]](diffhunk://#diff-3584b16f91716ce21552f951aac1a64769c0bb8eba8f9ef050f5d7972a92878dL31-R31) [[15]](diffhunk://#diff-2b87f20db110c8778aa040aa7037b5125268cfa228345aaf9f1498b83f7172fcL36-R36) [[16]](diffhunk://#diff-25fe8402560d6ecdf05aeed80dfb2fb40b78ebcfa600116a68f6281541552758L31-R31) [[17]](diffhunk://#diff-422a107a67a54e6f851f707c908e9aa7e92be1bbcab3ee5ecf71f8618d95f65dL36-R36) [[18]](diffhunk://#diff-016bb91a82a19805612ba8c325c9cec9a94a6009f8a593e229b9d99e0c2d0031L36-R36) [[19]](diffhunk://#diff-24916b62e880960161f9f9e875598efe8ee0ca2b0225d00256b5a53717ce0abeL35-R35)

**License checks for Microsoft Defender for Office 365:**

* Added a license capability check in `Set-CIPPDBCacheExoPresetSecurityPolicy` to skip caching Exchange Preset Security Policies if the tenant lacks the required MDO licenses.
* Added a license capability check in `Invoke-CIPPStandardAtpPolicyForO365` to ensure the standard only runs if the tenant has the required MDO licenses.