### PR TITLE
feat: configure auth method sub-settings

### DIFF
--- a/Modules/CIPPCore/Public/Set-CIPPAuthenticationPolicy.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPAuthenticationPolicy.ps1
@@ -18,6 +18,10 @@ function Set-CIPPAuthenticationPolicy {
         [Parameter()][ValidateRange(8, 20)]$QRCodePinLength = 8,
         [Parameter()][ValidateSet('default', 'enabled', 'disabled')]$EmailAllowExternalIdToUseEmailOtp,
         [Parameter()][string[]]$EmailExcludeGroupIds,
+        [Parameter()][bool]$FIDO2AttestationEnforced,
+        [Parameter()][bool]$FIDO2SelfServiceRegistration,
+        [Parameter()][bool]$VoiceIsOfficePhoneAllowed,
+        [Parameter()][bool]$SmsIsUsableForSignIn,
         $APIName = 'Set Authentication Policy',
         $Headers
     )
@@ -39,37 +43,52 @@ function Set-CIPPAuthenticationPolicy {
         # FIDO2
         'FIDO2' {
             if ($State -eq 'enabled') {
-                $CurrentInfo.isAttestationEnforced = $true
-                $CurrentInfo.isSelfServiceRegistrationAllowed = $true
+                # Honor passed values; otherwise default to enforced/allowed to preserve previous enable behavior
+                $CurrentInfo.isAttestationEnforced = if ($PSBoundParameters.ContainsKey('FIDO2AttestationEnforced')) { $FIDO2AttestationEnforced } else { $true }
+                $CurrentInfo.isSelfServiceRegistrationAllowed = if ($PSBoundParameters.ContainsKey('FIDO2SelfServiceRegistration')) { $FIDO2SelfServiceRegistration } else { $true }
+                $OptionalLogMessage = "with attestation enforced set to $($CurrentInfo.isAttestationEnforced) and self-service registration set to $($CurrentInfo.isSelfServiceRegistrationAllowed)"
             }
         }
 
         # Microsoft Authenticator
         'MicrosoftAuthenticator' {
             if ($State -eq 'enabled') {
+                $AuthChanges = [System.Collections.Generic.List[string]]::new()
                 # Set MS authenticator OTP state if parameter is passed in
                 if ($null -ne $MicrosoftAuthenticatorSoftwareOathEnabled) {
                     $CurrentInfo.isSoftwareOathEnabled = $MicrosoftAuthenticatorSoftwareOathEnabled
-                    $OptionalLogMessage = "and MS Authenticator software OTP to $MicrosoftAuthenticatorSoftwareOathEnabled"
+                    $AuthChanges.Add("software OTP set to $MicrosoftAuthenticatorSoftwareOathEnabled")
                 }
                 # Feature settings
                 if ($MicrosoftAuthenticatorDisplayAppInfo) {
                     $CurrentInfo.featureSettings.displayAppInformationRequiredState.state = $MicrosoftAuthenticatorDisplayAppInfo
+                    $AuthChanges.Add("display app information set to $MicrosoftAuthenticatorDisplayAppInfo")
                 }
                 if ($MicrosoftAuthenticatorDisplayLocation) {
                     $CurrentInfo.featureSettings.displayLocationInformationRequiredState.state = $MicrosoftAuthenticatorDisplayLocation
+                    $AuthChanges.Add("display location set to $MicrosoftAuthenticatorDisplayLocation")
                 }
                 if ($MicrosoftAuthenticatorCompanionApp) {
                     $CurrentInfo.featureSettings.companionAppAllowedState.state = $MicrosoftAuthenticatorCompanionApp
+                    $AuthChanges.Add("companion app set to $MicrosoftAuthenticatorCompanionApp")
                 }
                 # numberMatchingRequiredState is permanently enabled by Microsoft and can no longer be toggled
                 $CurrentInfo.featureSettings.PSObject.Properties.Remove('numberMatchingRequiredState')
+                if ($AuthChanges.Count -gt 0) {
+                    $OptionalLogMessage = "with $($AuthChanges -join ', ')"
+                }
             }
         }
 
         # SMS
         'SMS' {
-            # No special configuration needed
+            # SMS sign-in is set per include-target (smsAuthenticationMethodTarget.isUsableForSignIn)
+            if ($State -eq 'enabled' -and $PSBoundParameters.ContainsKey('SmsIsUsableForSignIn')) {
+                foreach ($Target in $CurrentInfo.includeTargets) {
+                    $Target | Add-Member -NotePropertyName 'isUsableForSignIn' -NotePropertyValue $SmsIsUsableForSignIn -Force
+                }
+                $OptionalLogMessage = "with SMS sign-in set to $SmsIsUsableForSignIn"
+            }
         }
 
         # Temporary Access Pass
@@ -80,7 +99,7 @@ function Set-CIPPAuthenticationPolicy {
                 $CurrentInfo.maximumLifetimeInMinutes = $TAPMaximumLifetime
                 $CurrentInfo.defaultLifetimeInMinutes = $TAPDefaultLifeTime
                 $CurrentInfo.defaultLength = $TAPDefaultLength
-                $OptionalLogMessage = "with TAP isUsableOnce set to $TAPisUsableOnce"
+                $OptionalLogMessage = "with TAP isUsableOnce set to $TAPisUsableOnce, minimum lifetime $TAPMinimumLifetime min, maximum lifetime $TAPMaximumLifetime min, default lifetime $TAPDefaultLifeTime min, and default length $TAPDefaultLength"
             }
         }
 
