### PR TITLE
Fix usageLocation value extraction in JIT Admin (#5910)

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddJITAdminTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddJITAdminTemplate.ps1
@@ -112,8 +112,8 @@ function Invoke-AddJITAdminTemplate {
             if (![string]::IsNullOrWhiteSpace($Request.Body.defaultUserName)) {
                 $TemplateObject.defaultUserName = $Request.Body.defaultUserName
             }
-            if (![string]::IsNullOrWhiteSpace($Request.Body.defaultUsageLocation)) {
-                $TemplateObject.defaultUsageLocation = $Request.Body.defaultUsageLocation
+            if ($Request.Body.defaultUsageLocation) {
+                $TemplateObject.defaultUsageLocation = $Request.Body.defaultUsageLocation.value ?? $Request.Body.defaultUsageLocation
             }
 
             # defaultDomain is only saved for specific tenant templates (not AllTenants)

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditJITAdminTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditJITAdminTemplate.ps1
@@ -130,8 +130,8 @@ function Invoke-EditJITAdminTemplate {
             if (![string]::IsNullOrWhiteSpace($Request.Body.defaultUserName)) {
                 $TemplateObject.defaultUserName = $Request.Body.defaultUserName
             }
-            if (![string]::IsNullOrWhiteSpace($Request.Body.defaultUsageLocation)) {
-                $TemplateObject.defaultUsageLocation = $Request.Body.defaultUsageLocation
+            if ($Request.Body.defaultUsageLocation) {
+                $TemplateObject.defaultUsageLocation = $Request.Body.defaultUsageLocation.value ?? $Request.Body.defaultUsageLocation
             }
 
             # defaultDomain is only saved for specific tenant templates (not AllTenants)

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecJITAdmin.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecJITAdmin.ps1
@@ -63,7 +63,7 @@ function Invoke-ExecJITAdmin {
                 'FirstName'         = $Request.Body.FirstName
                 'LastName'          = $Request.Body.LastName
                 'UserPrincipalName' = $Username
-                'UsageLocation'     = $Request.Body.usageLocation
+                'UsageLocation'     = $Request.Body.usageLocation.value ?? $Request.Body.usageLocation
             }
             Expiration   = $Expiration
             StartDate    = $Start


### PR DESCRIPTION
The usageLocation autocomplete sends {label, value} objects but Graph API
expects a plain string. This causes a "StartObject node found for
usageLocation, PrimitiveValue expected" error when creating JIT Admin users.

Extract .value before passing to the API, same as Invoke-AddUserDefaults
and Invoke-EditUser already do.