### PR TITLE
Fix/CIPPStandardDefenderCompliancePolicy Reporting

### DIFF
--- a/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderCompliancePolicy.ps1
+++ b/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardDefenderCompliancePolicy.ps1
@@ -180,7 +180,7 @@ function Invoke-CIPPStandardDefenderCompliancePolicy {
     }
 
     if ($Settings.report -eq $true) {
-        Set-CIPPStandardsCompareField -FieldName 'standards.DefenderCompliancePolicy' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -TenantFilter $Tenant
+        Set-CIPPStandardsCompareField -FieldName 'standards.DefenderCompliancePolicy' -FieldValue $StateIsCorrect -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -TenantFilter $Tenant
         Add-CIPPBPAField -FieldName 'DefenderCompliancePolicy' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $Tenant
     }
 }


### PR DESCRIPTION
Standard was remediating and updating the Applied Standards report. But was not updating the Standard & Drift Alignment > Alignment Score so it always failed to show the correct score.

This fixes this issue resulting in the Standard & Drift Alignment showing the correct score and Alignment Status.