### PR TITLE
feat: Support bulk updates for managers and sponsors

### DIFF
--- a/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPUserTask.ps1
@@ -81,13 +81,13 @@ function New-CIPPUserTask {
     }
 
     if ($UserObj.setManager) {
-        $ManagerResult = Set-CIPPManager -User $CreationResults.Username -Manager $UserObj.setManager.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
-        $Results.Add($ManagerResult)
+        $ManagerResults = Set-CIPPManager -Users $CreationResults.Username -Manager $UserObj.setManager.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
+        $Results.Add($ManagerResults.Result)
     }
 
     if ($UserObj.setSponsor) {
-        $SponsorResult = Set-CIPPSponsor -User $CreationResults.Username -Sponsor $UserObj.setSponsor.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
-        $Results.Add($SponsorResult)
+        $SponsorResults = Set-CIPPSponsor -Users $CreationResults.Username -Sponsor $UserObj.setSponsor.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
+        $Results.Add($SponsorResults.Result)
     }
 
     return @{

--- a/Modules/CIPPCore/Public/Set-CIPPManager.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPManager.ps1
@@ -1,23 +1,49 @@
 function Set-CIPPManager {
     [CmdletBinding()]
     param (
-        $User,
-        $Manager,
+        [Alias('User')]
+        [string[]] $Users,
+        [string] $Manager,
         $TenantFilter,
         $APIName = 'Set Manager',
         $Headers
     )
 
-    try {
-        $ManagerBody = [PSCustomObject]@{'@odata.id' = "https://graph.microsoft.com/beta/users/$($Manager)" }
-        $ManagerBodyJSON = ConvertTo-Json -Compress -Depth 10 -InputObject $ManagerBody
-        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($User)/manager/`$ref" -tenantid $TenantFilter -type PUT -body $ManagerBodyJSON
-        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Set $User's manager to $Manager" -Sev 'Info'
-    } catch {
-        $ErrorMessage = Get-CippException -Exception $_
-        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to Set Manager. Error:$($ErrorMessage.NormalizedError)" -Sev 'Error' -LogData $_
-        throw "Failed to set manager: $($ErrorMessage.NormalizedError)"
+    if ($Users.Count -eq 0) {
+        return @()
     }
-    return "Set $User's manager to $Manager"
-}
 
+    $RequestId = 0
+    $Requests = foreach ($User in $Users) {
+        @{
+            id      = ($RequestId++).ToString()
+            method  = 'PUT'
+            url     = "users/$User/manager/`$ref"
+            body    = @{ '@odata.id' = "https://graph.microsoft.com/beta/users/$Manager" }
+            headers = @{ 'Content-Type' = 'application/json' }
+        }
+    }
+
+    $Responses = New-GraphBulkRequest -tenantid $TenantFilter -Requests @($Requests)
+
+    $Results = foreach ($Response in @($Responses)) {
+        $ResponseIndex = [int]$Response.id
+        $User = $Users[$ResponseIndex]
+        $Success = [int]$Response.status -in @(200, 204)
+        $ErrorMessage = if ($Response.body.error.message) { $Response.body.error.message } else { "Unknown error (Status: $($Response.status))" }
+        $Result = if ($Success) { "Set $User's manager to $Manager" } else { "Failed to set $User's manager: $ErrorMessage" }
+        $Severity = if ($Success) { 'Info' } else { 'Error' }
+
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message $Result -Sev $Severity
+
+        [pscustomobject]@{
+            User    = $User
+            Manager = $Manager
+            Success = $Success
+            Result  = $Result
+            Status  = $Response.status
+        }
+    }
+
+    return @($Results)
+}

