### PR TITLE
Add AAD Premium license gate to ExternalMFATrusted standard

### DIFF
--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExternalMFATrusted.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExternalMFATrusted.ps1
@@ -26,6 +26,9 @@ function Invoke-CIPPStandardExternalMFATrusted {
         POWERSHELLEQUIVALENT
             Update-MgBetaPolicyCrossTenantAccessPolicyDefault
         RECOMMENDEDBY
+        REQUIREDCAPABILITIES
+            "AAD_PREMIUM"
+            "AAD_PREMIUM_P2"
         UPDATECOMMENTBLOCK
             Run the Tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
@@ -33,6 +36,11 @@ function Invoke-CIPPStandardExternalMFATrusted {
     #>
 
     param($Tenant, $Settings)
+    $TestResult = Test-CIPPStandardLicense -StandardName 'ExternalMFATrusted' -TenantFilter $Tenant -RequiredCapabilities @('AAD_PREMIUM', 'AAD_PREMIUM_P2')
+
+    if ($TestResult -eq $false) {
+        return $true
+    } #we're done.
 
     try {
         $ExternalMFATrusted = (New-GraphGetRequest -uri 'https://graph.microsoft.com/v1.0/policies/crossTenantAccessPolicy/default?$select=inboundTrust' -tenantid $Tenant)


### PR DESCRIPTION
## Summary

The ExternalMFATrusted standard configures `inboundTrust.isMfaAccepted` on the cross-tenant access policy. Microsoft gates this advanced cross-tenant setting behind **Azure AD Premium P1**, returning:

> Failed to set External MFA Trusted to enabled. Error: To add and configure advanced settings, you'll need to link a subscription with Azure AD Premium P1 to your tenant.

The standard had no license check, so it ran on every Exchange-licensed tenant and surfaced this Error-level log entry on every standards run for tenants without P1.

## Fix

Add the canonical `Test-CIPPStandardLicense` gate covering `AAD_PREMIUM` and `AAD_PREMIUM_P2` capabilities, matching the pattern already used by other P1-gated standards (Branding, ConditionalAccessTemplate, CustomBannedPasswordList).

```powershell
$TestResult = Test-CIPPStandardLicense -StandardName 'ExternalMFATrusted' -TenantFilter $Tenant -RequiredCapabilities @('AAD_PREMIUM', 'AAD_PREMIUM_P2')

if ($TestResult -eq $false) {
    return $true
}
```

Plus a `REQUIREDCAPABILITIES` block in the `.NOTES` comment so the standards comment regenerator and tooling pick it up.

## Effect

On unlicensed tenants:
- Standards run logs Info ("Tenant does not have the required capability...") instead of Error ("Failed to set External MFA Trusted...")
- Drift page renders "Not Licensed" via the `LicenseAvailable=false` flag set by `Test-CIPPStandardLicense`
- No spurious Microsoft API call attempting to write the advanced setting

## Test plan
- [ ] Tenant **with** AAD P1/P2 — standard runs as before, configures cross-tenant MFA trust, drift page reflects current vs expected
- [ ] Tenant **without** AAD P1 (e.g., Business Basic/Standard, post-Business Premium downgrade) — standard short-circuits at the gate, logs Info, drift page shows Not Licensed, no Error-level log