### PR TITLE
Escape square brackets in Intune assignment group name matching

### DIFF
--- a/Modules/CIPPCore/Public/Compare-CIPPIntuneAssignments.ps1
+++ b/Modules/CIPPCore/Public/Compare-CIPPIntuneAssignments.ps1
@@ -80,7 +80,7 @@ function Compare-CIPPIntuneAssignments {
             $ExpectedGroupIds = @(
                 $ExpectedCustomGroup.Split(',').Trim() | ForEach-Object {
                     $name = $_
-                    $AllGroupsCache | Where-Object { $_.displayName -like $name } | Select-Object -ExpandProperty id
+                    $AllGroupsCache | Where-Object { $_.displayName -like ($name -replace '\[', '`[' -replace '\]', '`]') } | Select-Object -ExpandProperty id
                 } | Where-Object { $_ }
             )
             $MissingIds = @($ExpectedGroupIds | Where-Object { $_ -notin $ExistingIncludeGroupIds })
@@ -97,7 +97,7 @@ function Compare-CIPPIntuneAssignments {
             $ExpectedExcludeIds = @(
                 $ExpectedExcludeGroup.Split(',').Trim() | ForEach-Object {
                     $name = $_
-                    $AllGroupsCache | Where-Object { $_.displayName -like $name } | Select-Object -ExpandProperty id
+                    $AllGroupsCache | Where-Object { $_.displayName -like ($name -replace '\[', '`[' -replace '\]', '`]') } | Select-Object -ExpandProperty id
                 } | Where-Object { $_ }
             )
             $MissingExcludeIds = @($ExpectedExcludeIds | Where-Object { $_ -notin $ExistingExcludeGroupIds })

--- a/Modules/CIPPCore/Public/Set-CIPPAssignedApplication.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPAssignedApplication.ps1
@@ -114,7 +114,7 @@ function Set-CIPPAssignedApplication {
                     $resolvedGroupIds = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/groups?$top=999&$select=id,displayName' -tenantid $TenantFilter | ForEach-Object {
                         $Group = $_
                         foreach ($SingleName in $GroupNames) {
-                            if ($Group.displayName -like $SingleName) {
+                            if ($Group.displayName -like ($SingleName -replace '\[', '`[' -replace '\]', '`]')) {
                                 $Group.id
                             }
                         }
@@ -161,7 +161,7 @@ function Set-CIPPAssignedApplication {
                 $ResolvedExcludeIds = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/groups?$top=999&$select=id,displayName' -tenantid $TenantFilter | ForEach-Object {
                     $Group = $_
                     foreach ($SingleName in $ExcludeGroupNames) {
-                        if ($Group.displayName -like $SingleName) {
+                        if ($Group.displayName -like ($SingleName -replace '\[', '`[' -replace '\]', '`]')) {
                             $Group.id
                         }
                     }

--- a/Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1
@@ -89,7 +89,7 @@ function Set-CIPPAssignedPolicy {
                     $resolvedGroupIds = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/groups?$select=id,displayName&$top=999' -tenantid $TenantFilter |
                         ForEach-Object {
                             foreach ($SingleName in $GroupNames) {
-                                if ($_.displayName -like $SingleName) {
+                                if ($_.displayName -like ($SingleName -replace '\[', '`[' -replace '\]', '`]')) {
                                     $_.id
                                 }
                             }
@@ -129,7 +129,7 @@ function Set-CIPPAssignedPolicy {
                 $ResolvedExcludeIds = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/groups?$select=id,displayName&$top=999' -tenantid $TenantFilter |
                     ForEach-Object {
                         foreach ($SingleName in $ExcludeGroupNames) {
-                            if ($_.displayName -like $SingleName) {
+                            if ($_.displayName -like ($SingleName -replace '\[', '`[' -replace '\]', '`]')) {
                                 $_.id
                             }
                         }


### PR DESCRIPTION
Resolves KelvinTegelaar/CIPP#6246

## Problem

Intune assignment resolves group and assignment-filter names with PowerShell's `-like`
operator. `-like` treats `[ ]` as wildcard character-class syntax, so a literal group
named `[WIN] Company Devices` never matches itself. Deploying an app (or policy) to such
a group fails with `No matching groups resolved for assignment request.`, even though the
group exists with that exact name. Bracket-prefixed naming schemes (`[WIN]`, `[PROD]`,
`[Pilot]`, ...) are common, so this hits real tenants. Other wildcard metacharacters in a
literal name (`?`, `*`) are affected the same way.

## Fix

Escape only the square brackets in the supplied name (`` `[ `` / `` `] ``) before the `-like`
match, so `[` and `]` are treated as literal characters instead of a wildcard character-class.
`*` and `?` are left untouched, so the documented wildcard matching (the assignment UI labels
say "Wildcards (*) are allowed") keeps working exactly as before. Only the unintended
bracket-as-character-class behaviour is fixed.

The same root cause is present in every Intune assignment group-name lookup, so all six
group-resolution sites are fixed together rather than only the one path in the report:

| File | Group lookups fixed |
|---|---|
| `Set-CIPPAssignedApplication.ps1` | include, exclude |
| `Set-CIPPAssignedPolicy.ps1` | include, exclude |
| `Compare-CIPPIntuneAssignments.ps1` | include, exclude |

This covers app deployment (Standards "Deploy Application", the Chrome-extension standard,
Office-app deploy, the assign-app endpoint), configuration-policy assignment, and the
assignment drift/comparison reporting, all of which share the predicate.

Assignment-filter name matching (which also uses `-like`) is deliberately left unchanged:
`Compare-CIPPIntuneAssignments` documents the filter name as supporting wildcards, so
escaping it would remove a documented feature. Only group-name resolution, which is matched
against exact names, is made literal here.

## Behaviour note

Wildcards `*` and `?` still work exactly as documented - only `[` and `]` are escaped. So
`Sales*` keeps matching every Sales group, while a literal `[WIN] Company Devices` now
resolves to itself instead of being read as the character-class `[WIN]`.

## Verification

Validated by inspection plus a standalone logic harness that reproduces the resolution
predicate (old vs new) against a realistic group set including bracketed, parenthesised and
near-collision names. The harness confirms: the bug pre-fix (bracketed name resolves to
nothing), the fix post-fix (resolves to the correct group only), plain names still resolve,
comma-separated multi-group input works, and no over-matching across similar names.

## Related (separate issue)

`Get-CIPPAlertGroupMembershipChange` uses the same `-like` pattern when matching audit-log
group names against the admin's monitored-group list. Bracketed monitored group names would
silently never alert. It is intentionally left out of this PR and raised separately, because
that path may be intended to support wildcard monitoring and the desired behaviour is a
maintainer decision.