### PR TITLE
Improve CIPP instance performance without Azure spend increase

### DIFF
--- a/Modules/CIPPCore/Public/Tools/Measure-CippTask.ps1
+++ b/Modules/CIPPCore/Public/Tools/Measure-CippTask.ps1
@@ -48,7 +48,9 @@ function Measure-CippTask {
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $result = $null
     $errorOccurred = $false
+    $cancelled = $false
     $errorMessage = $null
+    $errorType = $null
 
     try {
         # Execute the actual task (use dot-sourcing to preserve parent scope variables)
@@ -56,6 +58,10 @@ function Measure-CippTask {
     } catch {
         $errorOccurred = $true
         $errorMessage = $_.Exception.Message
+        $errorType = $_.Exception.GetType().Name
+        if ($_.Exception -is [System.OperationCanceledException] -or $_.Exception -is [System.Threading.Tasks.TaskCanceledException]) {
+            $cancelled = $true
+        }
         # Re-throw to preserve original error behavior
         throw
     } finally {
@@ -70,9 +76,20 @@ function Measure-CippTask {
                 $props = New-Object 'System.Collections.Generic.Dictionary[string,string]'
                 $props['TaskName'] = $TaskName
                 $props['Success'] = (-not $errorOccurred).ToString()
+                $props['Outcome'] = if ($cancelled) {
+                    'Cancelled'
+                } elseif ($errorOccurred) {
+                    'Failed'
+                } else {
+                    'Succeeded'
+                }
                 $props['RawPropsAsJson'] = ($Metadata | ConvertTo-Json -Compress)
                 if ($errorOccurred) {
                     $props['ErrorMessage'] = $errorMessage
+                    $props['ErrorType'] = $errorType
+                }
+                if ($Metadata -and $Metadata.ContainsKey('InvocationId') -and $Metadata['InvocationId']) {
+                    $props['InvocationId'] = [string]$Metadata['InvocationId']
                 }
 
                 # Add all metadata to properties
@@ -94,7 +111,10 @@ function Measure-CippTask {
 
                 # Send custom event to Application Insights
                 $global:TelemetryClient.TrackEvent($EventName, $props, $metrics)
-                $global:TelemetryClient.Flush()
+                $shouldFlush = $errorOccurred -or $cancelled -or ($env:CIPP_TELEMETRY_FORCE_FLUSH -in @('true', '1'))
+                if ($shouldFlush) {
+                    $global:TelemetryClient.Flush()
+                }
 
                 Write-Verbose "Telemetry sent for task '$TaskName' to event '$EventName' (${durationMs}ms)"
             } catch {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/New-CippCoreRequest.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/New-CippCoreRequest.ps1
@@ -138,6 +138,9 @@ function New-CippCoreRequest {
                         Method       = $Request.Method
                         TriggerType  = 'HTTP'
                     }
+                    if ($TriggerMetadata.InvocationId) {
+                        $metadata['InvocationId'] = $TriggerMetadata.InvocationId
+                    }
 
                     # Add tenant filter if present
                     if ($Request.Query.TenantFilter) {

--- a/Tests/Test-MeasureCippTask.ps1
+++ b/Tests/Test-MeasureCippTask.ps1
@@ -1,0 +1,93 @@
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+param()
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Tools/Measure-CippTask.ps1'
+
+if (-not (Test-Path $FunctionPath)) {
+    Write-Error "Measure-CippTask.ps1 not found at: $FunctionPath"
+    exit 1
+}
+
+. $FunctionPath
+
+function New-TestTelemetryClient {
+    $Client = [pscustomobject]@{
+        Events     = [System.Collections.Generic.List[object]]::new()
+        FlushCount  = 0
+    }
+
+    $Client | Add-Member -MemberType ScriptMethod -Name TrackEvent -Value {
+        param($EventName, $Props, $Metrics)
+        $this.Events.Add([pscustomobject]@{
+                EventName = $EventName
+                Props     = $Props
+                Metrics   = $Metrics
+            })
+    } -Force
+
+    $Client | Add-Member -MemberType ScriptMethod -Name Flush -Value {
+        $this.FlushCount++
+    } -Force
+
+    return $Client
+}
+
+function Assert-Equal {
+    param(
+        [string]$Label,
+        $Actual,
+        $Expected
+    )
+
+    if ($Actual -ne $Expected) {
+        Write-Host "[FAIL] $Label" -ForegroundColor Red
+        Write-Host "       Expected: $Expected"
+        Write-Host "       Actual:   $Actual"
+        return $false
+    }
+
+    Write-Host "[PASS] $Label" -ForegroundColor Green
+    return $true
+}
+
+$Failures = 0
+
+$global:TelemetryClient = New-TestTelemetryClient
+$SuccessResult = Measure-CippTask -TaskName 'SuccessTask' -Metadata @{
+    InvocationId = 'inv-success'
+    Endpoint     = 'CIPPHttpTrigger'
+} -Script {
+    'ok'
+}
+
+if (-not (Assert-Equal -Label 'returns the script result' -Actual $SuccessResult -Expected 'ok')) { $Failures++ }
+if (-not (Assert-Equal -Label 'records one telemetry event' -Actual $global:TelemetryClient.Events.Count -Expected 1)) { $Failures++ }
+if (-not (Assert-Equal -Label 'does not flush on success' -Actual $global:TelemetryClient.FlushCount -Expected 0)) { $Failures++ }
+if (-not (Assert-Equal -Label 'marks success outcome' -Actual $global:TelemetryClient.Events[0].Props['Outcome'] -Expected 'Succeeded')) { $Failures++ }
+if (-not (Assert-Equal -Label 'preserves invocation id' -Actual $global:TelemetryClient.Events[0].Props['InvocationId'] -Expected 'inv-success')) { $Failures++ }
+
+$global:TelemetryClient = New-TestTelemetryClient
+$CancellationThrew = $false
+try {
+    Measure-CippTask -TaskName 'CancelTask' -Metadata @{
+        InvocationId = 'inv-cancel'
+    } -Script {
+        throw [System.Threading.Tasks.TaskCanceledException]::new('cancelled')
+    } | Out-Null
+} catch {
+    $CancellationThrew = $true
+}
+
+if (-not (Assert-Equal -Label 'rethrows task cancellations' -Actual $CancellationThrew -Expected $true)) { $Failures++ }
+if (-not (Assert-Equal -Label 'flushes on cancellation' -Actual $global:TelemetryClient.FlushCount -Expected 1)) { $Failures++ }
+if (-not (Assert-Equal -Label 'marks cancellation outcome' -Actual $global:TelemetryClient.Events[0].Props['Outcome'] -Expected 'Cancelled')) { $Failures++ }
+if (-not (Assert-Equal -Label 'captures cancellation error type' -Actual $global:TelemetryClient.Events[0].Props['ErrorType'] -Expected 'TaskCanceledException')) { $Failures++ }
+
+if ($Failures -gt 0) {
+    Write-Host "[FAIL] Measure-CippTask validation failed with $Failures issue(s)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "[PASS] Measure-CippTask validation passed." -ForegroundColor Green

--- a/docs/performance/azure-side-approval-memo.md
+++ b/docs/performance/azure-side-approval-memo.md
@@ -1,0 +1,36 @@
+# Azure-Side Approval Memo for `cipp.kalleo.net`
+
+## Status
+
+No Azure-side change is proposed for this performance fix.
+
+## Why
+
+The current implementation targets the backend request path and telemetry behavior in code only. It does not modify:
+
+- App Service plans
+- Function App configuration
+- Azure diagnostics
+- Azure Monitor alert rules
+- RBAC
+- Key Vault
+- Storage settings
+- Networking
+- Public access
+
+## If Azure Changes Are Considered Later
+
+Any Azure-side change must be documented separately before implementation and include:
+
+- resource affected
+- expected performance benefit
+- expected reliability benefit
+- estimated monthly cost impact
+- assumptions behind the estimate
+- lower-cost alternative
+- rollback path
+- explicit approval required
+
+## Recommendation
+
+Keep this PR focused on the no-cost code-level fix and use the existing Application Insights query pack to measure the before/after impact.

--- a/docs/performance/cipp-httptrigger-validation.md
+++ b/docs/performance/cipp-httptrigger-validation.md
@@ -1,0 +1,71 @@
+# CIPPHttpTrigger Validation Guide for `cipp.kalleo.net`
+
+Use the existing Application Insights telemetry for the deployed `cipp.kalleo.net` instance and the PR #6 query pack to compare the hot path before and after the `Measure-CippTask` change in this branch.
+
+## What Changed
+
+- Successful measured tasks no longer force an Application Insights flush on every request.
+- Cancellation and failure cases still flush so the most important telemetry is retained.
+- `Measure-CippTask` now tags events with `Outcome`, `ErrorType`, and `InvocationId` when available.
+
+## Before/After Windows
+
+- Before: the same business window used in the failure-anomaly investigation for `cipp.kalleo.net`.
+- After: the same duration at the same time of day after deployment to `cipp.kalleo.net`.
+- Compare at least one full business day if traffic is bursty.
+
+## Queries To Reuse
+
+Start with the query pack from the review repository and compare:
+
+- `CIPPHttpTrigger` request duration p50/p95/p99
+- failed request count and failure rate
+- HTTP 499 count and rate
+- `TaskCanceledException` count
+- dependency failures correlated to `CIPPHttpTrigger`
+- top slow operations
+
+## Suggested KQL Checks
+
+### Request duration trend
+
+```kusto
+requests
+| where timestamp between (datetime(2026-05-12T11:30:00Z) .. datetime(2026-05-12T12:30:00Z))
+| where name has "CIPPHttpTrigger" or operation_Name has "CIPPHttpTrigger"
+| summarize Requests=count(), P50=percentile(duration, 50), P95=percentile(duration, 95), P99=percentile(duration, 99) by bin(timestamp, 5m)
+| order by timestamp asc
+```
+
+### Failure and cancellation view
+
+```kusto
+exceptions
+| where timestamp between (datetime(2026-05-12T11:30:00Z) .. datetime(2026-05-12T12:30:00Z))
+| where type has "TaskCanceledException" or outerType has "TaskCanceledException"
+| summarize Count=count() by bin(timestamp, 5m), type
+| order by timestamp asc
+```
+
+### Cancellation-aware task telemetry
+
+```kusto
+customEvents
+| where timestamp between (datetime(2026-05-12T11:30:00Z) .. datetime(2026-05-12T12:30:00Z))
+| where name == "CIPP.TaskCompleted"
+| where tostring(customDimensions.TaskName) has "CIPPHttpTrigger" or tostring(customDimensions.Endpoint) has "CIPPHttpTrigger"
+| summarize Count=count(), Succeeded=countif(tostring(customDimensions.Outcome) == "Succeeded"), Failed=countif(tostring(customDimensions.Outcome) == "Failed"), Cancelled=countif(tostring(customDimensions.Outcome) == "Cancelled") by bin(timestamp, 5m)
+| order by timestamp asc
+```
+
+## Success Criteria
+
+- Lower p95/p99 on the hot path.
+- Fewer 499s and timeout-driven cancellations.
+- Fewer `TaskCanceledException` entries.
+- No Azure resource or configuration changes.
+
+## Rollback
+
+- Revert the `Measure-CippTask` and `New-CippCoreRequest` changes.
+- Re-run the same KQL windows to confirm the previous telemetry profile returns.


### PR DESCRIPTION
## Summary
Small, reversible hot-path optimization for the deployed CIPP instance at cipp.kalleo.net.

## Change
- Stop forcing Application Insights flush on every successful measured task.
- Preserve flush behavior on failures and cancellations.
- Add invocation correlation metadata to the HTTP request path.
- Add a focused validation script and instance-specific KQL guide.

## Performance impact expected
- Lower synchronous overhead on the CIPPHttpTrigger hot path.
- Better correlation of latency, 499s, and TaskCanceledException events.
- No Azure spend increase.

## Rollback
Revert the commit if validation shows no improvement or telemetry loss is unacceptable.

## Validation
- `pwsh -NoProfile -File Tests/Test-MeasureCippTask.ps1`
- `git diff --check`

## Azure impact
No Azure resources modified.