### PR TITLE
Fix TenantAllowBlockListTemplate always reporting non-compliant

### DIFF
--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTenantAllowBlockListTemplate.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTenantAllowBlockListTemplate.ps1
@@ -121,4 +121,46 @@ function Invoke-CIPPStandardTenantAllowBlockListTemplate {
             }
         }
     }
+
+    $MissingByTemplate = @(foreach ($TemplateData in $ResolvedTemplates) {
+        $Entries = @($TemplateData.entries -split '[,;]' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.Trim() })
+        $ExistingItems = try { New-ExoRequest -tenantid $Tenant -cmdlet 'Get-TenantAllowBlockListItems' -cmdParams @{ ListType = $TemplateData.listType } } catch { @() }
+        $ExistingValues = @($ExistingItems | Select-Object -ExpandProperty Value)
+        $MissingEntries = @($Entries | Where-Object { $ExistingValues -notcontains $_ })
+        if ($MissingEntries.Count -gt 0) {
+            [PSCustomObject]@{
+                TemplateName   = $TemplateData.templateName
+                ListType       = $TemplateData.listType
+                Action         = $TemplateData.listMethod
+                MissingEntries = $MissingEntries
+            }
+        }
+    })
+
+    $StateIsCorrect = $MissingByTemplate.Count -eq 0
+
+    if ($Settings.alert -eq $true) {
+        if ($StateIsCorrect) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'All Tenant Allow/Block List template entries are present' -sev Info
+        } else {
+            $MissingSummary = ($MissingByTemplate | ForEach-Object { "$($_.TemplateName) [$($_.ListType)/$($_.Action)]: $($_.MissingEntries -join ', ')" }) -join '; '
+            Write-StandardsAlert -message "Tenant Allow/Block List entries are missing: $MissingSummary" -object $MissingByTemplate -tenant $Tenant -standardName 'TenantAllowBlockListTemplate' -standardId $Settings.standardId
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Tenant Allow/Block List entries are missing: $MissingSummary" -sev Info
+        }
+    }
+
+    if ($Settings.report -eq $true) {
+        if ($StateIsCorrect) {
+            $CurrentValue = 'All template entries are present'
+            $ExpectedValue = 'All template entries are present'
+        } else {
+            $ExpectedValue = ($ResolvedTemplates | ForEach-Object {
+                $Entries = @($_.entries -split '[,;]' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.Trim() })
+                "$($_.templateName) [$($_.listType)/$($_.listMethod)]: $($Entries -join ', ')"
+            }) -join '; '
+            $CurrentValue = ($MissingByTemplate | ForEach-Object { "$($_.TemplateName) [$($_.ListType)/$($_.Action)] - Missing: $($_.MissingEntries -join ', ')" }) -join '; '
+        }
+        Add-CIPPBPAField -FieldName 'TenantAllowBlockListTemplate' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $Tenant
+        Set-CIPPStandardsCompareField -FieldName 'standards.TenantAllowBlockListTemplate' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -TenantFilter $Tenant
+    }
 }


### PR DESCRIPTION
Standard was missing report and alert blocks so compliance state was never recorded. Added both blocks with correct Expected/Current Configuration output showing template name, list type, and Allow/Block action. Remediate block unchanged.

<img width="948" height="370" alt="image" src="https://github.com/user-attachments/assets/f67fc0fd-bac4-4087-a077-92a552638a35" />

<img width="951" height="353" alt="image" src="https://github.com/user-attachments/assets/4035a2c9-3b91-4319-82a0-5413160d79fb" />

Relates to #6081 - https://github.com/KelvinTegelaar/CIPP/issues/6081