### PR TITLE
Feat: Add online archive report functionality for mailboxes

### DIFF
--- a/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheMailboxes.ps1
+++ b/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheMailboxes.ps1
@@ -26,6 +26,7 @@ function Set-CIPPDBCacheMailboxes {
         Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Caching mailboxes' -sev Debug
 
         # Get mailboxes and user details in a single bulk request
+        $ZeroArchiveGuid = '00000000-0000-0000-0000-000000000000'
         $Select = 'id,ExchangeGuid,ArchiveGuid,UserPrincipalName,DisplayName,PrimarySMTPAddress,RecipientType,RecipientTypeDetails,EmailAddresses,WhenSoftDeleted,IsInactiveMailbox,ForwardingSmtpAddress,DeliverToMailboxAndForward,ForwardingAddress,HiddenFromAddressListsEnabled,ExternalDirectoryObjectId,MessageCopyForSendOnBehalfEnabled,MessageCopyForSentAsEnabled,GrantSendOnBehalfTo,PersistedCapabilities,LitigationHoldEnabled,LitigationHoldDate,LitigationHoldDuration,ComplianceTagHoldApplied,RetentionHoldEnabled,InPlaceHolds,RetentionPolicy,RemotePowerShellEnabled,Guid,Identity'
         $BulkRequests = @(
             @{ CmdletInput = @{ CmdletName = 'Get-Mailbox'; Parameters = @{} } }
@@ -49,6 +50,12 @@ function Set-CIPPDBCacheMailboxes {
                     @{ Name = 'UPN'; Expression = { $_.'UserPrincipalName' } },
                     @{ Name = 'displayName'; Expression = { $_.'DisplayName' } },
                     @{ Name = 'primarySmtpAddress'; Expression = { $_.'PrimarySMTPAddress' } },
+                    @{ Name = 'ArchiveEnabled'; Expression = { $_.ArchiveGuid -and $_.ArchiveGuid.ToString() -ne $ZeroArchiveGuid } },
+                    @{ Name = 'ArchiveSize'; Expression = { 0 } },
+                    @{ Name = 'ArchiveItemCount'; Expression = { 0 } },
+                    @{ Name = 'storageUsedInBytes'; Expression = { 0 } },
+                    @{ Name = 'prohibitSendReceiveQuotaInBytes'; Expression = { 0 } },
+                    @{ Name = 'MailboxItemCount'; Expression = { 0 } },
                     @{ Name = 'recipientType'; Expression = { $_.'RecipientType' } },
                     @{ Name = 'recipientTypeDetails'; Expression = { $_.'RecipientTypeDetails' } },
                     @{ Name = 'AdditionalEmailAddresses'; Expression = { ($_.'EmailAddresses' | Where-Object { $_ -clike 'smtp:*' }).Replace('smtp:', '') -join ', ' } },
@@ -71,6 +78,61 @@ function Set-CIPPDBCacheMailboxes {
                     @{ Name = 'RemotePowerShellEnabled'; Expression = { $MatchedUser.RemotePowerShellEnabled } },
                     @{ Name = 'Guid'; Expression = { $MatchedUser.Guid } },
                     @{ Name = 'Identity'; Expression = { $MatchedUser.Identity } }))
+        }
+
+        # $MailboxByUPN is the only lookup that stores mailbox objects. Enrichment steps below
+        # resolve back through this lookup before updating the objects written by Add-CIPPDbItem.
+        $MailboxByUPN = @{}
+        foreach ($Mailbox in @($Mailboxes)) {
+            if ($Mailbox.UPN) {
+                $MailboxByUPN[$Mailbox.UPN] = $Mailbox
+            }
+        }
+
+        try {
+            $MailboxUsage = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/reports/getMailboxUsageDetail(period='D7')?`$format=application%2fjson" -tenantid $TenantFilter
+            foreach ($Usage in @($MailboxUsage)) {
+                if ($Usage.userPrincipalName -and $MailboxByUPN.ContainsKey($Usage.userPrincipalName)) {
+                    $Mailbox = $MailboxByUPN[$Usage.userPrincipalName]
+                    $Mailbox.storageUsedInBytes = try { [int64]$Usage.storageUsedInBytes } catch { 0 }
+                    $Mailbox.prohibitSendReceiveQuotaInBytes = try { [int64]$Usage.prohibitSendReceiveQuotaInBytes } catch { 0 }
+                    $Mailbox.MailboxItemCount = try { [int64]$Usage.itemCount } catch { 0 }
+                }
+            }
+        } catch {
+            Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Failed to cache mailbox usage details: $($_.Exception.Message)" -sev Warning
+        }
+
+        $ArchiveMailboxes = @($Mailboxes | Where-Object { $_.ArchiveEnabled -eq $true -and $_.UPN })
+        if ($ArchiveMailboxes.Count -gt 0) {
+            Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Caching archive statistics for $($ArchiveMailboxes.Count) mailboxes" -sev Debug
+
+            $MailboxUPNByArchiveStatsRequestId = @{}
+            $ArchiveStatsRequests = @(foreach ($Mailbox in $ArchiveMailboxes) {
+                    $OperationGuid = [Guid]::NewGuid().ToString()
+                    $MailboxUPNByArchiveStatsRequestId[$OperationGuid] = $Mailbox.UPN
+
+                    @{
+                        CmdletInput   = @{
+                            CmdletName = 'Get-MailboxStatistics'
+                            Parameters = @{
+                                Identity = $Mailbox.UPN
+                                Archive  = $true
+                            }
+                        }
+                        OperationGuid = $OperationGuid
+                    }
+                })
+
+            $ArchiveStatsResults = New-ExoBulkRequest -tenantid $TenantFilter -cmdletArray $ArchiveStatsRequests -useSystemMailbox $true
+            foreach ($ArchiveStat in @($ArchiveStatsResults)) {
+                if ($ArchiveStat.OperationGuid -and $MailboxUPNByArchiveStatsRequestId.ContainsKey($ArchiveStat.OperationGuid) -and -not $ArchiveStat.error) {
+                    $ArchiveMailboxUPN = $MailboxUPNByArchiveStatsRequestId[$ArchiveStat.OperationGuid]
+                    $ArchiveMailbox = $MailboxByUPN[$ArchiveMailboxUPN]
+                    $ArchiveMailbox.ArchiveSize = try { Get-ExoOnlineStringBytes -SizeString $ArchiveStat.TotalItemSize } catch { 0 }
+                    $ArchiveMailbox.ArchiveItemCount = try { [int64]$ArchiveStat.ItemCount } catch { 0 }
+                }
+            }
         }
 
         $Mailboxes | Add-CIPPDbItem -TenantFilter $TenantFilter -Type 'Mailboxes' -AddCount

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1
@@ -30,6 +30,7 @@ function Invoke-ListMailboxes {
         }
 
         # Original live EXO logic
+        $ZeroArchiveGuid = '00000000-0000-0000-0000-000000000000'
         $Select = 'id,ExchangeGuid,ArchiveGuid,UserPrincipalName,DisplayName,PrimarySMTPAddress,RecipientType,RecipientTypeDetails,EmailAddresses,WhenSoftDeleted,IsInactiveMailbox,ForwardingSmtpAddress,DeliverToMailboxAndForward,ForwardingAddress,HiddenFromAddressListsEnabled,ExternalDirectoryObjectId,IsDirSynced,MessageCopyForSendOnBehalfEnabled,MessageCopyForSentAsEnabled,PersistedCapabilities,LitigationHoldEnabled,LitigationHoldDate,LitigationHoldDuration,ComplianceTagHoldApplied,RetentionHoldEnabled,InPlaceHolds,RetentionPolicy'
         $ExoRequest = @{
             tenantid  = $TenantFilter
@@ -73,6 +74,7 @@ function Invoke-ListMailboxes {
         @{ Name = 'UPN'; Expression = { $_.'UserPrincipalName' } },
         @{ Name = 'displayName'; Expression = { $_.'DisplayName' } },
         @{ Name = 'primarySmtpAddress'; Expression = { $_.'PrimarySMTPAddress' } },
+        @{ Name = 'ArchiveEnabled'; Expression = { $_.ArchiveGuid -and $_.ArchiveGuid.ToString() -ne $ZeroArchiveGuid } },
         @{ Name = 'recipientType'; Expression = { $_.'RecipientType' } },
         @{ Name = 'recipientTypeDetails'; Expression = { $_.'RecipientTypeDetails' } },
         @{ Name = 'AdditionalEmailAddresses'; Expression = { ($_.'EmailAddresses' | Where-Object { $_ -clike 'smtp:*' }).Replace('smtp:', '') -join ', ' } },


### PR DESCRIPTION
This update introduces caching for mailbox and archive usage metrics, enhancing the mailbox database cache with archive-enabled status, size, and item count. It also exposes archive information in live mailbox results, in an easier way than knowing that a guid of only 0 is equals to not enabled.

Fixes KelvinTegelaar/CIPP#6061

Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/6070