### PR TITLE
Fix drift report inaccuracies for TeamsMeeting, SPFileRequests, and policies

### DIFF
--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSelfServiceLicenses.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDisableSelfServiceLicenses.ps1
@@ -78,7 +78,7 @@ function Invoke-CIPPStandardDisableSelfServiceLicenses {
             $CurrentValues.Add([PSCustomObject]@{
                     productName = 'Trial Autoclaim'
                     productId   = 'autoclaim'
-                    policyValue = if ($null -eq $AutoClaimPolicy.policyValue) { 'Disabled' } else { $AutoClaimPolicy.policyValue }
+                    policyValue = $AutoClaimPolicy.tenantPolicyValue ?? 'Disabled'
                 })
         } catch {
             Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to retrieve trial autoclaim policy: $($_.Exception.Message)" -sev Error
@@ -178,7 +178,7 @@ function Invoke-CIPPStandardDisableSelfServiceLicenses {
                 $CurrentValues.Add([PSCustomObject]@{
                         productName = 'Trial Autoclaim'
                         productId   = 'autoclaim'
-                        policyValue = if ($null -eq $AutoClaimPolicy.policyValue) { 'Disabled' } else { $AutoClaimPolicy.policyValue }
+                        policyValue = $AutoClaimPolicy.tenantPolicyValue ?? 'Disabled'
                     })
             } catch {
                 Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to retrieve trial autoclaim policy after remediation: $($_.Exception.Message)" -sev Error

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMalwareFilterPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMalwareFilterPolicy.ps1
@@ -220,7 +220,7 @@ function Invoke-CIPPStandardMalwareFilterPolicy {
 	    Name = $CurrentState.Name
 	    EnableFileFilter = $CurrentState.EnableFileFilter
 	    FileTypeAction = $CurrentState.FileTypeAction
-	    FileTypes = $CurrentState.FileTypes
+	    FileTypes = @($CurrentState.FileTypes | Sort-Object)
 	    ZapEnabled = $CurrentState.ZapEnabled
 	    QuarantineTag = $CurrentState.QuarantineTag
 	    EnableInternalSenderAdminNotifications = $CurrentState.EnableInternalSenderAdminNotifications
@@ -238,7 +238,7 @@ function Invoke-CIPPStandardMalwareFilterPolicy {
             Name                                   = $PolicyName
             EnableFileFilter                       = $true
             FileTypeAction                         = $FileTypeAction
-            FileTypes                              = $ExpectedFileTypes
+            FileTypes                              = @($ExpectedFileTypes | Sort-Object)
             ZapEnabled                             = $true
             QuarantineTag                          = $Settings.QuarantineTag
             EnableInternalSenderAdminNotifications = $Settings.EnableInternalSenderAdminNotifications

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPFileRequests.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPFileRequests.ps1
@@ -97,6 +97,15 @@ function Invoke-CIPPStandardSPFileRequests {
 
                 $CurrentState | Set-CIPPSPOTenant -Properties $Properties
 
+                # Reflect the just-applied state in-memory so the report block does not write
+                # the pre-remediation values into the drift compare field.
+                $CurrentState.CoreRequestFilesLinkEnabled     = $WantedState
+                $CurrentState.OneDriveRequestFilesLinkEnabled = $WantedState
+                if ($null -ne $ExpirationDays -and $WantedState -eq $true) {
+                    $CurrentState.CoreRequestFilesLinkExpirationInDays     = $ExpirationDays
+                    $CurrentState.OneDriveRequestFilesLinkExpirationInDays = $ExpirationDays
+                }
+
                 $ExpirationMessage = if ($null -ne $ExpirationDays -and $WantedState -eq $true) { " with $ExpirationDays day expiration" } else { '' }
                 Write-LogMessage -API 'Standards' -tenant $tenant -message "Successfully set File Requests to $HumanReadableState$ExpirationMessage" -sev Info
             } catch {

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSafeLinksPolicy.ps1
@@ -231,7 +231,7 @@ function Invoke-CIPPStandardSafeLinksPolicy {
                 DeliverMessageAfterScan    = $CurrentState.DeliverMessageAfterScan
                 DisableUrlRewrite          = $CurrentState.DisableUrlRewrite
                 EnableOrganizationBranding = $CurrentState.EnableOrganizationBranding
-                DoNotRewriteUrls           = $CurrentState.DoNotRewriteUrls
+                DoNotRewriteUrls           = @($CurrentState.DoNotRewriteUrls | Sort-Object)
             }
             $ExpectedValue = @{
                 Name                       = $PolicyName
@@ -245,7 +245,7 @@ function Invoke-CIPPStandardSafeLinksPolicy {
                 DeliverMessageAfterScan    = $true
                 DisableUrlRewrite          = $Settings.DisableUrlRewrite
                 EnableOrganizationBranding = $Settings.EnableOrganizationBranding
-                DoNotRewriteUrls           = $Settings.DoNotRewriteUrls.value ?? @()
+                DoNotRewriteUrls           = @(($Settings.DoNotRewriteUrls.value ?? @()) | Sort-Object)
             }
             Set-CIPPStandardsCompareField -FieldName 'standards.SafeLinksPolicy' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -Tenant $Tenant
         }

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsFederationConfiguration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsFederationConfiguration.ps1
@@ -75,7 +75,7 @@ function Invoke-CIPPStandardTeamsFederationConfiguration {
             $AllowedDomains = $null
             $BlockedDomains = @()
             if ($null -ne $Settings.DomainList) {
-                $AllowedDomainsAsAList = @($Settings.DomainList).Split(',').Trim()
+                $AllowedDomainsAsAList = @($Settings.DomainList).Split(',').Trim() | Sort-Object
             } else {
                 $AllowedDomainsAsAList = @()
             }
@@ -85,7 +85,7 @@ function Invoke-CIPPStandardTeamsFederationConfiguration {
             $AllowedDomains = $AllowAllKnownDomains
             $AllowedDomainsAsAList = @()
             if ($null -ne $Settings.DomainList) {
-                $BlockedDomains = @($Settings.DomainList).Split(',').Trim()
+                $BlockedDomains = @($Settings.DomainList).Split(',').Trim() | Sort-Object
             } else {
                 $BlockedDomains = @()
             }

--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMeetingRecordingExpiration.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTeamsMeetingRecordingExpiration.ps1
@@ -91,7 +91,6 @@ function Invoke-CIPPStandardTeamsMeetingRecordingExpiration {
     if ($Settings.report -eq $true) {
         Add-CIPPBPAField -FieldName 'TeamsMeetingRecordingExpiration' -FieldValue $CurrentExpirationDays -StoreAs string -Tenant $Tenant
 
-        $CurrentExpirationDays = if ($StateIsCorrect) { $true } else { $CurrentExpirationDays }
         $CurrentValue = @{
             MeetingRecordingExpirationDays = $CurrentExpirationDays
         }


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the standards enforcement scripts, focusing on ensuring accurate reporting and consistency in policy comparisons. The main changes involve normalizing list-type values for reliable comparisons, correcting field references, and updating in-memory state after remediation to prevent reporting outdated values.

**Policy comparison normalization:**

* Updated all list-type fields (such as `FileTypes`, `DoNotRewriteUrls`, and domain lists in Teams federation) to be sorted before comparison, ensuring that order differences do not cause false drift reports. [[1]](diffhunk://#diff-21f5937855b4b87d151a77151a2b79e689eef46e372ef5fec22864e684729b19L223-R223) [[2]](diffhunk://#diff-21f5937855b4b87d151a77151a2b79e689eef46e372ef5fec22864e684729b19L241-R241) [[3]](diffhunk://#diff-636adbbc5bcc10efc5ba31410af63ff8cf0c352f5cfeac24dde5d4f7463348a5L234-R234) [[4]](diffhunk://#diff-636adbbc5bcc10efc5ba31410af63ff8cf0c352f5cfeac24dde5d4f7463348a5L248-R248) [[5]](diffhunk://#diff-8094476ac96a5b9884740aae3a3e267ea51843d9caa915f8c9fd87d1aecf9d87L78-R78) [[6]](diffhunk://#diff-8094476ac96a5b9884740aae3a3e267ea51843d9caa915f8c9fd87d1aecf9d87L88-R88)

**Bug fixes and accuracy improvements:**

* Corrected the field used for reporting the 'Trial Autoclaim' policy value from `policyValue` to `tenantPolicyValue` in `Invoke-CIPPStandardDisableSelfServiceLicenses`. [[1]](diffhunk://#diff-8d188a1e9388883bced1f8938fab119c89ab15d3aaea5f5357817a6a32cb4e5aL69-R69) [[2]](diffhunk://#diff-8d188a1e9388883bced1f8938fab119c89ab15d3aaea5f5357817a6a32cb4e5aL148-R148)
* In `Invoke-CIPPStandardSPFileRequests`, updated the in-memory state after remediation so that drift reports reflect the post-remediation values rather than outdated ones.

**Code cleanup:**

* Removed an unnecessary line in `Invoke-CIPPStandardTeamsMeetingRecordingExpiration` that could have incorrectly set the current value to `$true` instead of the actual expiration days.