### PR TITLE
feat: Add message trace retrieval to Push-BECRun function

### DIFF
--- a/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/BEC/Push-BECRun.ps1
+++ b/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/BEC/Push-BECRun.ps1
@@ -103,6 +103,21 @@ function Push-BECRun {
             $RulesLog = @()
         }
 
+        Write-Information 'Getting sent message trace'
+        try {
+            $MessageTraceParams = @{
+                SenderAddress = $UserName
+                StartDate     = $startDate.ToString('s')
+                EndDate       = $endDate.ToString('s')
+            }
+            $SentMessages = @(New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-MessageTraceV2' -cmdParams $MessageTraceParams -Anchor $UserName |
+                Select-Object MessageTraceId, Status, Subject, RecipientAddress, @{ Name = 'Received'; Expression = { $_.Received.ToString('u') } }, FromIP)
+        } catch {
+            $SentMessages = @()
+            $CippTraceError = Get-CippException -Exception $_
+            Write-LogMessage -API 'BECRun' -message "Failed to retrieve message trace for $($UserName): $($CippTraceError.NormalizedError)" -tenant $TenantFilter -sev Warning -LogData $CippTraceError
+        }
+
         Write-Information 'Getting last 50 logons'
         try {
             $Last50Logons = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/auditLogs/signIns?`$filter=userDisplayName ne 'On-Premises Directory Synchronization Service Account'&`$top=50&`$orderby=createdDateTime desc" -tenantid $TenantFilter -noPagination $true | Select-Object @{ Name = 'CreatedDateTime'; Expression = { $(($_.createdDateTime | Out-String) -replace '\r\n') } },
@@ -155,6 +170,7 @@ function Push-BECRun {
             LastSuspectUserLogon     = @($LastSignIn)
             SuspectUserDevices       = @($Devices)
             NewRules                 = @($RulesLog)
+            SentMessages             = @($SentMessages)
             MailboxPermissionChanges = @($PermissionsLog)
             NewUsers                 = @($NewUsers)
             MFADevices               = @($MFADevices | Where-Object { $_.'@odata.type' -ne '#microsoft.graph.passwordAuthenticationMethod' })


### PR DESCRIPTION
This pull request enhances the `Push-BECRun` PowerShell function by adding the retrieval and logging of sent message traces for a user, and includes this data in the output object. These changes improve the auditing and incident response capabilities of the function by providing more comprehensive information about user activity.

**Enhancements to auditing and user activity tracking:**

* Added retrieval of sent message traces using the `Get-MessageTraceV2` cmdlet, with error handling and logging in case of failures. The trace includes message details such as status, subject, recipient, received time, and sender IP.
* Included the collected sent message trace data as a new property (`SentMessages`) in the output object returned by the function.