### PR TITLE
Tests: add mailbox permission coverage

### DIFF
--- a/Tests/Private/Remove-CIPPMailboxPermissions.Tests.ps1
+++ b/Tests/Private/Remove-CIPPMailboxPermissions.Tests.ps1
@@ -1,0 +1,147 @@
+# Pester tests for Remove-CIPPMailboxPermissions
+# Covers the per-level single-mailbox removal branches (SendOnBehalf -> Set-Mailbox + GrantSendonBehalfTo,
+# SendAs -> Remove-RecipientPermission, FullAccess -> Remove-MailboxPermission), cache-sync gating,
+# the "already removed" message selection, the -UseCache report-driven path, and the error path.
+#
+# NOTE: the 'AllUsers' branch uses ForEach-Object -Parallel, which runs each iteration in a separate
+# runspace that re-imports the real CIPPCore/AzBobbyTables modules. Pester mocks live in the test
+# runspace and cannot cross that boundary, so that branch is intentionally NOT unit-tested here.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Remove-CIPPMailboxPermissions.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Remove-CIPPMailboxPermissions.ps1 under Modules/' }
+
+    function New-ExoRequest { param($Anchor, $tenantid, $cmdlet, $cmdParams, $Select) }
+    function Get-CippException { param($Exception) }
+    function Get-CIPPMailboxPermissionReport { param($TenantFilter, [switch]$ByUser) }
+    function Sync-CIPPMailboxPermissionCache { param($TenantFilter, $MailboxIdentity, $User, $PermissionType, $Action) }
+    function Write-LogMessage { param($headers, $API, $tenant, $message, $Sev, $LogData) }
+
+    . $FunctionPath
+}
+
+Describe 'Remove-CIPPMailboxPermissions' {
+    BeforeEach {
+        # A successful EXO removal returns a truthy response that does NOT contain an error substring.
+        # (The branches use `$result -notlike '*error*'`; note that with a $null response,
+        #  $null -notlike '<pattern>' is $false, which would route to the "already removed" message.)
+        Mock -CommandName New-ExoRequest -MockWith { 'OK' }
+        Mock -CommandName Get-CippException -MockWith { [pscustomobject]@{ NormalizedError = 'boom' } }
+        Mock -CommandName Get-CIPPMailboxPermissionReport -MockWith { }
+        Mock -CommandName Sync-CIPPMailboxPermissionCache -MockWith { }
+        Mock -CommandName Write-LogMessage -MockWith { }
+    }
+
+    Context 'Single-mailbox removal branches' {
+        It 'removes SendOnBehalf via Set-Mailbox with a GrantSendonBehalfTo remove hashtable' {
+            $result = Remove-CIPPMailboxPermissions -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -TenantFilter 'contoso.com' -PermissionsLevel @('SendOnBehalf')
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Set-Mailbox' -and
+                $cmdParams.GrantSendonBehalfTo.remove -eq 'user@contoso.com' -and
+                $cmdParams.GrantSendonBehalfTo['@odata.type'] -eq '#Exchange.GenericHashTable'
+            }
+            $result | Should -Match "Removed SendOnBehalf permissions for user@contoso.com from shared@contoso.com's mailbox\."
+        }
+
+        It 'removes SendAs via Remove-RecipientPermission and syncs the cache' {
+            $result = Remove-CIPPMailboxPermissions -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -TenantFilter 'contoso.com' -PermissionsLevel @('SendAs')
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Remove-RecipientPermission' -and $cmdParams.Trustee -eq 'user@contoso.com'
+            }
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter {
+                $PermissionType -eq 'SendAs' -and $Action -eq 'Remove'
+            }
+            $result | Should -Match "Removed SendAs permissions for user@contoso.com from shared@contoso.com's mailbox\."
+        }
+
+        It 'reports SendAs as already-removed when EXO says the ACE is not present' {
+            Mock -CommandName New-ExoRequest -MockWith { "can't remove the ACL because the ACE isn't present" }
+
+            $result = Remove-CIPPMailboxPermissions -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -TenantFilter 'contoso.com' -PermissionsLevel @('SendAs')
+
+            # cache is still synced regardless of whether the permission existed
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter { $PermissionType -eq 'SendAs' }
+            $result | Should -Match "were already removed or don't exist"
+        }
+
+        It 'removes FullAccess via Remove-MailboxPermission and syncs the cache' {
+            $result = Remove-CIPPMailboxPermissions -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -TenantFilter 'contoso.com' -PermissionsLevel @('FullAccess')
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Remove-MailboxPermission' -and
+                $cmdParams.user -eq 'user@contoso.com' -and
+                $cmdParams.accessRights -contains 'FullAccess'
+            }
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter { $PermissionType -eq 'FullAccess' }
+            $result | Should -Match "Removed FullAccess permissions for user@contoso.com from shared@contoso.com's mailbox\."
+        }
+
+        It 'reports FullAccess as already-removed when EXO says the ACE does not exist' {
+            Mock -CommandName New-ExoRequest -MockWith { "can't remove because the ACE doesn't exist on the object." }
+
+            $result = Remove-CIPPMailboxPermissions -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -TenantFilter 'contoso.com' -PermissionsLevel @('FullAccess')
+
+            $result | Should -Match "were already removed or don't exist"
+        }
+
+        It 'processes multiple permission levels in one call' {
+            $result = Remove-CIPPMailboxPermissions -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -TenantFilter 'contoso.com' -PermissionsLevel @('FullAccess', 'SendAs', 'SendOnBehalf')
+
+            Should -Invoke New-ExoRequest -Times 3 -Exactly
+            $result.Count | Should -Be 3
+        }
+    }
+
+    Context '-UseCache path' {
+        It 'removes every cached permission for the user via recursion and returns per-mailbox results' {
+            Mock -CommandName Get-CIPPMailboxPermissionReport -MockWith {
+                [pscustomobject]@{
+                    User        = 'user@contoso.com'
+                    MailboxCount = 2
+                    Permissions = @(
+                        [pscustomobject]@{ MailboxUPN = 'sharedA@contoso.com'; AccessRights = 'FullAccess' }
+                        [pscustomobject]@{ MailboxUPN = 'sharedB@contoso.com'; AccessRights = 'SendAs' }
+                    )
+                }
+            }
+
+            $result = Remove-CIPPMailboxPermissions -AccessUser 'user@contoso.com' -TenantFilter 'contoso.com' -UseCache
+
+            Should -Invoke Get-CIPPMailboxPermissionReport -Times 1 -Exactly
+            # one EXO call per recursive removal (FullAccess + SendAs)
+            Should -Invoke New-ExoRequest -Times 2 -Exactly
+            $result.Count | Should -Be 2
+        }
+
+        It 'returns an informational message when no cached permissions exist' {
+            Mock -CommandName Get-CIPPMailboxPermissionReport -MockWith { }
+
+            $result = Remove-CIPPMailboxPermissions -AccessUser 'user@contoso.com' -TenantFilter 'contoso.com' -UseCache
+
+            Should -Invoke New-ExoRequest -Times 0 -Exactly
+            $result | Should -Be 'No mailbox permissions found for user@contoso.com in cached data'
+        }
+    }
+
+    Context 'Error path' {
+        It 'returns a failure string and logs an error when New-ExoRequest throws' {
+            Mock -CommandName New-ExoRequest -MockWith { throw 'EXO down' }
+
+            $result = Remove-CIPPMailboxPermissions -userid 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -TenantFilter 'contoso.com' -PermissionsLevel @('FullAccess')
+
+            $result | Should -Be 'Could not remove mailbox permissions for shared@contoso.com. Error: boom'
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $Sev -eq 'Error' }
+        }
+    }
+}

