### PR TITLE
Add usageLocation support to JIT Admin creation and templates (#5910)

### DIFF
--- a/Modules/CIPPCore/Public/Set-CIPPUserJITAdmin.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPUserJITAdmin.ps1
@@ -10,7 +10,7 @@ function Set-CIPPUserJITAdmin {
     Tenant to manage for JIT admin
 
     .PARAMETER User
-    User object to manage JIT admin roles, required property UserPrincipalName - If user is being created we also require FirstName and LastName
+    User object to manage JIT admin roles, required property UserPrincipalName - If user is being created we also require FirstName and LastName. Optional UsageLocation (ISO 3166-1 alpha-2 country code) can be provided for user creation.
 
     .PARAMETER Roles
     List of Role GUIDs to add or remove
@@ -81,6 +81,9 @@ function Set-CIPPUserJITAdmin {
                         jitAdminReason     = $Reason
                         jitAdminCreatedBy  = if ($Headers) { ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Headers.'x-ms-client-principal')) | ConvertFrom-Json).userDetails } else { 'Unknown' }
                     }
+                }
+                if (-not [string]::IsNullOrWhiteSpace($User.UsageLocation)) {
+                    $Body.usageLocation = $User.UsageLocation
                 }
                 $Json = ConvertTo-Json -Depth 5 -InputObject $Body
                 try {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddJITAdminTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddJITAdminTemplate.ps1
@@ -112,6 +112,9 @@ function Invoke-AddJITAdminTemplate {
             if (![string]::IsNullOrWhiteSpace($Request.Body.defaultUserName)) {
                 $TemplateObject.defaultUserName = $Request.Body.defaultUserName
             }
+            if (![string]::IsNullOrWhiteSpace($Request.Body.defaultUsageLocation)) {
+                $TemplateObject.defaultUsageLocation = $Request.Body.defaultUsageLocation
+            }
 
             # defaultDomain is only saved for specific tenant templates (not AllTenants)
             if ($TenantFilter -ne 'AllTenants' -and $Request.Body.defaultDomain) {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditJITAdminTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditJITAdminTemplate.ps1
@@ -130,6 +130,9 @@ function Invoke-EditJITAdminTemplate {
             if (![string]::IsNullOrWhiteSpace($Request.Body.defaultUserName)) {
                 $TemplateObject.defaultUserName = $Request.Body.defaultUserName
             }
+            if (![string]::IsNullOrWhiteSpace($Request.Body.defaultUsageLocation)) {
+                $TemplateObject.defaultUsageLocation = $Request.Body.defaultUsageLocation
+            }
 
             # defaultDomain is only saved for specific tenant templates (not AllTenants)
             if ($TenantFilter -ne 'AllTenants' -and $Request.Body.defaultDomain) {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecJITAdmin.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecJITAdmin.ps1
@@ -63,6 +63,7 @@ function Invoke-ExecJITAdmin {
                 'FirstName'         = $Request.Body.FirstName
                 'LastName'          = $Request.Body.LastName
                 'UserPrincipalName' = $Username
+                'UsageLocation'     = $Request.Body.usageLocation
             }
             Expiration   = $Expiration
             StartDate    = $Start


### PR DESCRIPTION
## Summary
- Adds optional `usageLocation` (ISO 3166-1 alpha-2) to JIT Admin user creation via Graph API
- Saves `defaultUsageLocation` in JIT Admin templates (both Add and Edit)
- Prevents Huntress false-positive alerts for JIT Admin accounts missing usage location

Fixes https://github.com/KelvinTegelaar/CIPP/issues/5910

Companion PR (frontend): https://github.com/KelvinTegelaar/CIPP/pull/5971

## Changes
- `Set-CIPPUserJITAdmin.ps1` — conditionally includes `usageLocation` in the Graph POST body when creating users
- `Invoke-ExecJITAdmin.ps1` — passes `usageLocation` from request body to the User hashtable
- `Invoke-AddJITAdminTemplate.ps1` — saves `defaultUsageLocation` in template object
- `Invoke-EditJITAdminTemplate.ps1` — same for template editing