### PR TITLE
Refactor: share mailbox permission helper

### DIFF
--- a/Modules/CIPPCore/Public/Set-CIPPMailboxAccess.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPMailboxAccess.ps1
@@ -7,7 +7,7 @@ function Set-CIPPMailboxAccess {
         $TenantFilter,
         $APIName = 'Manage Shared Mailbox Access',
         $Headers,
-        [array]$AccessRights
+        [array]$AccessRights # Retained for caller compatibility; this helper grants FullAccess
     )
 
     # Ensure AccessUser is always an array
@@ -22,20 +22,12 @@ function Set-CIPPMailboxAccess {
 
     $Results = [system.collections.generic.list[string]]::new()
 
-    # Process each access user
+    # Delegate each grant to Set-CIPPMailboxPermission so the permission-level -> EXO cmdlet mapping,
+    # logging, cache sync, and error handling all live in one place. This helper grants FullAccess.
     foreach ($User in $AccessUser) {
-        try {
-            $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Add-MailboxPermission' -cmdParams @{Identity = $userid; user = $User; AutoMapping = $Automap; accessRights = $AccessRights; InheritanceType = 'all' } -Anchor $userid
-
-            $Message = "Successfully added $($User) to $($userid) Shared Mailbox $($Automap ? 'with' : 'without') AutoMapping, with the following permissions: $AccessRights"
-            Write-LogMessage -headers $Headers -API $APIName -message $Message -Sev 'Info' -tenant $TenantFilter
-            $Results.Add($Message)
-        } catch {
-            $ErrorMessage = Get-CippException -Exception $_
-            $Message = "Failed to add mailbox permissions for $($User) on $($userid). Error: $($ErrorMessage.NormalizedError)"
-            Write-LogMessage -headers $Headers -API $APIName -message $Message -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
-            $Results.Add($Message)
-        }
+        $Results.Add(
+            (Set-CIPPMailboxPermission -UserId $userid -AccessUser $User -PermissionLevel 'FullAccess' -Action 'Add' -AutoMap $Automap -TenantFilter $TenantFilter -APIName $APIName -Headers $Headers)
+        )
     }
 
     return $Results

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecEditMailboxPermissions.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecEditMailboxPermissions.ps1
@@ -17,110 +17,27 @@ function Invoke-ExecEditMailboxPermissions {
     $Username = $request.body.userID
     $Tenantfilter = $request.body.tenantfilter
     if ($username -eq $null) { exit }
-    $userid = (New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users/$($username)" -tenantid $Tenantfilter).id
     $Results = [System.Collections.ArrayList]@()
 
-    $RemoveFullAccess = ($Request.body.RemoveFullAccess).value
-    foreach ($RemoveUser in $RemoveFullAccess) {
-        try {
-            $MailboxPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Remove-mailboxpermission' -cmdParams @{Identity = $userid; user = $RemoveUser; accessRights = @('FullAccess'); }
-            $results.add("Removed $($removeuser) from $($username) Shared Mailbox permissions")
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Removed $($RemoveUser) from $($username) Shared Mailbox permission" -Sev 'Info' -tenant $TenantFilter
+    # Each request-body bucket maps to a (PermissionLevel, Action) pair. Delegate to
+    # Set-CIPPMailboxPermission so the EXO cmdlet mapping, logging, cache sync, and error handling
+    # all live in one place. The mailbox UPN is passed straight through as the identity - EXO accepts
+    # it, so no Graph id lookup is required.
+    $PermissionBuckets = @(
+        @{ Bucket = 'RemoveFullAccess'; PermissionLevel = 'FullAccess'; Action = 'Remove'; AutoMap = $true }
+        @{ Bucket = 'AddFullAccess'; PermissionLevel = 'FullAccess'; Action = 'Add'; AutoMap = $true }
+        @{ Bucket = 'AddFullAccessNoAutoMap'; PermissionLevel = 'FullAccess'; Action = 'Add'; AutoMap = $false }
+        @{ Bucket = 'AddSendAs'; PermissionLevel = 'SendAs'; Action = 'Add'; AutoMap = $true }
+        @{ Bucket = 'RemoveSendAs'; PermissionLevel = 'SendAs'; Action = 'Remove'; AutoMap = $true }
+        @{ Bucket = 'AddSendOnBehalf'; PermissionLevel = 'SendOnBehalf'; Action = 'Add'; AutoMap = $true }
+        @{ Bucket = 'RemoveSendOnBehalf'; PermissionLevel = 'SendOnBehalf'; Action = 'Remove'; AutoMap = $true }
+    )
 
-            # Sync cache
-            Sync-CIPPMailboxPermissionCache -TenantFilter $TenantFilter -MailboxIdentity $username -User $RemoveUser -PermissionType 'FullAccess' -Action 'Remove'
-        } catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Could not remove mailbox permissions for $($removeuser) on $($username)" -Sev 'Error' -tenant $TenantFilter
-            $results.add("Could not remove $($removeuser) shared mailbox permissions for $($username). Error: $($_.Exception.Message)")
-        }
-    }
-    $AddFullAccess = ($Request.body.AddFullAccess).value
-
-    foreach ($UserAutomap in $AddFullAccess) {
-        try {
-            $MailboxPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Add-MailboxPermission' -cmdParams @{Identity = $userid; user = $UserAutomap; accessRights = @('FullAccess'); automapping = $true }
-            $results.add( "Granted $($UserAutomap) access to $($username) Mailbox with automapping")
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Granted $($UserAutomap) access to $($username) Mailbox with automapping" -Sev 'Info' -tenant $TenantFilter
-
-            # Sync cache
-            Sync-CIPPMailboxPermissionCache -TenantFilter $TenantFilter -MailboxIdentity $username -User $UserAutomap -PermissionType 'FullAccess' -Action 'Add'
-
-        } catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Could not add mailbox permissions for $($UserAutomap) on $($username)" -Sev 'Error' -tenant $TenantFilter
-            $results.add( "Could not add $($UserAutomap) shared mailbox permissions for $($username). Error: $($_.Exception.Message)")
-        }
-    }
-    $AddFullAccessNoAutoMap = ($Request.body.AddFullAccessNoAutoMap).value
-
-    foreach ($UserNoAutomap in $AddFullAccessNoAutoMap) {
-        try {
-            $MailboxPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Add-MailboxPermission' -cmdParams @{Identity = $userid; user = $UserNoAutomap; accessRights = @('FullAccess'); automapping = $false }
-            $results.add( "Granted $UserNoAutomap access to $($username) Mailbox without automapping")
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Granted $UserNoAutomap access to $($username) Mailbox without automapping" -Sev 'Info' -tenant $TenantFilter
-
-            # Sync cache
-            Sync-CIPPMailboxPermissionCache -TenantFilter $TenantFilter -MailboxIdentity $username -User $UserNoAutomap -PermissionType 'FullAccess' -Action 'Add'
-        } catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Could not add mailbox permissions for $($UserNoAutomap) on $($username)" -Sev 'Error' -tenant $TenantFilter
-            $results.add("Could not add $($UserNoAutomap) shared mailbox permissions for $($username). Error: $($_.Exception.Message)")
-        }
-    }
-
-    $AddSendAS = ($Request.body.AddSendAs).value
-
-    foreach ($UserSendAs in $AddSendAS) {
-        try {
-            $MailboxPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Add-RecipientPermission' -cmdParams @{Identity = $userid; Trustee = $UserSendAs; accessRights = @('SendAs') }
-            $results.add( "Granted $UserSendAs access to $($username) with Send As permissions")
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Granted $UserSendAs access to $($username) with Send As permissions" -Sev 'Info' -tenant $TenantFilter
-
-            # Sync cache
-            Sync-CIPPMailboxPermissionCache -TenantFilter $TenantFilter -MailboxIdentity $username -User $UserSendAs -PermissionType 'SendAs' -Action 'Add'
-        } catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Could not add mailbox permissions for $($UserSendAs) on $($username)" -Sev 'Error' -tenant $TenantFilter
-            $results.add("Could not add $($UserSendAs) send-as permissions for $($username). Error: $($_.Exception.Message)")
-        }
-    }
-
-    $RemoveSendAs = ($Request.body.RemoveSendAs).value
-
-    foreach ($UserSendAs in $RemoveSendAs) {
-        try {
-            $MailboxPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Remove-RecipientPermission' -cmdParams @{Identity = $userid; Trustee = $UserSendAs; accessRights = @('SendAs') }
-            $results.add( "Removed $UserSendAs from $($username) with Send As permissions")
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Removed $UserSendAs from $($username) with Send As permissions" -Sev 'Info' -tenant $TenantFilter
-
-            # Sync cache
-            Sync-CIPPMailboxPermissionCache -TenantFilter $TenantFilter -MailboxIdentity $username -User $UserSendAs -PermissionType 'SendAs' -Action 'Remove'
-        } catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Could not remove mailbox permissions for $($UserSendAs) on $($username)" -Sev 'Error' -tenant $TenantFilter
-            $results.add("Could not remove $($UserSendAs) send-as permissions for $($username). Error: $($_.Exception.Message)")
-        }
-    }
-
-    $AddSendOnBehalf = ($Request.body.AddSendOnBehalf).value
-
-    foreach ($UserSendOnBehalf in $AddSendOnBehalf) {
-        try {
-            $MailboxPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Set-Mailbox' -cmdParams @{Identity = $userid; GrantSendonBehalfTo = @{'@odata.type' = '#Exchange.GenericHashTable'; add = $UserSendOnBehalf }; }
-            $results.add( "Granted $UserSendOnBehalf access to $($username) with Send On Behalf Permissions")
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Granted $UserSendOnBehalf access to $($username) with Send On Behalf Permissions" -Sev 'Info' -tenant $TenantFilter
-        } catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Could not add send on behalf permissions for $($UserSendOnBehalf) on $($username)" -Sev 'Error' -tenant $TenantFilter
-            $results.add("Could not add $($UserSendOnBehalf) send on behalf permissions for $($username). Error: $($_.Exception.Message)")
-        }
-    }
-
-    $RemoveSendOnBehalf = ($Request.body.RemoveSendOnBehalf).value
-
-    foreach ($UserSendOnBehalf in $RemoveSendOnBehalf) {
-        try {
-            $MailboxPerms = New-ExoRequest -Anchor $username -tenantid $Tenantfilter -cmdlet 'Set-Mailbox' -cmdParams @{Identity = $userid; GrantSendonBehalfTo = @{'@odata.type' = '#Exchange.GenericHashTable'; remove = $UserSendOnBehalf }; }
-            $results.add( "Removed $UserSendOnBehalf from $($username) Send on Behalf Permissions")
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Removed $UserSendOnBehalf from $($username) Send on Behalf Permissions" -Sev 'Info' -tenant $TenantFilter
-        } catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME-message "Could not Remove send on behalf permissions for $($UserSendOnBehalf) on $($username)" -Sev 'Error' -tenant $TenantFilter
-            $results.add("Could not remove $($UserSendOnBehalf) send on behalf permissions for $($username). Error: $($_.Exception.Message)")
+    foreach ($Bucket in $PermissionBuckets) {
+        foreach ($AccessUser in ($Request.body.($Bucket.Bucket)).value) {
+            $null = $Results.Add(
+                (Set-CIPPMailboxPermission -UserId $Username -AccessUser $AccessUser -PermissionLevel $Bucket.PermissionLevel -Action $Bucket.Action -AutoMap $Bucket.AutoMap -TenantFilter $Tenantfilter -APIName $APIName -Headers $Headers)
+            )
         }
     }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyMBPerms.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyMBPerms.ps1
@@ -1,4 +1,4 @@
-Function Invoke-ExecModifyMBPerms {
+function Invoke-ExecModifyMBPerms {
     <#
     .FUNCTIONALITY
         Entrypoint
@@ -9,41 +9,42 @@ Function Invoke-ExecModifyMBPerms {
     param($Request, $TriggerMetadata)
 
     $APIName = $Request.Params.CIPPEndpoint
-    Write-LogMessage -headers $Request.Headers -API $APINAME -message 'Accessed this API' -Sev 'Debug'
+    $Headers = $Request.Headers
+    Write-LogMessage -headers $Headers -API $APIName -message 'Accessed this API' -Sev 'Debug'
 
     # Extract mailbox requests - handle all three formats
     $MailboxRequests = $null
     $Results = [System.Collections.ArrayList]::new()
 
     # Direct array format
-    if ($request.body -is [array]) {
-        $MailboxRequests = $request.body
+    if ($Request.Body -is [array]) {
+        $MailboxRequests = $Request.Body
     }
     # Bulk format with mailboxRequests property
-    elseif ($request.body.mailboxRequests) {
-        $MailboxRequests = $request.body.mailboxRequests
+    elseif ($Request.Body.mailboxRequests) {
+        $MailboxRequests = $Request.Body.mailboxRequests
     }
     # Legacy single mailbox format
-    elseif ($request.body.userID -and $request.body.permissions) {
+    elseif ($Request.Body.userID -and $Request.Body.permissions) {
         $MailboxRequests = @([PSCustomObject]@{
-            userID = $request.body.userID
-            tenantFilter = $request.body.tenantFilter
-            permissions = $request.body.permissions
-        })
+                userID       = $Request.Body.userID
+                tenantFilter = $Request.Body.tenantFilter
+                permissions  = $Request.Body.permissions
+            })
     }
 
     if (-not $MailboxRequests -or $MailboxRequests.Count -eq 0) {
-        Write-LogMessage -headers $Request.Headers -API $APINAME -message 'No mailbox requests provided' -Sev 'Error'
-        $body = [pscustomobject]@{'Results' = @("No mailbox requests provided") }
+        Write-LogMessage -headers $Headers -API $APIName -message 'No mailbox requests provided' -Sev 'Error'
+        $body = [pscustomobject]@{'Results' = @('No mailbox requests provided') }
         return ([HttpResponseContext]@{
-            StatusCode = [HttpStatusCode]::BadRequest
-            Body       = $Body
-        })
+                StatusCode = [HttpStatusCode]::BadRequest
+                Body       = $Body
+            })
         return
     }
 
-    $TenantFilter = $Request.body.tenantFilter
-    Write-LogMessage -headers $Request.Headers -API $APINAME -message "Processing permission changes for $($MailboxRequests.Count) mailboxes" -Sev 'Info' -tenant $TenantFilter
+    $TenantFilter = $Request.Body.tenantFilter
+    Write-LogMessage -headers $Headers -API $APIName -message "Processing permission changes for $($MailboxRequests.Count) mailboxes" -Sev 'Info' -tenant $TenantFilter
 
     # Build cmdlet array for processing
     $CmdletArray = [System.Collections.ArrayList]::new()
@@ -51,12 +52,16 @@ Function Invoke-ExecModifyMBPerms {
     $GuidToMetadataMap = @{}  # Map GUIDs to our metadata
     $UserLookupCache = @{}
 
+    # Permission levels Set-CIPPMailboxPermission understands (its ValidateSet). Levels outside this
+    # set are silently skipped, matching the behaviour of the inline switch this used to carry.
+    $SupportedPermissionLevels = @('FullAccess', 'SendAs', 'SendOnBehalf', 'ReadPermission', 'ExternalAccount', 'DeleteItem', 'ChangePermission', 'ChangeOwner')
+
     foreach ($MailboxRequest in $MailboxRequests) {
         $Username = $MailboxRequest.userID
         $Permissions = $MailboxRequest.permissions
 
         if ([string]::IsNullOrEmpty($Username)) {
-            $null = $Results.Add("Skipped mailbox with missing userID")
+            $null = $Results.Add('Skipped mailbox with missing userID')
             continue
         }
 
@@ -65,18 +70,16 @@ Function Invoke-ExecModifyMBPerms {
             try {
                 $UserObject = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users/$($Username)" -tenantid $TenantFilter
                 $UserLookupCache[$Username] = $UserObject.userPrincipalName
-            }
-            catch {
+            } catch {
                 try {
                     $UserObject = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users?`$filter=userPrincipalName eq '$Username'" -tenantid $TenantFilter
                     if ($UserObject.value -and $UserObject.value.Count -gt 0) {
                         $UserLookupCache[$Username] = $UserObject.value[0].userPrincipalName
                     } else {
-                        throw "User not found"
+                        throw 'User not found'
                     }
-                }
-                catch {
-                    Write-LogMessage -headers $Request.Headers -API $APINAME -message "Could not find user $($Username)" -Sev 'Error' -tenant $TenantFilter
+                } catch {
+                    Write-LogMessage -headers $Headers -API $APIName -message "Could not find user $($Username)" -Sev 'Error' -tenant $TenantFilter
                     $null = $Results.Add("Could not find user $($Username)")
                     continue
                 }
@@ -99,7 +102,7 @@ Function Invoke-ExecModifyMBPerms {
             $AutoMap = if ($Permission.PSObject.Properties.Name -contains 'AutoMap') { $Permission.AutoMap } else { $true }
 
             # Handle multiple permission levels
-            $PermissionLevelArray = if ($PermissionLevels -like "*,*") {
+            $PermissionLevelArray = if ($PermissionLevels -like '*,*') {
                 $PermissionLevels -split ',' | ForEach-Object { $_.Trim() }
             } else {
                 @($PermissionLevels.Trim())
@@ -125,160 +128,35 @@ Function Invoke-ExecModifyMBPerms {
             foreach ($TargetUser in $TargetUsers) {
                 foreach ($PermissionLevel in $PermissionLevelArray) {
 
-                    # Create cmdlet parameters based on permission type and action
-                    $CmdletParams = @{}
-                    $CmdletName = ""
-                    $ExpectedResult = ""
+                    # Build the EXO cmdlet for this change via Set-CIPPMailboxPermission's
+                    # -AsCmdletObject mode - the single source of truth for the permission-level ->
+                    # cmdlet/parameter mapping. It returns @{ CmdletName; Parameters; ExpectedResult }
+                    # for supported combinations, or a plain string for unsupported ones (e.g. an Add
+                    # on a remove-only level), which we skip. The bulk machinery below is unchanged.
+                    if ($PermissionLevel -notin $SupportedPermissionLevels) { continue }
+                    $Action = if ($Modification -eq 'Remove') { 'Remove' } else { 'Add' }
 
-                    switch ($PermissionLevel) {
-                        'FullAccess' {
-                            if ($Modification -eq 'Remove') {
-                                $CmdletName = 'Remove-MailboxPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    user         = $TargetUser
-                                    accessRights = @('FullAccess')
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Removed $($TargetUser) from $($Username) FullAccess permissions"
-                            } else {
-                                $CmdletName = 'Add-MailboxPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    user         = $TargetUser
-                                    accessRights = @('FullAccess')
-                                    automapping  = $AutoMap
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Granted $($TargetUser) FullAccess to $($Username) with automapping $($AutoMap)"
-                            }
-                        }
-                        'SendAs' {
-                            if ($Modification -eq 'Remove') {
-                                $CmdletName = 'Remove-RecipientPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    Trustee      = $TargetUser
-                                    accessRights = @('SendAs')
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Removed $($TargetUser) SendAs permissions from $($Username)"
-                            } else {
-                                $CmdletName = 'Add-RecipientPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    Trustee      = $TargetUser
-                                    accessRights = @('SendAs')
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Granted $($TargetUser) SendAs permissions to $($Username)"
-                            }
-                        }
-                        'SendOnBehalf' {
-                            $CmdletName = 'Set-Mailbox'
-                            if ($Modification -eq 'Remove') {
-                                $CmdletParams = @{
-                                    Identity            = $UserId
-                                    GrantSendonBehalfTo = @{
-                                        '@odata.type' = '#Exchange.GenericHashTable'
-                                        remove        = $TargetUser
-                                    }
-                                    Confirm             = $false
-                                }
-                                $ExpectedResult = "Removed $($TargetUser) SendOnBehalf permissions from $($Username)"
-                            } else {
-                                $CmdletParams = @{
-                                    Identity            = $UserId
-                                    GrantSendonBehalfTo = @{
-                                        '@odata.type' = '#Exchange.GenericHashTable'
-                                        add           = $TargetUser
-                                    }
-                                    Confirm             = $false
-                                }
-                                $ExpectedResult = "Granted $($TargetUser) SendOnBehalf permissions to $($Username)"
-                            }
-                        }
-                        'ReadPermission' {
-                            if ($Modification -eq 'Remove') {
-                                $CmdletName = 'Remove-MailboxPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    user         = $TargetUser
-                                    accessRights = @('ReadPermission')
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Removed $($TargetUser) ReadPermission from $($Username)"
-                            }
-                        }
-                        'ExternalAccount' {
-                            if ($Modification -eq 'Remove') {
-                                $CmdletName = 'Remove-MailboxPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    user         = $TargetUser
-                                    accessRights = @('ExternalAccount')
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Removed $($TargetUser) ExternalAccount permissions from $($Username)"
-                            }
-                        }
-                        'DeleteItem' {
-                            if ($Modification -eq 'Remove') {
-                                $CmdletName = 'Remove-MailboxPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    user         = $TargetUser
-                                    accessRights = @('DeleteItem')
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Removed $($TargetUser) DeleteItem permissions from $($Username)"
-                            }
-                        }
-                        'ChangePermission' {
-                            if ($Modification -eq 'Remove') {
-                                $CmdletName = 'Remove-MailboxPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    user         = $TargetUser
-                                    accessRights = @('ChangePermission')
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Removed $($TargetUser) ChangePermission from $($Username)"
-                            }
-                        }
-                        'ChangeOwner' {
-                            if ($Modification -eq 'Remove') {
-                                $CmdletName = 'Remove-MailboxPermission'
-                                $CmdletParams = @{
-                                    Identity     = $UserId
-                                    user         = $TargetUser
-                                    accessRights = @('ChangeOwner')
-                                    Confirm      = $false
-                                }
-                                $ExpectedResult = "Removed $($TargetUser) ChangeOwner permissions from $($Username)"
-                            }
-                        }
-                    }
+                    $Mapping = Set-CIPPMailboxPermission -UserId $UserId -AccessUser $TargetUser -PermissionLevel $PermissionLevel -Action $Action -AutoMap $AutoMap -TenantFilter $TenantFilter -AsCmdletObject
 
-                    if ($CmdletName) {
+                    if ($Mapping -is [hashtable] -and $Mapping.CmdletName) {
                         # Generate unique GUID for this operation
                         $OperationGuid = [Guid]::NewGuid().ToString()
 
                         $CmdletObj = @{
-                            CmdletInput = @{
-                                CmdletName = $CmdletName
-                                Parameters = $CmdletParams
+                            CmdletInput   = @{
+                                CmdletName = $Mapping.CmdletName
+                                Parameters = $Mapping.Parameters
                             }
                             OperationGuid = $OperationGuid  # Add GUID to cmdlet object
                         }
 
                         $CmdletMetadata = [PSCustomObject]@{
-                            ExpectedResult = $ExpectedResult
-                            Mailbox = $Username
-                            TargetUser = $TargetUser
-                            Permission = $PermissionLevel
-                            Action = $Modification
-                            OperationGuid = $OperationGuid
+                            ExpectedResult = $Mapping.ExpectedResult
+                            Mailbox        = $Username
+                            TargetUser     = $TargetUser
+                            Permission     = $PermissionLevel
+                            Action         = $Modification
+                            OperationGuid  = $OperationGuid
                         }
 
                         $null = $CmdletArray.Add($CmdletObj)
@@ -293,12 +171,12 @@ Function Invoke-ExecModifyMBPerms {
     }
 
     if ($CmdletArray.Count -eq 0) {
-        Write-LogMessage -headers $Request.Headers -API $APINAME -message 'No valid cmdlets to process' -sev 'Warning' -tenant $TenantFilter
-        $body = [pscustomobject]@{'Results' = @("No valid permission changes to process") }
+        Write-LogMessage -headers $Headers -API $APIName -message 'No valid cmdlets to process' -sev 'Warning' -tenant $TenantFilter
+        $body = [pscustomobject]@{'Results' = @('No valid permission changes to process') }
         return ([HttpResponseContext]@{
-            StatusCode = [HttpStatusCode]::OK
-            Body       = $Body
-        })
+                StatusCode = [HttpStatusCode]::OK
+                Body       = $Body
+            })
         return
     }
 
@@ -306,7 +184,7 @@ Function Invoke-ExecModifyMBPerms {
     if ($CmdletArray.Count -gt 1) {
         # Use bulk processing with GUID tracking
         try {
-            Write-LogMessage -headers $Request.Headers -API $APINAME -message "Executing bulk request with $($CmdletArray.Count) cmdlets" -Sev 'Info' -tenant $TenantFilter
+            Write-LogMessage -headers $Headers -API $APIName -message "Executing bulk request with $($CmdletArray.Count) cmdlets" -Sev 'Info' -tenant $TenantFilter
             $BulkResults = New-ExoBulkRequest -tenantid $TenantFilter -cmdletArray @($CmdletArray) -ReturnWithCommand $true
 
             # Process bulk results using GUID mapping
@@ -321,13 +199,13 @@ Function Invoke-ExecModifyMBPerms {
                             if ($result.error) {
                                 $ErrorMessage = try { (Get-CippException -Exception $result.error).NormalizedError } catch { $result.error }
                                 $null = $Results.Add("Error processing $($metadata.Permission) for $($metadata.TargetUser) on $($metadata.Mailbox): $ErrorMessage")
-                                Write-LogMessage -headers $Request.Headers -API $APINAME -message "Error for operation $operationGuid`: $ErrorMessage" -Sev 'Error' -tenant $TenantFilter
+                                Write-LogMessage -headers $Headers -API $APIName -message "Error for operation $operationGuid`: $ErrorMessage" -Sev 'Error' -tenant $TenantFilter
                             } else {
                                 $null = $Results.Add($metadata.ExpectedResult)
-                                Write-LogMessage -headers $Request.Headers -API $APINAME -message "Success for operation $operationGuid`: $($metadata.ExpectedResult)" -Sev 'Info' -tenant $TenantFilter
+                                Write-LogMessage -headers $Headers -API $APIName -message "Success for operation $operationGuid`: $($metadata.ExpectedResult)" -Sev 'Info' -tenant $TenantFilter
                             }
                         } else {
-                            Write-LogMessage -headers $Request.Headers -API $APINAME -message "Could not map result to operation. GUID: $operationGuid, Available GUIDs: $($GuidToMetadataMap.Keys -join ', ')" -sev 'Warning' -tenant $TenantFilter
+                            Write-LogMessage -headers $Headers -API $APIName -message "Could not map result to operation. GUID: $operationGuid, Available GUIDs: $($GuidToMetadataMap.Keys -join ', ')" -sev 'Warning' -tenant $TenantFilter
 
                             # Fallback for unmapped results
                             if ($result.error) {
@@ -348,10 +226,9 @@ Function Invoke-ExecModifyMBPerms {
                 }
             }
 
-            Write-LogMessage -headers $Request.Headers -API $APINAME -message "Bulk request completed successfully" -Sev 'Info' -tenant $TenantFilter
-        }
-        catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME -message "Bulk request failed, using fallback: $($_.Exception.Message)" -Sev 'Error' -tenant $TenantFilter
+            Write-LogMessage -headers $Headers -API $APIName -message 'Bulk request completed successfully' -Sev 'Info' -tenant $TenantFilter
+        } catch {
+            Write-LogMessage -headers $Headers -API $APIName -message "Bulk request failed, using fallback: $($_.Exception.Message)" -Sev 'Error' -tenant $TenantFilter
 
             # Fallback to individual processing
             for ($i = 0; $i -lt $CmdletArray.Count; $i++) {
@@ -360,31 +237,28 @@ Function Invoke-ExecModifyMBPerms {
                 try {
                     $null = New-ExoRequest -Anchor $CmdletMetadata.Mailbox -tenantid $TenantFilter -cmdlet $CmdletObj.CmdletInput.CmdletName -cmdParams $CmdletObj.CmdletInput.Parameters
                     $null = $Results.Add($CmdletMetadata.ExpectedResult)
-                }
-                catch {
+                } catch {
                     $null = $Results.Add("Error processing $($CmdletMetadata.Permission) for $($CmdletMetadata.TargetUser) on $($CmdletMetadata.Mailbox): $($_.Exception.Message)")
                 }
             }
         }
-    }
-    else {
+    } else {
         # Use individual processing for single operation
         $CmdletObj = $CmdletArray[0]
         $CmdletMetadata = $CmdletMetadataArray[0]
         try {
             $null = New-ExoRequest -Anchor $CmdletMetadata.Mailbox -tenantid $TenantFilter -cmdlet $CmdletObj.CmdletInput.CmdletName -cmdParams $CmdletObj.CmdletInput.Parameters
             $null = $Results.Add($CmdletMetadata.ExpectedResult)
-            Write-LogMessage -headers $Request.Headers -API $APINAME -message "Executed $($CmdletMetadata.Permission) permission modification" -Sev 'Info' -tenant $TenantFilter
-        }
-        catch {
-            Write-LogMessage -headers $Request.Headers -API $APINAME -message "Permission modification failed: $($_.Exception.Message)" -Sev 'Error' -tenant $TenantFilter
+            Write-LogMessage -headers $Headers -API $APIName -message "Executed $($CmdletMetadata.Permission) permission modification" -Sev 'Info' -tenant $TenantFilter
+        } catch {
+            Write-LogMessage -headers $Headers -API $APIName -message "Permission modification failed: $($_.Exception.Message)" -Sev 'Error' -tenant $TenantFilter
             $null = $Results.Add("Error processing $($CmdletMetadata.Permission) for $($CmdletMetadata.TargetUser) on $($CmdletMetadata.Mailbox): $($_.Exception.Message)")
         }
     }
 
     $body = [pscustomobject]@{'Results' = @($Results) }
     return ([HttpResponseContext]@{
-        StatusCode = [HttpStatusCode]::OK
-        Body       = $Body
-    })
+            StatusCode = [HttpStatusCode]::OK
+            Body       = $Body
+        })
 }

--- a/Tests/Endpoint/Invoke-ExecEditMailboxPermissions.Tests.ps1
+++ b/Tests/Endpoint/Invoke-ExecEditMailboxPermissions.Tests.ps1
@@ -1,0 +1,127 @@
+# Pester tests for Invoke-ExecEditMailboxPermissions
+# The endpoint now delegates every request bucket (RemoveFullAccess / AddFullAccess /
+# AddFullAccessNoAutoMap / AddSendAs / RemoveSendAs / AddSendOnBehalf / RemoveSendOnBehalf) to
+# Set-CIPPMailboxPermission, so these tests assert each bucket maps to the right
+# PermissionLevel / Action / AutoMap. The EXO cmdlet mapping, logging, and cache sync are the
+# delegate's responsibility and are covered by Set-CIPPMailboxPermission.Tests.ps1.
+#
+# NOTE: the early `if ($username -eq $null) { exit }` guard is deliberately NOT exercised - `exit`
+# inside a dot-sourced function terminates the Pester runspace, so it cannot be tested in-process.
+# Every test below supplies a userID.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-ExecEditMailboxPermissions.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Invoke-ExecEditMailboxPermissions.ps1 under Modules/' }
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    # The function uses the short [HttpStatusCode] (the Functions host supplies `using namespace
+    # System.Net`). Register a type accelerator so it resolves when the function is dot-sourced here.
+    $TypeAccelerators = [PowerShell].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+    if (-not ([System.Management.Automation.PSTypeName]'HttpStatusCode').Type) {
+        $TypeAccelerators::Add('HttpStatusCode', [System.Net.HttpStatusCode])
+    }
+
+    function Set-CIPPMailboxPermission { param($UserId, $AccessUser, $PermissionLevel, $Action, $AutoMap, $TenantFilter, $APIName, $Headers) }
+    function Write-LogMessage { param($headers, $API, $tenant, $message, $Sev, $LogData) }
+
+    . $FunctionPath
+
+    # Build a request whose body carries a single bucket of delegates (mirrors the frontend's
+    # { value = @(...) } shape that the function reads via ($Request.body.<Bucket>).value).
+    function New-EditRequest {
+        param([string]$Bucket, [string[]]$Users, [string]$UserID = 'shared@contoso.com')
+        $body = [pscustomobject]@{ userID = $UserID; tenantfilter = 'contoso.com' }
+        $body | Add-Member -NotePropertyName $Bucket -NotePropertyValue ([pscustomobject]@{ value = $Users })
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'ExecEditMailboxPermissions' }
+            Headers = @{ Authorization = 'token' }
+            Body    = $body
+        }
+    }
+}
+
+Describe 'Invoke-ExecEditMailboxPermissions' {
+    BeforeEach {
+        Mock -CommandName Set-CIPPMailboxPermission -MockWith { "$Action $PermissionLevel for $AccessUser" }
+        Mock -CommandName Write-LogMessage -MockWith { }
+    }
+
+    It 'returns OK and passes the mailbox UPN through as the identity' {
+        $response = Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'AddFullAccess' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $UserId -eq 'shared@contoso.com' -and $TenantFilter -eq 'contoso.com' }
+    }
+
+    It 'RemoveFullAccess -> FullAccess / Remove' {
+        Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'RemoveFullAccess' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter {
+            $PermissionLevel -eq 'FullAccess' -and $Action -eq 'Remove' -and $AccessUser -eq 'user@contoso.com'
+        }
+    }
+
+    It 'AddFullAccess -> FullAccess / Add with AutoMap $true' {
+        Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'AddFullAccess' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter {
+            $PermissionLevel -eq 'FullAccess' -and $Action -eq 'Add' -and $AutoMap -eq $true
+        }
+    }
+
+    It 'AddFullAccessNoAutoMap -> FullAccess / Add with AutoMap $false' {
+        Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'AddFullAccessNoAutoMap' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter {
+            $PermissionLevel -eq 'FullAccess' -and $Action -eq 'Add' -and $AutoMap -eq $false
+        }
+    }
+
+    It 'AddSendAs -> SendAs / Add' {
+        Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'AddSendAs' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $PermissionLevel -eq 'SendAs' -and $Action -eq 'Add' }
+    }
+
+    It 'RemoveSendAs -> SendAs / Remove' {
+        Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'RemoveSendAs' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $PermissionLevel -eq 'SendAs' -and $Action -eq 'Remove' }
+    }
+
+    It 'AddSendOnBehalf -> SendOnBehalf / Add' {
+        Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'AddSendOnBehalf' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $PermissionLevel -eq 'SendOnBehalf' -and $Action -eq 'Add' }
+    }
+
+    It 'RemoveSendOnBehalf -> SendOnBehalf / Remove' {
+        Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'RemoveSendOnBehalf' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $PermissionLevel -eq 'SendOnBehalf' -and $Action -eq 'Remove' }
+    }
+
+    It 'processes every user in a multi-user bucket and collects their results' {
+        $response = Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'AddSendAs' -Users @('a@contoso.com', 'b@contoso.com')) -TriggerMetadata $null
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 2 -Exactly -ParameterFilter { $PermissionLevel -eq 'SendAs' -and $Action -eq 'Add' }
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        $response.Body.Results | Should -Contain 'Add SendAs for a@contoso.com'
+        $response.Body.Results | Should -Contain 'Add SendAs for b@contoso.com'
+    }
+
+    It 'surfaces the delegate failure string in Results and still returns OK' {
+        Mock -CommandName Set-CIPPMailboxPermission -MockWith { 'Failed to Add FullAccess for user@contoso.com on shared@contoso.com: boom' }
+
+        $response = Invoke-ExecEditMailboxPermissions -Request (New-EditRequest -Bucket 'AddFullAccess' -Users @('user@contoso.com')) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        ($response.Body.Results -join "`n") | Should -Match 'Failed to Add FullAccess for user@contoso.com on shared@contoso.com: boom'
+    }
+}

