### PR TITLE
fix: Update endpoint roles to use Autopilot.Read

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListAndroidEnrollmentProfiles.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListAndroidEnrollmentProfiles.ps1
@@ -3,7 +3,7 @@ function Invoke-ListAndroidEnrollmentProfiles {
     .FUNCTIONALITY
         Entrypoint
     .ROLE
-        Endpoint.MEM.Read
+        Endpoint.Autopilot.Read
     .DESCRIPTION
         Lists Android Enterprise enrollment profiles and hydrates token fields when Graph omits them from the list response.
     #>

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListAppleEnrollmentProfiles.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListAppleEnrollmentProfiles.ps1
@@ -3,7 +3,7 @@ function Invoke-ListAppleEnrollmentProfiles {
     .FUNCTIONALITY
         Entrypoint
     .ROLE
-        Endpoint.MEM.Read
+        Endpoint.Autopilot.Read
     .DESCRIPTION
         Lists Apple Automated Device Enrollment tokens and enrollment profiles.
     #>


### PR DESCRIPTION
Change endpoint roles for Android and Apple enrollment profile functions to use `Autopilot.Read` instead of `MEM.Read`.

Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/6079