### PR TITLE
Fix: MCP tools/list emits invalid JSON Schema when a composite has one entry (allOf collapses to object)

### DIFF
--- a/Modules/CIPPCore/Public/MCP/Get-CippMcpToolList.ps1
+++ b/Modules/CIPPCore/Public/MCP/Get-CippMcpToolList.ps1
@@ -155,7 +155,9 @@ function Resolve-CippMcpNode {
     }
 
     if ($Node -is [System.Collections.IEnumerable]) {
-        return @($Node | ForEach-Object { Resolve-CippMcpNode -Node $_ -Spec $Spec -Depth ($Depth + 1) -Seen $Seen })
+        # The unary comma prevents PowerShell from unrolling single-element arrays on return,
+        # which would turn e.g. a one-entry allOf into a bare object (invalid JSON Schema).
+        return , @($Node | ForEach-Object { Resolve-CippMcpNode -Node $_ -Spec $Spec -Depth ($Depth + 1) -Seen $Seen })
     }
 
     return $Node


### PR DESCRIPTION
## Summary

`Resolve-CippMcpNode` (Modules/CIPPCore/Public/MCP/Get-CippMcpToolList.ps1) returns arrays with `return @(...)`. PowerShell unrolls single-element arrays on function return, so a valid one-entry composite from the OpenAPI spec:

```json
"integrationCompany": { "allOf": [ { "$ref": "#/components/schemas/LabelValue" } ] }
```

is advertised by `tools/list` as:

```json
"integrationCompany": { "allOf": { "type": "object", ... } }
```

`allOf`/`anyOf`/`oneOf` must be **arrays** per the JSON Schema metaschema, so the emitted `inputSchema` fails draft 2020-12 validation. Validating all advertised tools with ajv (Ajv2020), `ListTenants` is the only affected tool today — but any future endpoint whose spec contains a one-entry composite gets the same treatment.

## Impact

MCP clients that forward `inputSchema` to the Anthropic Messages API get the whole request rejected once the affected tool is loaded (the API validates the entire `tools` array):

```
API Error: 400 tools.<N>.custom.input_schema: JSON schema is invalid.
It must match JSON Schema draft 2020-12
```

This is the failure reported in KelvinTegelaar/CIPP#6133 and diagnosed in KelvinTegelaar/CIPP#6136. It can look environment-dependent: sessions only fail after the broken tool is actually loaded into a request, so clients that load tools lazily appear to work until `ListTenants` is pulled in.

## Fix

One line — the unary comma prevents the unroll, so the array reaches the caller intact:

```powershell
return , @($Node | ForEach-Object { Resolve-CippMcpNode -Node $_ -Spec $Spec -Depth ($Depth + 1) -Seen $Seen })
```

Minimal demonstration of the underlying behavior:

```powershell
function Unrolled { return @(1) }
function Preserved { return , @(1) }
(Unrolled)  -is [array]   # False
(Preserved) -is [array]   # True
```

## Validation

Dot-sourced the patched function and resolved a node mimicking the failing spec shape:

* one-entry `allOf` with `$ref` → now serializes as `"allOf": [ { ... } ]` ✅
* empty array → stays `[]` ✅
* multi-element array → unchanged ✅
* dictionary nodes → unchanged ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)