### PR TITLE
Fix IPv6 alert geolocation fallback and stale location cache reuse

### DIFF
--- a/Modules/CIPPCore/Public/Get-CIPPGeoIPLocation.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPGeoIPLocation.ps1
@@ -1,23 +1,99 @@
 function Get-CIPPGeoIPLocation {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $true)]
         [string]$IP
     )
 
     $CacheGeoIPTable = Get-CippTable -tablename 'cachegeoip'
     $30DaysAgo = (Get-Date).AddDays(-30).ToString('yyyy-MM-ddTHH:mm:ssZ')
     $Filter = "PartitionKey eq 'IP' and RowKey eq '$IP' and Timestamp ge datetime'$30DaysAgo'"
+    $ParsedIPAddress = $null
+    $IsIPv6 = $false
+    $CountryFallbackUsed = $false
+
+    try {
+        $ParsedIPAddress = [System.Net.IPAddress]::Parse($IP)
+        $IsIPv6 = $ParsedIPAddress.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetworkV6
+    } catch {
+        $ParsedIPAddress = $null
+    }
+
     $GeoIP = Get-CippAzDataTableEntity @CacheGeoIPTable -Filter $Filter
     if ($GeoIP -and $GeoIP.Data) {
-        return ($GeoIP.Data | ConvertFrom-Json)
+        $CachedLocation = $GeoIP.Data | ConvertFrom-Json -ErrorAction SilentlyContinue
+        $CachedCountry = $CachedLocation.countryCode ?? $CachedLocation.CountryOrRegion ?? $CachedLocation.country
+        if (-not ($IsIPv6 -and ([string]::IsNullOrWhiteSpace($CachedCountry) -or $CachedCountry -eq 'Unknown'))) {
+            return $CachedLocation
+        }
     }
-    $location = Invoke-CIPPRestMethod -Uri "https://geoipdb.azurewebsites.net/api/GetIPInfo?IP=$IP"
-    if ($location.status -eq 'FAIL') { throw "Could not get location for $IP" }
+
+    $EncodedIP = [System.Uri]::EscapeDataString($IP)
+    $Location = $null
+    try {
+        $Location = Invoke-CIPPRestMethod -Uri "https://geoipdb.azurewebsites.net/api/GetIPInfo?IP=$EncodedIP"
+    } catch {
+        Write-Information "Primary GeoIP lookup failed for ${IP}: $($_.Exception.Message)"
+        $Location = $null
+    }
+
+    $CountryCode = $Location.countryCode ?? $Location.CountryOrRegion ?? $Location.country
+    $City = $Location.city ?? $Location.City
+    $Proxy = if ($null -ne $Location.proxy) { $Location.proxy } elseif ($null -ne $Location.Proxy) { $Location.Proxy } else { $null }
+    $Hosting = if ($null -ne $Location.hosting) { $Location.hosting } elseif ($null -ne $Location.Hosting) { $Location.Hosting } else { $null }
+    $ASName = $Location.asname ?? $Location.ASName
+
+    if ($IsIPv6 -and ($null -eq $Location -or $Location.status -eq 'FAIL' -or [string]::IsNullOrWhiteSpace($CountryCode) -or $CountryCode -eq 'Unknown')) {
+        try {
+            $CountryFallback = Invoke-CIPPRestMethod -Uri "https://api.country.is/$EncodedIP"
+            if (-not [string]::IsNullOrWhiteSpace($CountryFallback.country)) {
+                $CountryCode = $CountryFallback.country
+                $CountryFallbackUsed = $true
+                Write-Information "GeoIP fallback resolved IPv6 country for $IP via api.country.is"
+            }
+        } catch {
+            $CountryFallbackUsed = $false
+        }
+    }
+
+    if (($null -eq $Location -or $Location.status -eq 'FAIL') -and -not $CountryFallbackUsed) {
+        throw "Could not get location for $IP"
+    }
+
+    $LocationDataValues = @(
+        $CountryCode,
+        $City,
+        $(if ($null -ne $Proxy) { [string]$Proxy } else { $null }),
+        $(if ($null -ne $Hosting) { [string]$Hosting } else { $null }),
+        $ASName
+    )
+    $HasLocationData = $LocationDataValues | Where-Object {
+        -not [string]::IsNullOrWhiteSpace($_) -and $_ -ne 'Unknown'
+    }
+    if (@($HasLocationData).Count -eq 0) {
+        throw "Could not get location for $IP"
+    }
+
+    $NormalizedLocation = [PSCustomObject]@{
+        ip              = $IP
+        countryCode     = $CountryCode
+        city            = $City
+        proxy           = $Proxy
+        hosting         = $Hosting
+        asname          = $ASName
+        CountryOrRegion = $CountryCode
+        source          = if ($CountryFallbackUsed) {
+            if ($null -ne $Location -and $Location.status -ne 'FAIL') { 'geoipdb+country.is' } else { 'country.is' }
+        } else {
+            'geoipdb'
+        }
+    }
+
     $CacheGeo = @{
         PartitionKey = 'IP'
         RowKey       = $IP
-        Data         = [string]($location | ConvertTo-Json -Compress)
+        Data         = [string]($NormalizedLocation | ConvertTo-Json -Compress -Depth 10)
     }
     Add-AzDataTableEntity @CacheGeoIPTable -Entity $CacheGeo -Force
