### PR TITLE
Fix: Improve conversion for EnableAutoTrim setting

### DIFF
--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPOVersionControl.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardSPOVersionControl.ps1
@@ -49,7 +49,7 @@ function Invoke-CIPPStandardSPOVersionControl {
         return $true
     }
 
-    $DesiredAutoTrim = [bool]$Settings.EnableAutoTrim
+    $DesiredAutoTrim = [System.Convert]::ToBoolean($Settings.EnableAutoTrim)
     $DesiredMajorVersionLimit = [int]($Settings.MajorVersionLimit ?? 50)
     $DesiredExpireVersionsAfterDays = [int]($Settings.ExpireVersionsAfterDays ?? 0)
 


### PR DESCRIPTION
Enhance the robustness of the conversion for the EnableAutoTrim setting to ensure proper boolean handling. 

Resolves [bool]'false' = $true issue