### PR TITLE
Fix Check extension alerts repeating on every run (watermark never advanced)

### DIFF
--- a/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertCheckExtension.ps1
+++ b/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertCheckExtension.ps1
@@ -16,9 +16,16 @@ function Get-CIPPAlertCheckExtension {
         $LastRunTable = Get-CippTable -tablename 'AlertLastRun'
         $LastRunKey = "$TenantFilter-Get-CIPPAlertCheckExtension"
 
-        # Get the last run timestamp for this tenant to only fetch new alerts
+        # Capture the start of this run. The watermark is advanced to this value
+        # after processing so the next run only fetches alerts from this point
+        # onward, including any that arrive while this run is still processing.
+        $RunStart = (Get-Date).ToUniversalTime()
+
+        # Get the last run timestamp for this tenant to only fetch new alerts.
         $LastRun = Get-CIPPAzDataTableEntity @LastRunTable -Filter "PartitionKey eq 'AlertLastRun' and RowKey eq '$LastRunKey'" | Select-Object -First 1
-        $Since = if ($LastRun.Timestamp) {
+        $Since = if ($LastRun.LastRunTime) {
+            [datetime]::Parse($LastRun.LastRunTime, [cultureinfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind)
+        } elseif ($LastRun.Timestamp) {
             $LastRun.Timestamp.UtcDateTime
         } else {
             (Get-Date).AddDays(-1).ToUniversalTime()
@@ -45,6 +52,16 @@ function Get-CIPPAlertCheckExtension {
         if ($AlertData) {
             Write-AlertTrace -cmdletName $MyInvocation.MyCommand -tenantFilter $TenantFilter -data $AlertData
         }
+
+        # Advance the watermark so the next run only picks up alerts newer than
+        # this run. Without this, $Since always fell back to the default window
+        # and previously sent alerts were re-sent on every run.
+        $LastRunEntity = @{
+            PartitionKey = 'AlertLastRun'
+            RowKey       = $LastRunKey
+            LastRunTime  = $RunStart.ToString('o')
+        }
+        $null = Add-CIPPAzDataTableEntity @LastRunTable -Entity $LastRunEntity -Force
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
         Write-AlertMessage -message "Check Extension alert failed: $($ErrorMessage.NormalizedError)" -tenant $TenantFilter -LogData $ErrorMessage


### PR DESCRIPTION
## What

The "Check" add-in's alerts are re-sent on every scheduled run - each run dumps the whole recent backlog to the configured webhook instead of only new alerts. Reported in #6216 (e.g. 13 test alerts resulted in 13 entries on every run).

## Cause

`Get-CIPPAlertCheckExtension` reads a per-tenant watermark from the `AlertLastRun` table (`PartitionKey 'AlertLastRun'`, `RowKey "<tenant>-Get-CIPPAlertCheckExtension"`) so it only fetches alerts newer than the previous run - but it never writes that watermark back. As a result `$Since` always falls back to the default 24-hour window, so every run re-fetches and re-sends the same alerts (and the day-partitioned de-dupe in `Write-AlertTrace` resets at midnight, which lines up with the reported timing jumps).

## Fix

Capture the run start, read/store an explicit `LastRunTime` watermark (falling back to the existing `Timestamp` for backward compatibility), and upsert the `AlertLastRun` row after processing. Each run now only sends alerts created since the previous run.

## Testing

- PowerShell parses clean.
- A mock-storage harness confirms the behaviour: run 1 sends the backlog, run 2 (no new alerts) sends nothing, run 3 sends only a newly-added alert.

Fixes KelvinTegelaar/CIPP#6216