--- a/Tests/Private/Set-CIPPMailboxPermission.Tests.ps1
+++ b/Tests/Private/Set-CIPPMailboxPermission.Tests.ps1
@@ -1,0 +1,185 @@
+# Pester tests for Set-CIPPMailboxPermission
+# Covers the permission-level -> EXO cmdlet/parameter mapping (via -AsCmdletObject, no execution),
+# the execute path (New-ExoRequest + logging), cache-sync gating, and the error path.
+
+BeforeAll {
+    # Resolve by name under Modules/ so the test survives the function moving between modules.
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Set-CIPPMailboxPermission.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Set-CIPPMailboxPermission.ps1 under Modules/' }
+
+    # Stub every CIPP helper the function calls so Pester's Mock has a command to replace.
+    function New-ExoRequest { param($Anchor, $tenantid, $cmdlet, $cmdParams) }
+    function Get-CippException { param($Exception) }
+    function Sync-CIPPMailboxPermissionCache { param($TenantFilter, $MailboxIdentity, $User, $PermissionType, $Action) }
+    function Write-LogMessage { param($headers, $API, $tenant, $message, $Sev, $LogData) }
+
+    . $FunctionPath
+}
+
+Describe 'Set-CIPPMailboxPermission' {
+
+    Context '-AsCmdletObject mapping matrix (no execution)' {
+
+        It 'maps FullAccess Add to Add-MailboxPermission with automapping and InheritanceType' {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'FullAccess' -Action 'Add' -AutoMap $true -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result.CmdletName | Should -Be 'Add-MailboxPermission'
+            $result.Parameters.Identity | Should -Be 'shared@contoso.com'
+            $result.Parameters.user | Should -Be 'user@contoso.com'
+            $result.Parameters.accessRights | Should -Be @('FullAccess')
+            $result.Parameters.automapping | Should -BeTrue
+            $result.Parameters.InheritanceType | Should -Be 'all'
+            $result.Parameters.Confirm | Should -BeFalse
+            $result.ExpectedResult | Should -Be 'Granted user@contoso.com FullAccess to shared@contoso.com with automapping True'
+        }
+
+        It 'passes automapping through as $false when AutoMap is disabled' {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'FullAccess' -Action 'Add' -AutoMap $false -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result.Parameters.automapping | Should -BeFalse
+            $result.ExpectedResult | Should -Match 'automapping False'
+        }
+
+        It 'maps FullAccess Remove to Remove-MailboxPermission' {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'FullAccess' -Action 'Remove' -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result.CmdletName | Should -Be 'Remove-MailboxPermission'
+            $result.Parameters.accessRights | Should -Be @('FullAccess')
+            $result.Parameters.Keys | Should -Not -Contain 'automapping'
+            $result.ExpectedResult | Should -Be 'Removed user@contoso.com FullAccess from shared@contoso.com'
+        }
+
+        It 'maps SendAs Add to Add-RecipientPermission with Trustee' {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'SendAs' -Action 'Add' -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result.CmdletName | Should -Be 'Add-RecipientPermission'
+            $result.Parameters.Trustee | Should -Be 'user@contoso.com'
+            $result.Parameters.accessRights | Should -Be @('SendAs')
+            $result.ExpectedResult | Should -Be 'Granted user@contoso.com SendAs permissions to shared@contoso.com'
+        }
+
+        It 'maps SendAs Remove to Remove-RecipientPermission with Trustee' {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'SendAs' -Action 'Remove' -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result.CmdletName | Should -Be 'Remove-RecipientPermission'
+            $result.Parameters.Trustee | Should -Be 'user@contoso.com'
+            $result.ExpectedResult | Should -Be 'Removed user@contoso.com SendAs permissions from shared@contoso.com'
+        }
+
+        It 'maps SendOnBehalf Add to Set-Mailbox with GrantSendonBehalfTo add hashtable' {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'SendOnBehalf' -Action 'Add' -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result.CmdletName | Should -Be 'Set-Mailbox'
+            $result.Parameters.GrantSendonBehalfTo['@odata.type'] | Should -Be '#Exchange.GenericHashTable'
+            $result.Parameters.GrantSendonBehalfTo.add | Should -Be 'user@contoso.com'
+            $result.Parameters.GrantSendonBehalfTo.Keys | Should -Not -Contain 'remove'
+            $result.ExpectedResult | Should -Be 'Granted user@contoso.com SendOnBehalf permissions to shared@contoso.com'
+        }
+
+        It 'maps SendOnBehalf Remove to Set-Mailbox with GrantSendonBehalfTo remove hashtable' {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'SendOnBehalf' -Action 'Remove' -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result.CmdletName | Should -Be 'Set-Mailbox'
+            $result.Parameters.GrantSendonBehalfTo.remove | Should -Be 'user@contoso.com'
+            $result.Parameters.GrantSendonBehalfTo.Keys | Should -Not -Contain 'add'
+            $result.ExpectedResult | Should -Be 'Removed user@contoso.com SendOnBehalf permissions from shared@contoso.com'
+        }
+
+        It 'maps default-level Remove (<Level>) to Remove-MailboxPermission with that access right' -ForEach @(
+            @{ Level = 'ReadPermission' }
+            @{ Level = 'ExternalAccount' }
+            @{ Level = 'DeleteItem' }
+            @{ Level = 'ChangePermission' }
+            @{ Level = 'ChangeOwner' }
+        ) {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel $Level -Action 'Remove' -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result.CmdletName | Should -Be 'Remove-MailboxPermission'
+            $result.Parameters.accessRights | Should -Be @($Level)
+            $result.ExpectedResult | Should -Be "Removed user@contoso.com $Level from shared@contoso.com"
+        }
+
+        It 'returns an unsupported-action string for default-level Add (<Level>)' -ForEach @(
+            @{ Level = 'ReadPermission' }
+            @{ Level = 'ExternalAccount' }
+            @{ Level = 'DeleteItem' }
+            @{ Level = 'ChangePermission' }
+            @{ Level = 'ChangeOwner' }
+        ) {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel $Level -Action 'Add' -TenantFilter 'contoso.com' -AsCmdletObject
+
+            $result | Should -Be "Add action is not supported for $Level"
+        }
+    }
+
+    Context 'Execute path' {
+        BeforeEach {
+            Mock -CommandName New-ExoRequest -MockWith { }
+            Mock -CommandName Sync-CIPPMailboxPermissionCache -MockWith { }
+            Mock -CommandName Write-LogMessage -MockWith { }
+            Mock -CommandName Get-CippException -MockWith { [pscustomobject]@{ NormalizedError = 'boom' } }
+        }
+
+        It 'invokes New-ExoRequest with the mapped cmdlet/params anchored on the mailbox and returns the result string' {
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'FullAccess' -Action 'Add' -TenantFilter 'contoso.com'
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Add-MailboxPermission' -and
+                $Anchor -eq 'shared@contoso.com' -and
+                $tenantid -eq 'contoso.com' -and
+                $cmdParams.user -eq 'user@contoso.com'
+            }
+            $result | Should -Be 'Granted user@contoso.com FullAccess to shared@contoso.com with automapping True'
+        }
+
+        It 'logs an Info message on success' {
+            Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'SendAs' -Action 'Add' -TenantFilter 'contoso.com'
+
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $Sev -eq 'Info' }
+        }
+
+        It 'syncs the cache for cached permission types (<Level>)' -ForEach @(
+            @{ Level = 'FullAccess' }
+            @{ Level = 'SendAs' }
+            @{ Level = 'SendOnBehalf' }
+        ) {
+            Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel $Level -Action 'Add' -TenantFilter 'contoso.com'
+
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter {
+                $PermissionType -eq $Level -and $Action -eq 'Add'
+            }
+        }
+
+        It 'does not sync the cache for non-cached permission types' {
+            Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'ReadPermission' -Action 'Remove' -TenantFilter 'contoso.com'
+
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 0 -Exactly
+        }
+
+        It 'returns a failure string and logs an error when New-ExoRequest throws' {
+            Mock -CommandName New-ExoRequest -MockWith { throw 'EXO down' }
+
+            $result = Set-CIPPMailboxPermission -UserId 'shared@contoso.com' -AccessUser 'user@contoso.com' `
+                -PermissionLevel 'FullAccess' -Action 'Add' -TenantFilter 'contoso.com'
+
+            $result | Should -Be 'Failed to Add FullAccess for user@contoso.com on shared@contoso.com: boom'
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $Sev -eq 'Error' }
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 0 -Exactly
+        }
+    }
+}

--- a/Tests/Private/Set-CIPPMailboxVacation.Tests.ps1
+++ b/Tests/Private/Set-CIPPMailboxVacation.Tests.ps1
@@ -1,0 +1,132 @@
+# Pester tests for Set-CIPPMailboxVacation
+# Covers the mailbox-permission loop (delegating to Set-CIPPMailboxPermission), the calendar-permission
+# loop (Set-CIPPCalendarPermission), hashtable vs PSCustomObject entry access, missing-field skips,
+# Action propagation, and the calendar error path.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Set-CIPPMailboxVacation.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Set-CIPPMailboxVacation.ps1 under Modules/' }
+
+    function Set-CIPPMailboxPermission { param($UserId, $AccessUser, $PermissionLevel, $Action, $AutoMap, $TenantFilter, $APIName, $Headers) }
+    function Set-CIPPCalendarPermission { param($TenantFilter, $UserID, $FolderName, $APIName, $Headers, $RemoveAccess, $UserToGetPermissions, $Permissions, $CanViewPrivateItems) }
+    function Get-CippException { param($Exception) }
+
+    . $FunctionPath
+}
+
+Describe 'Set-CIPPMailboxVacation' {
+    BeforeEach {
+        Mock -CommandName Set-CIPPMailboxPermission -MockWith { 'mailbox-perm-result' }
+        Mock -CommandName Set-CIPPCalendarPermission -MockWith { 'calendar-perm-result' }
+        Mock -CommandName Get-CippException -MockWith { [pscustomobject]@{ NormalizedError = 'boom' } }
+    }
+
+    Context 'Mailbox permissions' {
+        It 'forwards each mailbox permission to Set-CIPPMailboxPermission with the requested Action' {
+            $perms = @(
+                [pscustomobject]@{ UserId = 'shared@contoso.com'; AccessUser = 'user@contoso.com'; PermissionLevel = 'FullAccess'; AutoMap = $true }
+            )
+
+            $results = Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Add' -MailboxPermissions $perms
+
+            Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter {
+                $UserId -eq 'shared@contoso.com' -and
+                $AccessUser -eq 'user@contoso.com' -and
+                $PermissionLevel -eq 'FullAccess' -and
+                $Action -eq 'Add' -and
+                $AutoMap -eq $true -and
+                $TenantFilter -eq 'contoso.com'
+            }
+            $results | Should -Contain 'mailbox-perm-result'
+        }
+
+        It 'propagates the Remove action to the delegate cmdlet' {
+            $perms = @([pscustomobject]@{ UserId = 'shared@contoso.com'; AccessUser = 'user@contoso.com'; PermissionLevel = 'SendAs' })
+
+            Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Remove' -MailboxPermissions $perms
+
+            Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $Action -eq 'Remove' }
+        }
+
+        It 'accepts hashtable entries as well as PSCustomObject entries' {
+            $perms = @(@{ UserId = 'shared@contoso.com'; AccessUser = 'user@contoso.com'; PermissionLevel = 'FullAccess' })
+
+            Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Add' -MailboxPermissions $perms
+
+            Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $UserId -eq 'shared@contoso.com' }
+        }
+
+        It 'defaults AutoMap to $true when not supplied' {
+            $perms = @([pscustomobject]@{ UserId = 'shared@contoso.com'; AccessUser = 'user@contoso.com'; PermissionLevel = 'FullAccess' })
+
+            Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Add' -MailboxPermissions $perms
+
+            Should -Invoke Set-CIPPMailboxPermission -Times 1 -Exactly -ParameterFilter { $AutoMap -eq $true }
+        }
+
+        It 'skips entries with missing required fields and records a skip message' {
+            $perms = @([pscustomobject]@{ UserId = 'shared@contoso.com'; PermissionLevel = 'FullAccess' }) # no AccessUser
+
+            $results = Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Add' -MailboxPermissions $perms
+
+            Should -Invoke Set-CIPPMailboxPermission -Times 0 -Exactly
+            $results | Should -Contain 'Skipped mailbox permission with missing fields'
+        }
+    }
+
+    Context 'Calendar permissions' {
+        It 'forwards Add calendar permissions with delegate, permissions and private-items flag' {
+            $cal = @(
+                [pscustomobject]@{ UserID = 'shared@contoso.com'; UserToGetPermissions = 'user@contoso.com'; FolderName = 'Calendar'; Permissions = 'Editor'; CanViewPrivateItems = $true }
+            )
+
+            $results = Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Add' -CalendarPermissions $cal
+
+            Should -Invoke Set-CIPPCalendarPermission -Times 1 -Exactly -ParameterFilter {
+                $UserID -eq 'shared@contoso.com' -and
+                $UserToGetPermissions -eq 'user@contoso.com' -and
+                $Permissions -eq 'Editor' -and
+                $CanViewPrivateItems -eq $true
+            }
+            $results | Should -Contain 'calendar-perm-result'
+        }
+
+        It 'uses RemoveAccess when the action is Remove' {
+            $cal = @([pscustomobject]@{ UserID = 'shared@contoso.com'; UserToGetPermissions = 'user@contoso.com' })
+
+            Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Remove' -CalendarPermissions $cal
+
+            Should -Invoke Set-CIPPCalendarPermission -Times 1 -Exactly -ParameterFilter {
+                $RemoveAccess -eq 'user@contoso.com'
+            }
+        }
+
+        It 'defaults the calendar folder name to Calendar' {
+            $cal = @([pscustomobject]@{ UserID = 'shared@contoso.com'; UserToGetPermissions = 'user@contoso.com' })
+
+            Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Add' -CalendarPermissions $cal
+
+            Should -Invoke Set-CIPPCalendarPermission -Times 1 -Exactly -ParameterFilter { $FolderName -eq 'Calendar' }
+        }
+
+        It 'skips calendar entries with missing required fields' {
+            $cal = @([pscustomobject]@{ UserID = 'shared@contoso.com' }) # no delegate
+
+            $results = Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Add' -CalendarPermissions $cal
+
+            Should -Invoke Set-CIPPCalendarPermission -Times 0 -Exactly
+            $results | Should -Contain 'Skipped calendar permission with missing fields'
+        }
+
+        It 'records a failure message when the calendar permission throws' {
+            Mock -CommandName Set-CIPPCalendarPermission -MockWith { throw 'cal down' }
+            $cal = @([pscustomobject]@{ UserID = 'shared@contoso.com'; UserToGetPermissions = 'user@contoso.com' })
+
+            $results = Set-CIPPMailboxVacation -TenantFilter 'contoso.com' -Action 'Add' -CalendarPermissions $cal
+
+            $results | Should -Match 'Failed calendar permission for user@contoso.com on shared@contoso.com: boom'
+        }
+    }
+}


### PR DESCRIPTION
Split out of #2096 (3/4).

New Pester coverage for `Set-CIPPMailboxPermission`, `Set-CIPPMailboxVacation`, and `Remove-CIPPMailboxPermissions`: permission-level → EXO cmdlet mapping, cache sync, Add/Remove actions, and error paths. Tests dot-source the function under test and stub CIPP helpers, matching the existing test style.

Test-only change; 43 tests pass locally against current `dev`.