### PR TITLE
Fix: tenant groups cache issue

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-ListTenantDetails.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Tenant/Invoke-ListTenantDetails.ps1
@@ -24,7 +24,7 @@ Function Invoke-ListTenantDetails {
         $customProperties = Get-TenantProperties -customerId $TenantFilter
         $org | Add-Member -MemberType NoteProperty -Name 'customProperties' -Value $customProperties
 
-        $Groups = (Get-TenantGroups -TenantFilter $TenantFilter) ?? @()
+        $Groups = (Get-TenantGroups -TenantFilter $TenantFilter -SkipCache) ?? @()
         $org | Add-Member -MemberType NoteProperty -Name 'Groups' -Value @($Groups)
         $StatusCode = [HttpStatusCode]::OK
 


### PR DESCRIPTION
Ensure tenant groups skip cache to prevent alternating results when refreshed.