### PR TITLE
Fix: Implement clearable fields in user edit

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
@@ -30,7 +30,6 @@ function Invoke-EditUser {
 
     #Edit the user
     try {
-        Write-Host "$([boolean]$UserObj.MustChangePass)"
         $UserPrincipalName = "$($UserObj.username)@$($UserObj.Domain ? $UserObj.Domain : $UserObj.primDomain.value)"
         $normalizedOtherMails = @(
             @($UserObj.otherMails) | ForEach-Object {
@@ -66,9 +65,27 @@ function Invoke-EditUser {
             }
         } | ForEach-Object {
             $NonEmptyProperties = $_.PSObject.Properties |
-            Where-Object { -not [string]::IsNullOrWhiteSpace($_.Value) } |
-            Select-Object -ExpandProperty Name
-            $_ | Select-Object -Property $NonEmptyProperties
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_.Value) } |
+                Select-Object -ExpandProperty Name
+                $_ | Select-Object -Property $NonEmptyProperties
+            }
+        # Explicit clears: the frontend lists the profile fields the user actively emptied.
+        # We re-add them as null (scalars) / empty array (collections) so Graph clears them, while
+        # untouched empty fields stay omitted. Whitelisted to safe attributes
+        $ClearableFields = @(
+            'givenName', 'surname', 'department', 'jobTitle', 'mobilePhone',
+            'streetAddress', 'city', 'state', 'postalCode', 'country', 'companyName',
+            'businessPhones', 'otherMails'
+        )
+        $ClearList = @($UserObj.clearProperties | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        foreach ($Prop in $ClearList) {
+            if ($Prop -notin $ClearableFields) { continue }
+            # Pass @() literally; routing it through a variable unrolls it back to $null.
+            if ($Prop -in 'businessPhones', 'otherMails') {
+                $BodyToShip | Add-Member -NotePropertyName $Prop -NotePropertyValue @() -Force
+            } else {
+                $BodyToShip | Add-Member -NotePropertyName $Prop -NotePropertyValue $null -Force
+            }
         }
         if ($UserObj.defaultAttributes) {
             $UserObj.defaultAttributes | Get-Member -MemberType NoteProperty | ForEach-Object {

--- a/Tests/Endpoint/Invoke-EditUser.Tests.ps1
+++ b/Tests/Endpoint/Invoke-EditUser.Tests.ps1
@@ -1,0 +1,94 @@
+# Pester tests for Invoke-EditUser
+# Validates the clear-vs-omit behaviour of the user PATCH body:
+# a profile field present in the request (even as null) is forwarded to Graph as a clear,
+# while an omitted field is left untouched.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1'
+
+    class HttpResponseContext {
+        [object]$StatusCode
+        [object]$Body
+    }
+    # The Functions worker exposes [HttpStatusCode]; map it for standalone test runs.
+    $Accelerators = [PSObject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+    if (-not ('HttpStatusCode' -as [type])) {
+        $Accelerators::Add('HttpStatusCode', [System.Net.HttpStatusCode])
+    }
+
+    function Write-LogMessage { param($headers, $API, $tenant, $message, $Sev, $LogData) }
+    function Get-CippException { param($Exception) $Exception }
+    # Capture the body of the user PATCH (first call; password reset is a separate call we don't trigger)
+    function New-GraphPostRequest {
+        param($uri, $tenantid, $type, $body, [switch]$verbose)
+        if ($null -eq $script:lastBody) { $script:lastBody = $body }
+    }
+
+    function New-EditRequest {
+        param([hashtable]$Extra)
+        $body = [pscustomobject]@{
+            id           = '11111111-1111-1111-1111-111111111111'
+            tenantFilter = 'contoso.onmicrosoft.com'
+            username     = 'jdoe'
+            Domain       = 'contoso.com'
+            displayName  = 'John Doe'
+        }
+        foreach ($key in $Extra.Keys) {
+            $body | Add-Member -NotePropertyName $key -NotePropertyValue $Extra[$key] -Force
+        }
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'EditUser' }
+            Headers = @{}
+            Body    = $body
+        }
+    }
+
+    . $FunctionPath
+}
+
+Describe 'Invoke-EditUser body construction' {
+    BeforeEach {
+        $script:lastBody = $null
+    }
+
+    It 'clears a field listed in clearProperties' {
+        $request = New-EditRequest -Extra @{ clearProperties = @('jobTitle') }
+
+        $null = Invoke-EditUser -Request $request -TriggerMetadata $null
+
+        $script:lastBody | Should -Match '"jobTitle":null'
+    }
+
+    It 'omits a field that was neither sent nor listed for clearing' {
+        $request = New-EditRequest -Extra @{}
+
+        $null = Invoke-EditUser -Request $request -TriggerMetadata $null
+
+        $script:lastBody | Should -Not -Match 'jobTitle'
+    }
+
+    It 'sends a provided value unchanged' {
+        $request = New-EditRequest -Extra @{ jobTitle = 'Manager' }
+
+        $null = Invoke-EditUser -Request $request -TriggerMetadata $null
+
+        $script:lastBody | Should -Match '"jobTitle":"Manager"'
+    }
+
+    It 'clears a collection field with an empty array' {
+        $request = New-EditRequest -Extra @{ clearProperties = @('otherMails') }
+
+        $null = Invoke-EditUser -Request $request -TriggerMetadata $null
+
+        $script:lastBody | Should -Match '"otherMails":\[\]'
+    }
+
+    It 'never clears displayName even when listed (Graph rejects it)' {
+        $request = New-EditRequest -Extra @{ clearProperties = @('displayName') }
+
+        $null = Invoke-EditUser -Request $request -TriggerMetadata $null
+
+        $script:lastBody | Should -Not -Match '"displayName":(null|"")'
+    }
+}


### PR DESCRIPTION
Introduce functionality to allow specific user profile fields to be cleared when editing a user. Currently the property is just quietly dropped with a success message.

Frontend PR: https://github.com/KelvinTegelaar/CIPP/pull/6261