--- a/Modules/CIPPCore/Public/Set-CIPPSponsor.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPSponsor.ps1
@@ -1,22 +1,49 @@
 function Set-CIPPSponsor {
     [CmdletBinding()]
     param (
-        $User,
-        $Sponsor,
+        [Alias('User')]
+        [string[]] $Users,
+        [string] $Sponsor,
         $TenantFilter,
         $APIName = 'Set Sponsor',
         $Headers
     )
 
-    try {
-        $SponsorBody = [PSCustomObject]@{'@odata.id' = "https://graph.microsoft.com/beta/users/$($Sponsor)" }
-        $SponsorBodyJSON = ConvertTo-Json -Compress -Depth 10 -InputObject $SponsorBody
-        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($User)/sponsors/`$ref" -tenantid $TenantFilter -type PUT -body $SponsorBodyJSON
-        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Set $User's sponsor to $Sponsor" -Sev 'Info'
-    } catch {
-        $ErrorMessage = Get-CippException -Exception $_
-        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to Set Sponsor. Error:$($ErrorMessage.NormalizedError)" -Sev 'Error' -LogData $_
-        throw "Failed to set sponsor: $($_.Exception.Message)"
+    if ($Users.Count -eq 0) {
+        return @()
     }
-    return "Set $user's sponsor to $Sponsor"
+
+    $RequestId = 0
+    $Requests = foreach ($User in $Users) {
+        @{
+            id      = ($RequestId++).ToString()
+            method  = 'PUT'
+            url     = "users/$User/sponsors/`$ref"
+            body    = @{ '@odata.id' = "https://graph.microsoft.com/beta/users/$Sponsor" }
+            headers = @{ 'Content-Type' = 'application/json' }
+        }
+    }
+
+    $Responses = New-GraphBulkRequest -tenantid $TenantFilter -Requests @($Requests)
+
+    $Results = foreach ($Response in @($Responses)) {
+        $ResponseIndex = [int]$Response.id
+        $User = $Users[$ResponseIndex]
+        $Success = [int]$Response.status -in @(200, 204)
+        $ErrorMessage = if ($Response.body.error.message) { $Response.body.error.message } else { "Unknown error (Status: $($Response.status))" }
+        $Result = if ($Success) { "Set $User's sponsor to $Sponsor" } else { "Failed to set $User's sponsor: $ErrorMessage" }
+        $Severity = if ($Success) { 'Info' } else { 'Error' }
+
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message $Result -Sev $Severity
+
+        [pscustomobject]@{
+            User    = $User
+            Sponsor = $Sponsor
+            Success = $Success
+            Result  = $Result
+            Status  = $Response.status
+        }
+    }
+
+    return @($Results)
 }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