--- a/Tests/Endpoint/Invoke-ExecModifyMBPerms.Tests.ps1
+++ b/Tests/Endpoint/Invoke-ExecModifyMBPerms.Tests.ps1
@@ -1,0 +1,278 @@
+# Pester tests for Invoke-ExecModifyMBPerms
+# The endpoint delegates the permission-level -> EXO cmdlet/parameter mapping to
+# Set-CIPPMailboxPermission (dot-sourced below and called in -AsCmdletObject mode), so these tests
+# focus on what the endpoint owns: the single-operation vs bulk (New-ExoBulkRequest + GUID mapping)
+# execution paths, the bulk-failure fallback, the three accepted input shapes, the user-lookup
+# fallback, and the request guards. The mapping itself is covered by Set-CIPPMailboxPermission.Tests.ps1.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-ExecModifyMBPerms.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Invoke-ExecModifyMBPerms.ps1 under Modules/' }
+
+    # Dot-source the REAL Set-CIPPMailboxPermission so -AsCmdletObject produces real mappings - the
+    # endpoint now delegates the level -> cmdlet mapping to it. Its -AsCmdletObject path only builds a
+    # hashtable and returns early, so none of the EXO / log stubs below are exercised by it.
+    $PermissionFunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Set-CIPPMailboxPermission.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $PermissionFunctionPath) { throw 'Could not locate Set-CIPPMailboxPermission.ps1 under Modules/' }
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    # The function uses the short [HttpStatusCode]; register a type accelerator so it resolves here.
+    $TypeAccelerators = [PowerShell].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+    if (-not ([System.Management.Automation.PSTypeName]'HttpStatusCode').Type) {
+        $TypeAccelerators::Add('HttpStatusCode', [System.Net.HttpStatusCode])
+    }
+
+    function New-GraphGetRequest { param($uri, $tenantid) }
+    function New-ExoRequest { param($Anchor, $tenantid, $cmdlet, $cmdParams) }
+    function New-ExoBulkRequest { param($tenantid, $cmdletArray, $ReturnWithCommand) }
+    function Get-CippException { param($Exception) }
+    function Write-LogMessage { param($headers, $API, $tenant, $message, $Sev, $LogData) }
+
+    . $PermissionFunctionPath
+    . $FunctionPath
+
+    # Build a request in the bulk 'mailboxRequests' shape.
+    function New-ModifyRequest {
+        param($Mailboxes)
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'ExecModifyMBPerms' }
+            Headers = @{ Authorization = 'token' }
+            Body    = [pscustomobject]@{ tenantFilter = 'contoso.com'; mailboxRequests = $Mailboxes }
+        }
+    }
+
+    # Build a single mailbox request object with one permission.
+    function New-Perm {
+        param($Level, $Modification, $TargetUser = 'user@contoso.com', $AutoMap = $true)
+        [pscustomobject]@{
+            PermissionLevel = $Level
+            Modification    = $Modification
+            AutoMap         = $AutoMap
+            UserID          = @([pscustomobject]@{ value = $TargetUser })
+        }
+    }
+    function New-Mailbox {
+        param($UserID = 'shared@contoso.com', $Permissions)
+        [pscustomobject]@{ userID = $UserID; permissions = $Permissions }
+    }
+}
+
+Describe 'Invoke-ExecModifyMBPerms' {
+    BeforeEach {
+        Mock -CommandName New-GraphGetRequest -MockWith { [pscustomobject]@{ userPrincipalName = 'shared@contoso.com' } }
+        Mock -CommandName New-ExoRequest -MockWith { }
+        Mock -CommandName New-ExoBulkRequest -MockWith {
+            param($tenantid, $cmdletArray, $ReturnWithCommand)
+            # Echo each operation back as a success keyed by cmdlet name (GUID round-trips so the
+            # function can map results to its metadata).
+            $h = @{}
+            foreach ($c in $cmdletArray) {
+                $name = $c.CmdletInput.CmdletName
+                if (-not $h.ContainsKey($name)) { $h[$name] = @() }
+                $h[$name] += [pscustomobject]@{ OperationGuid = $c.OperationGuid }
+            }
+            $h
+        }
+        Mock -CommandName Get-CippException -MockWith { [pscustomobject]@{ NormalizedError = 'boom' } }
+        Mock -CommandName Write-LogMessage -MockWith { }
+    }
+
+    Context 'Single-operation execution and per-level mapping' {
+        It 'FullAccess Add -> individual New-ExoRequest with Add-MailboxPermission' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Add'))
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Add-MailboxPermission' -and $cmdParams.user -eq 'user@contoso.com' -and
+                $cmdParams.Identity -eq 'shared@contoso.com' -and $cmdParams.automapping -eq $true
+            }
+            Should -Invoke New-ExoBulkRequest -Times 0 -Exactly
+            $response.Body.Results | Should -Contain 'Granted user@contoso.com FullAccess to shared@contoso.com with automapping True'
+        }
+
+        It 'FullAccess Remove -> Remove-MailboxPermission' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Remove'))
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter { $cmdlet -eq 'Remove-MailboxPermission' }
+            $response.Body.Results | Should -Contain 'Removed user@contoso.com FullAccess from shared@contoso.com'
+        }
+
+        It 'SendAs Add -> Add-RecipientPermission with Trustee' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'SendAs' -Modification 'Add'))
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter { $cmdlet -eq 'Add-RecipientPermission' -and $cmdParams.Trustee -eq 'user@contoso.com' }
+        }
+
+        It 'SendOnBehalf Add -> Set-Mailbox with GrantSendonBehalfTo add hashtable' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'SendOnBehalf' -Modification 'Add'))
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Set-Mailbox' -and $cmdParams.GrantSendonBehalfTo.add -eq 'user@contoso.com' -and
+                $cmdParams.GrantSendonBehalfTo['@odata.type'] -eq '#Exchange.GenericHashTable'
+            }
+        }
+
+        It 'SendOnBehalf Remove -> Set-Mailbox with GrantSendonBehalfTo remove hashtable' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'SendOnBehalf' -Modification 'Remove'))
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter { $cmdlet -eq 'Set-Mailbox' -and $cmdParams.GrantSendonBehalfTo.remove -eq 'user@contoso.com' }
+        }
+
+        It 'default-level Remove (<Level>) -> Remove-MailboxPermission with that access right' -ForEach @(
+            @{ Level = 'ReadPermission' }
+            @{ Level = 'ExternalAccount' }
+            @{ Level = 'DeleteItem' }
+            @{ Level = 'ChangePermission' }
+            @{ Level = 'ChangeOwner' }
+        ) {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level $Level -Modification 'Remove'))
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter { $cmdlet -eq 'Remove-MailboxPermission' -and $cmdParams.accessRights -contains $Level }
+        }
+
+        It 'default-level Add produces no cmdlet -> OK with a no-op message' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'ReadPermission' -Modification 'Add'))
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+            Should -Invoke New-ExoRequest -Times 0 -Exactly
+            $response.Body.Results | Should -Contain 'No valid permission changes to process'
+        }
+    }
+
+    Context 'Bulk execution path' {
+        It 'two operations -> New-ExoBulkRequest with GUID-mapped results, no individual calls' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(
+                (New-Perm -Level 'FullAccess' -Modification 'Add')
+                (New-Perm -Level 'SendAs' -Modification 'Add')
+            ))
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke New-ExoBulkRequest -Times 1 -Exactly
+            Should -Invoke New-ExoRequest -Times 0 -Exactly
+            $response.Body.Results | Should -Contain 'Granted user@contoso.com FullAccess to shared@contoso.com with automapping True'
+            $response.Body.Results | Should -Contain 'Granted user@contoso.com SendAs permissions to shared@contoso.com'
+        }
+
+        It 'maps a per-operation error from the bulk result to an error string' {
+            Mock -CommandName New-ExoBulkRequest -MockWith {
+                param($tenantid, $cmdletArray, $ReturnWithCommand)
+                $h = @{}
+                foreach ($c in $cmdletArray) {
+                    $name = $c.CmdletInput.CmdletName
+                    if (-not $h.ContainsKey($name)) { $h[$name] = @() }
+                    $h[$name] += [pscustomobject]@{ OperationGuid = $c.OperationGuid; error = 'kaboom' }
+                }
+                $h
+            }
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(
+                (New-Perm -Level 'FullAccess' -Modification 'Add')
+                (New-Perm -Level 'SendAs' -Modification 'Add')
+            ))
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            ($response.Body.Results -join "`n") | Should -Match 'Error processing FullAccess for user@contoso.com on shared@contoso.com: boom'
+        }
+
+        It 'falls back to individual New-ExoRequest calls when the bulk request throws' {
+            Mock -CommandName New-ExoBulkRequest -MockWith { throw 'bulk endpoint down' }
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(
+                (New-Perm -Level 'FullAccess' -Modification 'Add')
+                (New-Perm -Level 'SendAs' -Modification 'Add')
+            ))
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke New-ExoRequest -Times 2 -Exactly
+            $response.Body.Results | Should -Contain 'Granted user@contoso.com FullAccess to shared@contoso.com with automapping True'
+        }
+    }
+
+    Context 'Input shapes' {
+        It 'accepts the legacy single-mailbox format (userID + permissions on the body)' {
+            $req = [pscustomobject]@{
+                Params  = @{ CIPPEndpoint = 'ExecModifyMBPerms' }
+                Headers = @{ Authorization = 'token' }
+                Body    = [pscustomobject]@{
+                    tenantFilter = 'contoso.com'
+                    userID       = 'shared@contoso.com'
+                    permissions  = @(New-Perm -Level 'FullAccess' -Modification 'Add')
+                }
+            }
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter { $cmdlet -eq 'Add-MailboxPermission' }
+            $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        }
+    }
+
+    Context 'User lookup' {
+        It 'falls back to a userPrincipalName filter query when the direct Graph lookup fails' {
+            Mock -CommandName New-GraphGetRequest -MockWith { [pscustomobject]@{ value = @([pscustomobject]@{ userPrincipalName = 'shared@contoso.com' }) } } -ParameterFilter { $uri -like '*filter*' }
+            Mock -CommandName New-GraphGetRequest -MockWith { throw 'direct lookup failed' }
+
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Add'))
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke New-GraphGetRequest -ParameterFilter { $uri -like '*filter*' }
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter { $cmdlet -eq 'Add-MailboxPermission' }
+            $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        }
+
+        It 'records a "could not find user" message when both lookups fail' {
+            # Graph fails for 'ghost' on both the direct and filter lookups; a second valid mailbox
+            # keeps CmdletArray non-empty so the specific message is not discarded by the
+            # "No valid permission changes" guard (which returns only a generic string).
+            Mock -CommandName New-GraphGetRequest -MockWith { throw 'not found' } -ParameterFilter { $uri -like '*ghost@contoso.com*' }
+
+            $req = New-ModifyRequest -Mailboxes @(
+                (New-Mailbox -UserID 'ghost@contoso.com' -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Add'))
+                (New-Mailbox -UserID 'valid@contoso.com' -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Add'))
+            )
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            ($response.Body.Results -join "`n") | Should -Match 'Could not find user ghost@contoso.com'
+        }
+    }
+
+    Context 'Guards' {
+        It 'returns BadRequest when no mailbox requests are provided' {
+            $req = [pscustomobject]@{
+                Params  = @{ CIPPEndpoint = 'ExecModifyMBPerms' }
+                Headers = @{ Authorization = 'token' }
+                Body    = [pscustomobject]@{ tenantFilter = 'contoso.com' }
+            }
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
+            $response.Body.Results | Should -Contain 'No mailbox requests provided'
+        }
+
+        It 'skips a mailbox request that is missing its userID' {
+            # A second valid mailbox keeps CmdletArray non-empty so the "Skipped" message survives
+            # (the empty-array guard would otherwise replace Results with a generic string).
+            $req = New-ModifyRequest -Mailboxes @(
+                (New-Mailbox -UserID '' -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Add'))
+                (New-Mailbox -UserID 'valid@contoso.com' -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Add'))
+            )
+
+            $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly
+            ($response.Body.Results -join "`n") | Should -Match 'Skipped mailbox with missing userID'
+        }
+    }
+}

--- a/Tests/Private/Set-CIPPMailboxAccess.Tests.ps1
+++ b/Tests/Private/Set-CIPPMailboxAccess.Tests.ps1
@@ -1,0 +1,79 @@
+# Pester tests for Set-CIPPMailboxAccess
+# Set-CIPPMailboxAccess now delegates each grant to Set-CIPPMailboxPermission (FullAccess / Add), so
+# these tests cover the per-user fan-out, extraction of frontend objects with a .value property,
+# AutoMap pass-through, and that one user's failure does not stop the rest (the delegate returns an
+# error string rather than throwing). The EXO cmdlet mapping itself is covered by
+# Set-CIPPMailboxPermission.Tests.ps1.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Set-CIPPMailboxAccess.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Set-CIPPMailboxAccess.ps1 under Modules/' }
+
+    function Set-CIPPMailboxPermission { param($UserId, $AccessUser, $PermissionLevel, $Action, $AutoMap, $TenantFilter, $APIName, $Headers) }
+
+    . $FunctionPath
+}
+
+Describe 'Set-CIPPMailboxAccess' {
+    BeforeEach {
+        Mock -CommandName Set-CIPPMailboxPermission -MockWith { "Granted $AccessUser FullAccess to $UserId with automapping $AutoMap" }
+    }
+
+    It 'delegates a single user to Set-CIPPMailboxPermission as a FullAccess Add' {
+        $result = Set-CIPPMailboxAccess -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+            -Automap $true -TenantFilter 'contoso.com' -AccessRights @('FullAccess')
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter {
+            $UserId -eq 'shared@contoso.com' -and
+            $AccessUser -eq 'user@contoso.com' -and
+            $PermissionLevel -eq 'FullAccess' -and
+            $Action -eq 'Add' -and
+            $AutoMap -eq $true -and
+            $TenantFilter -eq 'contoso.com'
+        }
+        $result | Should -Contain 'Granted user@contoso.com FullAccess to shared@contoso.com with automapping True'
+    }
+
+    It 'processes an array of users, one delegate call per user' {
+        $result = Set-CIPPMailboxAccess -userid 'shared@contoso.com' -AccessUser @('a@contoso.com', 'b@contoso.com') `
+            -Automap $true -TenantFilter 'contoso.com' -AccessRights @('FullAccess')
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 2 -Exactly
+        $result.Count | Should -Be 2
+    }
+
+    It 'extracts the .value property from frontend objects' {
+        $accessUsers = @([pscustomobject]@{ value = 'picked@contoso.com'; label = 'Picked User' })
+
+        Set-CIPPMailboxAccess -userid 'shared@contoso.com' -AccessUser $accessUsers `
+            -Automap $true -TenantFilter 'contoso.com' -AccessRights @('FullAccess')
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $AccessUser -eq 'picked@contoso.com' }
+    }
+
+    It 'passes AutoMap through to the delegate when disabled' {
+        Set-CIPPMailboxAccess -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+            -Automap $false -TenantFilter 'contoso.com' -AccessRights @('FullAccess')
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $AutoMap -eq $false }
+    }
+
+    It 'continues to the next user when one user returns a failure string' {
+        Mock -CommandName Set-CIPPMailboxPermission -MockWith {
+            if ($AccessUser -eq 'bad@contoso.com') {
+                'Failed to Add FullAccess for bad@contoso.com on shared@contoso.com: boom'
+            } else {
+                "Granted $AccessUser FullAccess to shared@contoso.com with automapping True"
+            }
+        }
+
+        $result = Set-CIPPMailboxAccess -userid 'shared@contoso.com' -AccessUser @('bad@contoso.com', 'good@contoso.com') `
+            -Automap $true -TenantFilter 'contoso.com' -AccessRights @('FullAccess')
+
+        Should -Invoke Set-CIPPMailboxPermission -Times 2 -Exactly
+        ($result -join "`n") | Should -Match 'Failed to Add FullAccess for bad@contoso.com on shared@contoso.com: boom'
+        ($result -join "`n") | Should -Match 'Granted good@contoso.com FullAccess to shared@contoso.com'
+    }
+}


### PR DESCRIPTION
Split out of #2096 (2/4).

`Set-CIPPMailboxAccess`, `Invoke-ExecEditMailboxPermissions`, and `Invoke-ExecModifyMBPerms` each duplicated the permission → EXO cmdlet mapping. They now share the existing `Set-CIPPMailboxPermission` helper (~230 fewer lines). Bulk processing in `ExecModifyMBPerms` is unchanged. Includes Pester coverage for all three refactored functions (34 tests, passing locally).

## Intended behavior changes

- `ExecEditMailboxPermissions` drops a redundant Graph `id` lookup — the UPN is passed straight to EXO as the identity.
- `SendOnBehalf` now syncs the permission cache, matching FullAccess/SendAs.