-    return $location
+    return $NormalizedLocation
 }

--- a/Modules/CIPPCore/Public/New-CIPPAlertTemplate.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPAlertTemplate.ps1
@@ -23,7 +23,9 @@ function New-CIPPAlertTemplate {
     $AfterButtonText = ''
     $RuleTable = ''
     $Table = ''
-    $LocationInfo = $LocationInfo ?? $Data.CIPPLocationInfo | ConvertFrom-Json -ErrorAction SilentlyContinue | Select-Object * -ExcludeProperty Etag, PartitionKey, TimeStamp
+    $LocationInfo = $LocationInfo ?? ($Data.CIPPLocationInfo | ConvertFrom-Json -ErrorAction SilentlyContinue | Select-Object * -ExcludeProperty Etag, PartitionKey, TimeStamp)
+    $LocationCountry = $LocationInfo.CountryOrRegion ?? $LocationInfo.countryCode ?? $LocationInfo.Country ?? 'Unknown'
+    $LocationCity = $LocationInfo.City ?? $LocationInfo.city ?? 'Unknown'
     if ($Data -is [string]) {
         $Data = @{ message = $Data }
     }
@@ -250,7 +252,7 @@ function New-CIPPAlertTemplate {
                 $Table = ($data | ConvertTo-Html -Fragment -As List | Out-String).Replace('<table>', ' <table class="table-modern">')
                 if ($Appname) { $AppName = $AppName.'Application Name' } else { $appName = $data.ApplicationId }
                 $Title = "$($Tenant) - a user has logged on from a location you've set up to receive alerts for."
-                $IntroText = "$($data.UserId) ($($data.Userkey)) has logged on from IP $($data.ClientIP) to the application $($Appname). According to our database this is located in $($LocationInfo.Country) - $($LocationInfo.City). <br/><br> You have set up alerts to be notified when this happens. See the table below for more info.$Table"
+                $IntroText = "$($data.UserId) ($($data.Userkey)) has logged on from IP $($data.ClientIP) to the application $($Appname). According to our database this is located in $LocationCountry - $LocationCity. <br/><br> You have set up alerts to be notified when this happens. See the table below for more info.$Table"
                 if ($ActionResults) { $IntroText = $IntroText + "<p>Based on the rule, the following actions have been taken: $($ActionResults -join '<br/>' )</p>" }
                 if ($LocationInfo) {
                     $LocationTable = ($LocationInfo | ConvertTo-Html -Fragment -As List | Out-String).Replace('<table>', ' <table class="table-modern">')

--- a/Modules/CIPPCore/Public/Webhooks/Test-CIPPAuditLogRules.ps1
+++ b/Modules/CIPPCore/Public/Webhooks/Test-CIPPAuditLogRules.ps1
@@ -473,6 +473,13 @@ function Test-CIPPAuditLogRules {
 
                         $IPRegex = '^(?<IP>(?:\d{1,3}(?:\.\d{1,3}){3}|\[[0-9a-fA-F:]+\]|[0-9a-fA-F:]+))(?::\d+)?$'
                         $Data.clientip = $Data.clientip -replace $IPRegex, '$1' -replace '[\[\]]', ''
+                        $IsIPv6Address = $false
+                        try {
+                            $IPAddress = [System.Net.IPAddress]::Parse($Data.clientip)
+                            $IsIPv6Address = $IPAddress.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetworkV6
+                        } catch {
+                            $IsIPv6Address = $false
+                        }
 
                         # Check if IP is on trusted IP list
                         $TrustedIP = Get-CIPPAzDataTableEntity @TrustedIPTable -Filter "((PartitionKey eq '$TenantFilter') or (PartitionKey eq 'AllTenants')) and RowKey eq '$($Data.clientip)' and state eq 'Trusted'"
@@ -488,11 +495,18 @@ function Test-CIPPAuditLogRules {
                             Write-Warning "Cache lookup for IP $($Data.clientip) took $CacheLookupSeconds seconds"
 
                             if ($Location) {
-                                $Country = $Location.CountryOrRegion
-                                $City = $Location.City
-                                $Proxy = $Location.Proxy
-                                $hosting = $Location.Hosting
-                                $ASName = $Location.ASName
+                                $CachedCountry = $Location.CountryOrRegion ?? $Location.countryCode ?? $Location.country
+                                if ($IsIPv6Address -and ([string]::IsNullOrWhiteSpace($CachedCountry) -or $CachedCountry -eq 'Unknown')) {
+                                    $Location = $null
+                                }
+                            }
+
+                            if ($Location) {
+                                $Country = if (-not [string]::IsNullOrWhiteSpace($Location.CountryOrRegion ?? $Location.countryCode ?? $Location.country)) { $Location.CountryOrRegion ?? $Location.countryCode ?? $Location.country } else { 'Unknown' }
+                                $City = if (-not [string]::IsNullOrWhiteSpace($Location.City ?? $Location.city)) { $Location.City ?? $Location.city } else { 'Unknown' }
+                                $Proxy = if ($null -ne ($Location.Proxy ?? $Location.proxy)) { $Location.Proxy ?? $Location.proxy } else { 'Unknown' }
+                                $Hosting = if ($null -ne ($Location.Hosting ?? $Location.hosting)) { $Location.Hosting ?? $Location.hosting } else { 'Unknown' }
+                                $ASName = if (-not [string]::IsNullOrWhiteSpace($Location.ASName ?? $Location.asname)) { $Location.ASName ?? $Location.asname } else { 'Unknown' }
                             } else {
                                 try {
                                     $IPLookupStartTime = Get-Date
@@ -501,38 +515,54 @@ function Test-CIPPAuditLogRules {
                                     $IPLookupSeconds = ($IPLookupEndTime - $IPLookupStartTime).TotalSeconds
                                     Write-Warning "IP lookup for $($Data.clientip) took $IPLookupSeconds seconds"
                                 } catch {
+                                    $Location = $null
+                                    Write-Information "Unable to get IP location for $($Data.clientip): $($_.Exception.Message)"
                                     #write-warning "Unable to get IP location for $($Data.clientip): $($_.Exception.Message)"
                                 }
-                                $Country = if ($Location.countryCode) { $Location.countryCode } else { 'Unknown' }
-                                $City = if ($Location.city) { $Location.city } else { 'Unknown' }
-                                $Proxy = if ($Location.proxy -ne $null) { $Location.proxy } else { 'Unknown' }
-                                $hosting = if ($Location.hosting -ne $null) { $Location.hosting } else { 'Unknown' }
-                                $ASName = if ($Location.asname) { $Location.asname } else { 'Unknown' }
-                                $IP = $Data.ClientIP
-                                $LocationInfo = @{
+                                $Country = if (-not [string]::IsNullOrWhiteSpace($Location.countryCode ?? $Location.CountryOrRegion ?? $Location.country)) { $Location.countryCode ?? $Location.CountryOrRegion ?? $Location.country } else { 'Unknown' }
+                                $City = if (-not [string]::IsNullOrWhiteSpace($Location.city ?? $Location.City)) { $Location.city ?? $Location.City } else { 'Unknown' }
+                                $Proxy = if ($null -ne ($Location.proxy ?? $Location.Proxy)) { $Location.proxy ?? $Location.Proxy } else { 'Unknown' }
+                                $Hosting = if ($null -ne ($Location.hosting ?? $Location.Hosting)) { $Location.hosting ?? $Location.Hosting } else { 'Unknown' }
+                                $ASName = if (-not [string]::IsNullOrWhiteSpace($Location.asname ?? $Location.ASName)) { $Location.asname ?? $Location.ASName } else { 'Unknown' }
+                                $LocationCacheEntry = @{
                                     RowKey          = [string]$Data.clientip
                                     PartitionKey    = 'ip'
                                     Tenant          = [string]$TenantFilter
                                     CountryOrRegion = "$Country"
                                     City            = "$City"
                                     Proxy           = "$Proxy"
-                                    Hosting         = "$hosting"
+                                    Hosting         = "$Hosting"
                                     ASName          = "$ASName"
                                 }
 
-                                try {
-                                    $null = Add-CIPPAzDataTableEntity @LocationTable -Entity $LocationInfo -Force
-                                } catch {
-                                    #write-warning "Failed to add location info for $($Data.clientip) to cache: $($_.Exception.Message)"
-
+                                $ShouldCacheLocation = @($Country, $City, $Proxy, $Hosting, $ASName) | Where-Object {
+                                    -not [string]::IsNullOrWhiteSpace([string]$_) -and [string]$_ -ne 'Unknown'
                                 }
+
+                                if ($ShouldCacheLocation) {
+                                    try {
+                                        $null = Add-CIPPAzDataTableEntity @LocationTable -Entity $LocationCacheEntry -Force
+                                    } catch {
+                                        #write-warning "Failed to add location info for $($Data.clientip) to cache: $($_.Exception.Message)"
+
+                                    }
+                                }
+                            }
+
+                            $LocationInfo = [PSCustomObject]@{
+                                IP              = [string]$Data.clientip
+                                CountryOrRegion = "$Country"
+                                City            = "$City"
+                                Proxy           = "$Proxy"
+                                Hosting         = "$Hosting"
+                                ASName          = "$ASName"
                             }
                             $Data.CIPPGeoLocation = $Country
                             $Data.CIPPBadRepIP = $Proxy
-                            $Data.CIPPHostedIP = $hosting
-                            $Data.CIPPIPDetected = $IP
-                            $Data.CIPPLocationInfo = ($Location | ConvertTo-Json -Compress -Depth 10)
-                            $HasLocationData = $true
+                            $Data.CIPPHostedIP = $Hosting
+                            $Data.CIPPIPDetected = $Data.ClientIP
+                            $Data.CIPPLocationInfo = ($LocationInfo | ConvertTo-Json -Compress -Depth 10)
+                            $HasLocationData = -not [string]::IsNullOrWhiteSpace($Country) -and $Country -ne 'Unknown'
                         }
                     }
                     $Data.AuditRecord = [string]($RootProperties | ConvertTo-Json -Compress -Depth 10)


### PR DESCRIPTION
## Summary

This change hardens the alert geolocation pipeline for IPv6 sign-ins.

It updates the GeoIP helper to:
- URL-encode IP addresses before calling the primary GeoIP provider
- fall back to `api.country.is` for IPv6 addresses when the primary lookup fails or returns no usable country
- skip stale cached IPv6 entries that only contain `Unknown`
- return a normalized location object for downstream consumers

It also updates the audit-log alert processing flow to:
- ignore stale `Unknown` IPv6 rows from the location cache
- avoid writing new cache entries when the lookup result is not meaningful
- serialize consistent location data into the alert payload

It also fixes the `UserLoggedIn` alert template to read the normalized country and city fields correctly.

## Why

We observed a pattern where alert locations were consistently `Unknown` for IPv6 sign-ins.

The exact upstream cause is still not proven, so this change is intentionally defensive:
- it prevents bad IPv6 lookup results from poisoning caches
- it adds a narrow country-only fallback for IPv6
- it corrects a template field mismatch that could hide valid country data

## Notes

This change does not delete existing cache rows from storage. Instead, stale IPv6 cache entries with `Unknown` country are ignored at runtime and only replaced when a meaningful lookup succeeds.

The majority of this fix was implemented with AI, for a fault that was found by Humans.

The issue with IPs not being URL-encoded, potentially-permanent stale IPv6 cache entries, and the alert template, along with need to normalise location payloads was all identified by GPT-5.4 Xhigh.

## Validation

Validated with:
- PowerShell parser checks on the touched files
- editor diagnostics on the touched files with no reported errors

Testing in a live or development environment has now been conducted yet but will be occurring concurrently to this PR given we do not know how to easily trigger an IPv6 login alert and seemingly do not have access to test the geoipdb.azurewebsites.net API for IPv6 compatibility.