### PR TITLE
Resolve tenant variables in Win32 Custom App detection script

### DIFF
--- a/Modules/CIPPCore/Public/Add-CIPPW32ScriptApplication.ps1
+++ b/Modules/CIPPCore/Public/Add-CIPPW32ScriptApplication.ps1
@@ -74,7 +74,9 @@ function Add-CIPPW32ScriptApplication {
     # Build detection rules — detection script takes priority, then file detection, then marker file fallback
     if ($Properties.detectionScript) {
         # PowerShell script detection: script should write to STDOUT and exit 0 when detected
-        $DetectionScriptContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Properties.detectionScript))
+        # Resolve %tenantid%/%tenantfilter%/etc. for consistency with the install/uninstall scripts below
+        $ReplacedDetectionScript = Get-CIPPTextReplacement -Text $Properties.detectionScript -TenantFilter $TenantFilter
+        $DetectionScriptContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($ReplacedDetectionScript))
         $DetectionRules = @(
             @{
                 '@odata.type'         = '#microsoft.graph.win32LobAppPowerShellScriptDetection'


### PR DESCRIPTION
# Resolve tenant variables in the Win32 Custom App detection script

Fixes KelvinTegelaar/CIPP#6226.

`%tenantid%` and the other `Get-CIPPTextReplacement` tokens resolve in a Win32 Custom Application's install and uninstall scripts, but not in the detection script, which reaches Intune with the literal `%tenantid%` string.

In `Add-CIPPW32ScriptApplication.ps1` the install and uninstall scripts are passed through `Get-CIPPTextReplacement` before being base64-encoded, but the detection script was encoded from the raw `$Properties.detectionScript`. This change runs the detection script through `Get-CIPPTextReplacement` first, the same way as the install and uninstall scripts directly below it.

Verified against the real `Get-CIPPTextReplacement` with mocked tenant lookups: before the change the detection script keeps the literal `%tenantid%`; after, it resolves to the tenant's customerId and matches what the install script produces. Other tokens such as `%tenantfilter%` resolve too.