@@ -242,13 +242,13 @@ function Invoke-EditUser {
     }
 
     if ($Request.body.setManager.value) {
-        $ManagerResult = Set-CIPPManager -User $UserPrincipalName -Manager $Request.body.setManager.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
-        $Results.Add($ManagerResult)
+        $ManagerResults = Set-CIPPManager -Users $UserPrincipalName -Manager $Request.body.setManager.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
+        $Results.Add($ManagerResults.Result)
     }
 
     if ($Request.body.setSponsor.value) {
-        $SponsorResult = Set-CIPPSponsor -User $UserPrincipalName -Sponsor $Request.body.setSponsor.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
-        $Results.Add($SponsorResult)
+        $SponsorResults = Set-CIPPSponsor -Users $UserPrincipalName -Sponsor $Request.body.setSponsor.value -TenantFilter $UserObj.tenantFilter -Headers $Headers
+        $Results.Add($SponsorResults.Result)
     }
 
     return ([HttpResponseContext]@{

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-PatchUser.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-PatchUser.ps1
@@ -14,7 +14,7 @@ function Invoke-PatchUser {
 
     $HttpResponse = [HttpResponseContext]@{
         StatusCode = [HttpStatusCode]::OK
-        Body       = @{'Results' = @("Default response, you should never see this.") }
+        Body       = @{'Results' = @('Default response, you should never see this.') }
     }
 
     try {
@@ -36,22 +36,37 @@ function Invoke-PatchUser {
             # Group users by tenant filter
             $UsersByTenant = $Users | Group-Object -Property tenantFilter
 
-            $TotalSuccessCount = 0
-            $AllErrorMessages = @()
+            $TotalPatchSuccessCount = 0
+            $TotalManagerSuccessCount = 0
+            $TotalSponsorSuccessCount = 0
+            $AllErrorMessages = [System.Collections.Generic.List[string]]::new()
+            $HasManagerUpdates = @($Users | Where-Object { -not [string]::IsNullOrWhiteSpace($_.manager) }).Count -gt 0
+            $HasSponsorUpdates = @($Users | Where-Object { -not [string]::IsNullOrWhiteSpace($_.sponsor) }).Count -gt 0
+            $HasRelationshipUpdates = $HasManagerUpdates -or $HasSponsorUpdates
 
             # Process each tenant separately
             foreach ($TenantGroup in $UsersByTenant) {
                 $tenantFilter = $TenantGroup.Name
                 $TenantUsers = $TenantGroup.Group
+                $UsersWithManager = $TenantUsers | Where-Object { -not [string]::IsNullOrWhiteSpace($_.manager) }
+                $ManagerGroups = $UsersWithManager | Group-Object -Property manager
+                $UsersWithSponsor = $TenantUsers | Where-Object { -not [string]::IsNullOrWhiteSpace($_.sponsor) }
+                $SponsorGroups = $UsersWithSponsor | Group-Object -Property sponsor
 
                 # Build bulk requests for this tenant
                 $int = 0
-                $BulkRequests = foreach ($User in $TenantUsers) {
-                    # Remove the id and tenantFilter properties from the body since they're not user properties
-                    $PatchBody = $User | Select-Object -Property * -ExcludeProperty id, tenantFilter
+                $BulkRequests = [System.Collections.Generic.List[object]]::new()
+                $BulkRequestUsers = [System.Collections.Generic.List[object]]::new()
+                foreach ($User in $TenantUsers) {
+                    # Remove routing and relationship properties from the body since they're not normal PATCH properties.
+                    $PatchBody = $User | Select-Object -Property * -ExcludeProperty id, tenantFilter, manager, sponsor
 
-                    @{
-                        id        = $int++
+                    if (@($PatchBody.PSObject.Properties).Count -eq 0) {
+                        continue
+                    }
+
+                    $BulkRequest = @{
+                        id        = ($int++).ToString()
                         method    = 'PATCH'
                         url       = "users/$($User.id)"
                         body      = $PatchBody
@@ -59,38 +74,107 @@ function Invoke-PatchUser {
                             'Content-Type' = 'application/json'
                         }
                     }
+                    [void]$BulkRequests.Add($BulkRequest)
+                    [void]$BulkRequestUsers.Add($User)
                 }
 
                 # Execute bulk request for this tenant
-                $BulkResults = New-GraphBulkRequest -tenantid $tenantFilter -Requests @($BulkRequests)
+                if ($BulkRequests.Count -gt 0) {
+                    $BulkResults = New-GraphBulkRequest -tenantid $tenantFilter -Requests ($BulkRequests.ToArray())
 
-                # Process results for this tenant
-                for ($i = 0; $i -lt $BulkResults.Count; $i++) {
-                    $result = $BulkResults[$i]
-                    $user = $TenantUsers[$i]
+                    # Process results for this tenant
+                    foreach ($BulkResult in @($BulkResults)) {
+                        $ResultIndex = [int]$BulkResult.id
+                        $User = $BulkRequestUsers[$ResultIndex]
 
-                    if ($result.status -eq 200 -or $result.status -eq 204) {
-                        $TotalSuccessCount++
-                        Write-LogMessage -headers $Headers -API $APIName -tenant $tenantFilter -message "Successfully patched user $($user.id)" -Sev 'Info'
-                    } else {
-                        $errorMsg = if ($result.body.error.message) {
-                            $result.body.error.message
+                        if ($BulkResult.status -eq 200 -or $BulkResult.status -eq 204) {
+                            $TotalPatchSuccessCount++
+                            Write-LogMessage -headers $Headers -API $APIName -tenant $tenantFilter -message "Successfully patched user $($User.id)" -Sev 'Info'
                         } else {
-                            "Unknown error (Status: $($result.status))"
+                            $ErrorMessage = if ($BulkResult.body.error.message) {
+                                $BulkResult.body.error.message
+                            } else {
+                                "Unknown error (Status: $($BulkResult.status))"
+                            }
+                            [void]$AllErrorMessages.Add("Failed to patch user $($User.id) in tenant $($tenantFilter): $ErrorMessage")
+                            Write-LogMessage -headers $Headers -API $APIName -tenant $tenantFilter -message "Failed to patch user $($User.id). Error: $ErrorMessage" -Sev 'Error'
                         }
-                        $AllErrorMessages += "Failed to patch user $($user.id) in tenant $($tenantFilter): $errorMsg"
-                        Write-LogMessage -headers $Headers -API $APIName -tenant $tenantFilter -message "Failed to patch user $($user.id). Error: $errorMsg" -Sev 'Error'
+                    }
+                }
+
+                foreach ($ManagerGroup in $ManagerGroups) {
+                    $UserIds = @($ManagerGroup.Group | ForEach-Object { $_.id })
+                    $ManagerUpn = $ManagerGroup.Name
+
+                    try {
+                        $ManagerResults = Set-CIPPManager -Users $UserIds -Manager $ManagerUpn -TenantFilter $tenantFilter -Headers $Headers -APIName $APIName
+
+                        foreach ($ManagerResult in @($ManagerResults)) {
+                            if ($ManagerResult.Success) {
+                                $TotalManagerSuccessCount++
+                            } else {
+                                [void]$AllErrorMessages.Add("Failed to set manager for $($ManagerResult.User) in tenant $($tenantFilter): $($ManagerResult.Result)")
+                            }
+                        }
+                    } catch {
+                        foreach ($UserId in $UserIds) {
+                            [void]$AllErrorMessages.Add("Failed to set manager for $UserId in tenant $($tenantFilter): $($_.Exception.Message)")
+                        }
+                    }
+                }
+
+                foreach ($SponsorGroup in $SponsorGroups) {
+                    $UserIds = @($SponsorGroup.Group | ForEach-Object { $_.id })
+                    $SponsorUpn = $SponsorGroup.Name
+
+                    try {
+                        $SponsorResults = Set-CIPPSponsor -Users $UserIds -Sponsor $SponsorUpn -TenantFilter $tenantFilter -Headers $Headers -APIName $APIName
+
+                        foreach ($SponsorResult in @($SponsorResults)) {
+                            if ($SponsorResult.Success) {
+                                $TotalSponsorSuccessCount++
+                            } else {
+                                [void]$AllErrorMessages.Add("Failed to set sponsor for $($SponsorResult.User) in tenant $($tenantFilter): $($SponsorResult.Result)")
+                            }
+                        }
+                    } catch {
+                        foreach ($UserId in $UserIds) {
+                            [void]$AllErrorMessages.Add("Failed to set sponsor for $UserId in tenant $($tenantFilter): $($_.Exception.Message)")
+                        }
                     }
                 }
             }
 
             # Build final response
+            $TenantCount = ($Users | Select-Object -Property tenantFilter -Unique).Count
+            $RelationshipResults = [System.Collections.Generic.List[string]]::new()
+            if ($HasManagerUpdates) {
+                [void]$RelationshipResults.Add("$TotalManagerSuccessCount manager assignment$(if($TotalManagerSuccessCount -ne 1){'s'})")
+            }
+            if ($HasSponsorUpdates) {
+                [void]$RelationshipResults.Add("$TotalSponsorSuccessCount sponsor assignment$(if($TotalSponsorSuccessCount -ne 1){'s'})")
+            }
+            $RelationshipResultMessage = [string]::Join(' and ', $RelationshipResults.ToArray())
+
+            $SuccessMessage = if ($HasRelationshipUpdates -and $TotalPatchSuccessCount -gt 0) {
+                "Successfully patched $TotalPatchSuccessCount user$(if($TotalPatchSuccessCount -ne 1){'s'}) and updated $RelationshipResultMessage across $TenantCount tenant$(if($TenantCount -ne 1){'s'})"
+            } elseif ($HasRelationshipUpdates) {
+                "Successfully updated $RelationshipResultMessage across $TenantCount tenant$(if($TenantCount -ne 1){'s'})"
+            } else {
+                "Successfully patched $TotalPatchSuccessCount user$(if($TotalPatchSuccessCount -ne 1){'s'}) across $TenantCount tenant$(if($TenantCount -ne 1){'s'})"
+            }
+
             if ($AllErrorMessages.Count -eq 0) {
-                $TenantCount = ($Users | Select-Object -Property tenantFilter -Unique).Count
-                $HttpResponse.Body = @{'Results' = @("Successfully patched $TotalSuccessCount user$(if($TotalSuccessCount -ne 1){'s'}) across $TenantCount tenant$(if($TenantCount -ne 1){'s'})") }
+                $HttpResponse.Body = @{'Results' = @($SuccessMessage) }
             } else {
                 $HttpResponse.StatusCode = [HttpStatusCode]::BadRequest
-                $HttpResponse.Body = @{'Results' = $AllErrorMessages + @("Successfully patched $TotalSuccessCount of $($Users.Count) users") }
+                $PartialSuccessMessage = if ($HasRelationshipUpdates) { $SuccessMessage } else { "Successfully patched $TotalPatchSuccessCount of $($Users.Count) users" }
+                $Results = [System.Collections.Generic.List[string]]::new()
+                foreach ($ErrorMessage in $AllErrorMessages) {
+                    [void]$Results.Add($ErrorMessage)
+                }
+                [void]$Results.Add($PartialSuccessMessage)
+                $HttpResponse.Body = @{'Results' = @($Results.ToArray()) }
             }
         }
 


### PR DESCRIPTION
Enable bulk processing for setting multiple managers and sponsors in user updates. 
Introduce 'manager' and 'sponsor' properties to the user patching functionality.

Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/5976