### PR TITLE
Extend SharePoint quota calculation for Multi-Geo tenants

### DIFF
--- a/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertSharepointQuota.ps1
+++ b/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertSharepointQuota.ps1
@@ -25,12 +25,14 @@ function Get-CIPPAlertSharepointQuota {
         } catch {
             $Value = 90
         }
-        $UsedStoragePercentage = [int](($sharepointQuota.GeoUsedStorageMB / $sharepointQuota.TenantStorageMB) * 100)
+        $GeoUsedStorageMB = ($sharepointQuota.GeoUsedStorageMB | Measure-Object -Sum).Sum
+        $TenantStorageMB = $sharepointQuota.TenantStorageMB | Select-Object -First 1
+        $UsedStoragePercentage = [int](($GeoUsedStorageMB / $TenantStorageMB) * 100)
         if ($UsedStoragePercentage -gt $Value) {
             $AlertData = [PSCustomObject]@{
                 UsedStoragePercentage = $UsedStoragePercentage
-                StorageUsed           = ([math]::Round($sharepointQuota.GeoUsedStorageMB / 1024, 2))
-                StorageQuota          = ([math]::Round($sharepointQuota.TenantStorageMB / 1024, 2))
+                StorageUsed           = ([math]::Round($GeoUsedStorageMB / 1024, 2))
+                StorageQuota          = ([math]::Round($TenantStorageMB / 1024, 2))
                 AlertQuotaThreshold   = $Value
                 Tenant                = $TenantFilter
             }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Teams-Sharepoint/Invoke-ListSharepointQuota.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Teams-Sharepoint/Invoke-ListSharepointQuota.ps1
@@ -20,10 +20,12 @@ Function Invoke-ListSharepointQuota {
             $extraHeaders = @{
                 'Accept' = 'application/json'
             }
-            $SharePointQuota = (New-GraphGetRequest -extraHeaders $extraHeaders -scope "$($SharePointInfo.AdminUrl)/.default" -tenantid $TenantFilter -uri "$($SharePointInfo.AdminUrl)/_api/StorageQuotas()?api-version=1.3.2") | Sort-Object -Property GeoUsedStorageMB -Descending | Select-Object -First 1
+            $SharePointQuota = New-GraphGetRequest -extraHeaders $extraHeaders -scope "$($SharePointInfo.AdminUrl)/.default" -tenantid $TenantFilter -uri "$($SharePointInfo.AdminUrl)/_api/StorageQuotas()?api-version=1.3.2"
+            $GeoUsedStorageMB = ($SharePointQuota.GeoUsedStorageMB | Measure-Object -Sum).Sum
+            $TenantStorageMB = $SharePointQuota.TenantStorageMB | Select-Object -First 1
 
-            if ($SharePointQuota) {
-                $UsedStoragePercentage = [int](($SharePointQuota.GeoUsedStorageMB / $SharePointQuota.TenantStorageMB) * 100)
+            if ($TenantStorageMB) {
+                $UsedStoragePercentage = [int](($GeoUsedStorageMB / $TenantStorageMB) * 100)
             }
         } catch {
             $UsedStoragePercentage = 'Not available'
@@ -31,8 +33,8 @@ Function Invoke-ListSharepointQuota {
     }
 
     $SharePointQuotaDetails = @{
-        GeoUsedStorageMB = $SharePointQuota.GeoUsedStorageMB
-        TenantStorageMB  = $SharePointQuota.TenantStorageMB
+        GeoUsedStorageMB = $GeoUsedStorageMB
+        TenantStorageMB  = $TenantStorageMB
         Percentage       = $UsedStoragePercentage
         Dashboard        = "$($UsedStoragePercentage) / 100"
     }


### PR DESCRIPTION
The SharePoint admin _api/StorageQuotas() endpoint returns one row per geo location for Multi-Geo tenants instead of a single row.  This broke the two functions that consume it:

  - `Get-CIPPAlertSharepointQuota` threw `[System.Object[]] does not contain a method named 'op_Division'` because it divided GeoUsedStorageMB by TenantStorageMB when both were arrays, so the quota alert errored for any Multi-Geo tenant.
  - `Invoke-ListSharepointQuota` used `Sort-Object GeoUsedStorageMB -Descending | Select-Object -First 1`, reporting only the largest geo and undercounting total usage.