@@ -96,7 +115,10 @@ function Set-CIPPAuthenticationPolicy {
 
         # Voice call
         'Voice' {
-            # No special configuration needed
+            if ($State -eq 'enabled' -and $PSBoundParameters.ContainsKey('VoiceIsOfficePhoneAllowed')) {
+                $CurrentInfo.isOfficePhoneAllowed = $VoiceIsOfficePhoneAllowed
+                $OptionalLogMessage = "with isOfficePhoneAllowed set to $VoiceIsOfficePhoneAllowed"
+            }
         }
 
         # Email OTP
@@ -106,7 +128,8 @@ function Set-CIPPAuthenticationPolicy {
                     $CurrentInfo.allowExternalIdToUseEmailOtp = $EmailAllowExternalIdToUseEmailOtp
                     $OptionalLogMessage = "with allowExternalIdToUseEmailOtp set to $EmailAllowExternalIdToUseEmailOtp"
                 }
-                if ($EmailExcludeGroupIds) {
+                # Present (even empty) means the caller is setting the exclude list; an empty array clears it
+                if ($PSBoundParameters.ContainsKey('EmailExcludeGroupIds')) {
                     $CurrentInfo.excludeTargets = @(
                         foreach ($id in $EmailExcludeGroupIds) {
                             [pscustomobject]@{
@@ -115,7 +138,11 @@ function Set-CIPPAuthenticationPolicy {
                             }
                         }
                     )
-                    $OptionalLogMessage += " and excluded groups set to $($EmailExcludeGroupIds -join ', ')"
+                    if ($EmailExcludeGroupIds) {
+                        $OptionalLogMessage += " and excluded groups set to $($EmailExcludeGroupIds -join ', ')"
+                    } else {
+                        $OptionalLogMessage += ' and excluded groups cleared'
+                    }
                 }
             }
         }
@@ -130,6 +157,7 @@ function Set-CIPPAuthenticationPolicy {
             if ($State -eq 'enabled') {
                 $CurrentInfo.standardQRCodeLifetimeInDays = $QRCodeLifetimeInDays
                 $CurrentInfo.pinLength = $QRCodePinLength
+                $OptionalLogMessage = "with QR code lifetime $QRCodeLifetimeInDays days and PIN length $QRCodePinLength"
             }
         }
         default {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Invoke-SetAuthMethod.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Invoke-SetAuthMethod.ps1
@@ -28,6 +28,20 @@ function Invoke-SetAuthMethod {
         if ($GroupIds) {
             $Params.GroupIds = @($GroupIds)
         }
+        # Forward any method-specific sub-settings present in the body (omitted ones keep current/default values)
+        $OptionalSettings = @(
+            'TAPisUsableOnce', 'TAPMinimumLifetime', 'TAPMaximumLifetime', 'TAPDefaultLifeTime', 'TAPDefaultLength'
+            'MicrosoftAuthenticatorSoftwareOathEnabled', 'MicrosoftAuthenticatorDisplayAppInfo', 'MicrosoftAuthenticatorDisplayLocation', 'MicrosoftAuthenticatorCompanionApp'
+            'EmailAllowExternalIdToUseEmailOtp', 'EmailExcludeGroupIds'
+            'QRCodeLifetimeInDays', 'QRCodePinLength'
+            'FIDO2AttestationEnforced', 'FIDO2SelfServiceRegistration', 'VoiceIsOfficePhoneAllowed'
+            'SmsIsUsableForSignIn'
+        )
+        foreach ($Setting in $OptionalSettings) {
+            if ($null -ne $Request.Body.$Setting) {
+                $Params.$Setting = $Request.Body.$Setting
+            }
+        }
         $Result = Set-CIPPAuthenticationPolicy @Params
         $StatusCode = [HttpStatusCode]::OK
     } catch {

--- a/Tests/Private/Set-CIPPAuthenticationPolicy.Tests.ps1
+++ b/Tests/Private/Set-CIPPAuthenticationPolicy.Tests.ps1
@@ -1,0 +1,129 @@
+# Pester tests for Set-CIPPAuthenticationPolicy
+# Validates that method-specific sub-settings are written to the Graph PATCH body
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Set-CIPPAuthenticationPolicy.ps1'
+
+    # Mock returns whatever the current test stored, simulating the existing Graph config
+    function New-GraphGetRequest { param($Uri, $tenantid, $AsApp) return $script:mockCurrentInfo }
+    function New-GraphPostRequest {
+        param($tenantid, $Uri, $Type, $Body, $ContentType, $AsApp)
+        $script:lastBody = $Body
+    }
+    function Write-LogMessage { param($headers, $API, $tenant, $message, $sev, $LogData) }
+    function Get-CippException { param($Exception) $Exception }
+
+    . $FunctionPath
+}
+
+Describe 'Set-CIPPAuthenticationPolicy' {
+    BeforeEach {
+        $script:lastBody = $null
+        $script:mockCurrentInfo = $null
+    }
+
+    It 'writes Temporary Access Pass sub-settings to the PATCH body' {
+        $script:mockCurrentInfo = [pscustomobject]@{
+            state                    = 'disabled'
+            isUsableOnce             = $true
+            minimumLifetimeInMinutes = 10
+            maximumLifetimeInMinutes = 20
+            defaultLifetimeInMinutes = 15
+            defaultLength            = 8
+        }
+
+        Set-CIPPAuthenticationPolicy -Tenant 'contoso.onmicrosoft.com' -AuthenticationMethodId 'TemporaryAccessPass' `
+            -Enabled $true -TAPisUsableOnce $false -TAPDefaultLength 12 -TAPDefaultLifeTime 90
+
+        $body = $script:lastBody | ConvertFrom-Json
+        $body.state | Should -Be 'enabled'
+        $body.isUsableOnce | Should -Be $false
+        $body.defaultLength | Should -Be 12
+        $body.defaultLifetimeInMinutes | Should -Be 90
+    }
+
+    It 'honors the FIDO2 attestation/self-service parameters instead of forcing true' {
+        $script:mockCurrentInfo = [pscustomobject]@{
+            state                            = 'disabled'
+            isAttestationEnforced            = $true
+            isSelfServiceRegistrationAllowed = $true
+        }
+
+        Set-CIPPAuthenticationPolicy -Tenant 'contoso.onmicrosoft.com' -AuthenticationMethodId 'FIDO2' `
+            -Enabled $true -FIDO2AttestationEnforced $false -FIDO2SelfServiceRegistration $false
+
+        $body = $script:lastBody | ConvertFrom-Json
+        $body.isAttestationEnforced | Should -Be $false
+        $body.isSelfServiceRegistrationAllowed | Should -Be $false
+    }
+
+    It 'defaults FIDO2 to enforced/allowed when no parameters are passed' {
+        $script:mockCurrentInfo = [pscustomobject]@{
+            state                            = 'disabled'
+            isAttestationEnforced            = $false
+            isSelfServiceRegistrationAllowed = $false
+        }
+
+        Set-CIPPAuthenticationPolicy -Tenant 'contoso.onmicrosoft.com' -AuthenticationMethodId 'FIDO2' -Enabled $true
+
+        $body = $script:lastBody | ConvertFrom-Json
+        $body.isAttestationEnforced | Should -Be $true
+        $body.isSelfServiceRegistrationAllowed | Should -Be $true
+    }
+
+    It 'scopes the method to all users when GroupIds contains all_users' {
+        $script:mockCurrentInfo = [pscustomobject]@{
+            state          = 'disabled'
+            includeTargets = @()
+        }
+
+        Set-CIPPAuthenticationPolicy -Tenant 'contoso.onmicrosoft.com' -AuthenticationMethodId 'softwareOath' `
+            -Enabled $true -GroupIds @('all_users')
+
+        $body = $script:lastBody | ConvertFrom-Json
+        $body.includeTargets[0].targetType | Should -Be 'group'
+        $body.includeTargets[0].id | Should -Be 'all_users'
+    }
+
+    It 'stamps SMS isUsableForSignIn onto every include-target' {
+        $script:mockCurrentInfo = [pscustomobject]@{
+            state          = 'disabled'
+            includeTargets = @(
+                [pscustomobject]@{ targetType = 'group'; id = 'all_users' }
+            )
+        }
+
+        Set-CIPPAuthenticationPolicy -Tenant 'contoso.onmicrosoft.com' -AuthenticationMethodId 'SMS' `
+            -Enabled $true -SmsIsUsableForSignIn $true
+
+        $body = $script:lastBody | ConvertFrom-Json
+        $body.includeTargets[0].isUsableForSignIn | Should -Be $true
+    }
+
+    It 'clears Email exclude targets when an empty group list is supplied' {
+        $script:mockCurrentInfo = [pscustomobject]@{
+            state          = 'disabled'
+            excludeTargets = @([pscustomobject]@{ targetType = 'group'; id = 'old-group' })
+        }
+
+        Set-CIPPAuthenticationPolicy -Tenant 'contoso.onmicrosoft.com' -AuthenticationMethodId 'Email' `
+            -Enabled $true -EmailExcludeGroupIds @()
+
+        $body = $script:lastBody | ConvertFrom-Json
+        @($body.excludeTargets).Count | Should -Be 0
+    }
+
+    It 'writes the Voice isOfficePhoneAllowed setting to the PATCH body' {
+        $script:mockCurrentInfo = [pscustomobject]@{
+            state               = 'disabled'
+            isOfficePhoneAllowed = $false
+        }
+
+        Set-CIPPAuthenticationPolicy -Tenant 'contoso.onmicrosoft.com' -AuthenticationMethodId 'Voice' `
+            -Enabled $true -VoiceIsOfficePhoneAllowed $true
+
+        $body = $script:lastBody | ConvertFrom-Json
+        $body.isOfficePhoneAllowed | Should -Be $true
+    }
+}


### PR DESCRIPTION
Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/6238

The `SetAuthMethod` endpoint only toggled state and group targeting, so every method-specific option was unreachable from the portal. This forwards those settings through `Invoke-SetAuthMethod` and applies them in `Set-CIPPAuthenticationPolicy`.

**Added/exposed settings**
- TAP: `isUsableOnce`, min/max/default lifetime, default length
- Microsoft Authenticator: software OATH + display-app-info / display-location / companion-app feature states
- Email OTP: external-ID state, exclude groups (empty list now explicitly clears `excludeTargets`)
- QR Code PIN: lifetime + PIN length
- FIDO2: `isAttestationEnforced` + `isSelfServiceRegistrationAllowed` (were hardcoded on enable)
- Voice: `isOfficePhoneAllowed`
- SMS: `isUsableForSignIn` (stamped onto each include-target)

Log messages now spell out the changed values per method.

**Tests:** adds `Tests/Private/Set-CIPPAuthenticationPolicy.Tests.ps1` (7 cases) — `Invoke-Pester -Path ./Tests/Private/Set-CIPPAuthenticationPolicy.Tests.ps1`.
