### PR TITLE
feat: Add AutoDiscover check to domain analysis

### DIFF
--- a/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Domain Analyser/Push-DomainAnalyserDomain.ps1
+++ b/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Domain Analyser/Push-DomainAnalyserDomain.ps1
@@ -62,6 +62,7 @@ function Push-DomainAnalyserDomain {
         MSCNAMEDKIMSelectors   = ''
         EnterpriseEnrollment   = ''
         EnterpriseRegistration = ''
+        AutoDiscover           = ''
         Score                  = ''
         MaximumScore           = 160
         ScorePercentage        = ''
@@ -292,6 +293,26 @@ function Push-DomainAnalyserDomain {
         Write-LogMessage -API 'DomainAnalyser' -tenant $DomainObject.TenantId -message "Enterprise Registration CNAME error for $Domain" -LogData (Get-CippException -Exception $_) -sev Error
     }
     #EndRegion Intune Enrollment CNAME Check
+
+    #Region AutoDiscover Check
+    try {
+        $AutoDiscoverRecord = Read-AutoDiscoverRecord -Domain $Domain
+        $AutoDiscoverFailCount = $AutoDiscoverRecord.ValidationFails | Measure-Object | Select-Object -ExpandProperty Count
+        $AutoDiscoverWarnCount = $AutoDiscoverRecord.ValidationWarns | Measure-Object | Select-Object -ExpandProperty Count
+        if ($AutoDiscoverFailCount -eq 0 -and $AutoDiscoverWarnCount -eq 0) {
+            $Result.AutoDiscover = 'Correct'
+        } elseif ($AutoDiscoverFailCount -eq 0) {
+            $Result.AutoDiscover = "$($AutoDiscoverRecord.RecordType): $($AutoDiscoverRecord.Record)"
+            $ScoreExplanation.Add("AutoDiscover $($AutoDiscoverRecord.RecordType) record points to unexpected target") | Out-Null
+        } else {
+            $Result.AutoDiscover = 'No Record'
+            $ScoreExplanation.Add('No AutoDiscover DNS record found') | Out-Null
+        }
+    } catch {
+        $Result.AutoDiscover = 'Error'
+        Write-LogMessage -API 'DomainAnalyser' -tenant $DomainObject.TenantId -message "AutoDiscover check error for $Domain" -LogData (Get-CippException -Exception $_) -sev Error
+    }
+    #EndRegion AutoDiscover Check
 
     #Region MSCNAME DKIM Records
     # Get Microsoft DKIM CNAME selector Records

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ListDomainHealth.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ListDomainHealth.ps1
@@ -133,6 +133,15 @@ function Invoke-ListDomainHealth {
                         }
                         $Body = Test-MtaSts @HttpsQuery
                     }
+                    'ReadAutoDiscover' {
+                        $AutoDiscoverQuery = @{
+                            Domain = $Request.Query.Domain
+                        }
+                        if ($Request.Query.ExpectedTarget) {
+                            $AutoDiscoverQuery.ExpectedTarget = $Request.Query.ExpectedTarget
+                        }
+                        $Body = Read-AutoDiscoverRecord @AutoDiscoverQuery
+                    }
                 }
             } else {
                 $body = [pscustomobject]@{'Results' = "Domain: $($Request.Query.Domain) is invalid" }


### PR DESCRIPTION
**Important:** This PR is dependant on https://github.com/JohnDuprey/DNSHealth/pull/26 being merged and the module updated in CIPP

Implement AutoDiscover record validation in the domain analysis process and enhance the domain health listing functionality to support AutoDiscover record retrieval. 

Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/5974
