### PR TITLE
feat: user filter + cache sync for mailbox permissions

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyMBPerms.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyMBPerms.ps1
@@ -15,6 +15,7 @@ function Invoke-ExecModifyMBPerms {
     # Extract mailbox requests - handle all three formats
     $MailboxRequests = $null
     $Results = [System.Collections.ArrayList]::new()
+    $SuccessfulOps = [System.Collections.ArrayList]::new()
 
     # Direct array format
     if ($Request.Body -is [array]) {
@@ -155,7 +156,7 @@ function Invoke-ExecModifyMBPerms {
                             Mailbox        = $Username
                             TargetUser     = $TargetUser
                             Permission     = $PermissionLevel
-                            Action         = $Modification
+                            Action         = $Action
                             OperationGuid  = $OperationGuid
                         }
 
@@ -202,6 +203,7 @@ function Invoke-ExecModifyMBPerms {
                                 Write-LogMessage -headers $Headers -API $APIName -message "Error for operation $operationGuid`: $ErrorMessage" -Sev 'Error' -tenant $TenantFilter
                             } else {
                                 $null = $Results.Add($metadata.ExpectedResult)
+                                $null = $SuccessfulOps.Add($metadata)
                                 Write-LogMessage -headers $Headers -API $APIName -message "Success for operation $operationGuid`: $($metadata.ExpectedResult)" -Sev 'Info' -tenant $TenantFilter
                             }
                         } else {
@@ -222,6 +224,7 @@ function Invoke-ExecModifyMBPerms {
                 foreach ($CmdletMetadata in $CmdletMetadataArray) {
                     if ($CmdletMetadata.ExpectedResult) {
                         $null = $Results.Add($CmdletMetadata.ExpectedResult)
+                        $null = $SuccessfulOps.Add($CmdletMetadata)
                     }
                 }
             }
@@ -237,6 +240,7 @@ function Invoke-ExecModifyMBPerms {
                 try {
                     $null = New-ExoRequest -Anchor $CmdletMetadata.Mailbox -tenantid $TenantFilter -cmdlet $CmdletObj.CmdletInput.CmdletName -cmdParams $CmdletObj.CmdletInput.Parameters
                     $null = $Results.Add($CmdletMetadata.ExpectedResult)
+                    $null = $SuccessfulOps.Add($CmdletMetadata)
                 } catch {
                     $null = $Results.Add("Error processing $($CmdletMetadata.Permission) for $($CmdletMetadata.TargetUser) on $($CmdletMetadata.Mailbox): $($_.Exception.Message)")
                 }
@@ -249,10 +253,24 @@ function Invoke-ExecModifyMBPerms {
         try {
             $null = New-ExoRequest -Anchor $CmdletMetadata.Mailbox -tenantid $TenantFilter -cmdlet $CmdletObj.CmdletInput.CmdletName -cmdParams $CmdletObj.CmdletInput.Parameters
             $null = $Results.Add($CmdletMetadata.ExpectedResult)
+            $null = $SuccessfulOps.Add($CmdletMetadata)
             Write-LogMessage -headers $Headers -API $APIName -message "Executed $($CmdletMetadata.Permission) permission modification" -Sev 'Info' -tenant $TenantFilter
         } catch {
             Write-LogMessage -headers $Headers -API $APIName -message "Permission modification failed: $($_.Exception.Message)" -Sev 'Error' -tenant $TenantFilter
             $null = $Results.Add("Error processing $($CmdletMetadata.Permission) for $($CmdletMetadata.TargetUser) on $($CmdletMetadata.Mailbox): $($_.Exception.Message)")
+        }
+    }
+
+    # Keep the reporting DB cache in step with what actually changed. The bulk path bypasses
+    # Set-CIPPMailboxPermission's own execute-mode sync (-AsCmdletObject returns early), so
+    # without this the cached permission report goes stale after every bulk change.
+    foreach ($Op in $SuccessfulOps) {
+        if ($Op.Permission -in @('FullAccess', 'SendAs', 'SendOnBehalf')) {
+            try {
+                Sync-CIPPMailboxPermissionCache -TenantFilter $TenantFilter -MailboxIdentity $Op.Mailbox -User $Op.TargetUser -PermissionType $Op.Permission -Action $Op.Action
+            } catch {
+                Write-Information "Cache sync warning: $($_.Exception.Message)"
+            }
         }
     }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyMBPerms.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ExecModifyMBPerms.ps1
@@ -151,9 +151,11 @@ function Invoke-ExecModifyMBPerms {
                             OperationGuid = $OperationGuid  # Add GUID to cmdlet object
                         }
 
+                        # Use the resolved UPN, not the raw request identifier (which may be an
+                        # object id) - the cache sync below matches cached rows by mailbox UPN.
                         $CmdletMetadata = [PSCustomObject]@{
                             ExpectedResult = $Mapping.ExpectedResult
-                            Mailbox        = $Username
+                            Mailbox        = $UserId
                             TargetUser     = $TargetUser
                             Permission     = $PermissionLevel
                             Action         = $Action

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListmailboxPermissions.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListmailboxPermissions.ps1
@@ -29,7 +29,9 @@ function Invoke-ListmailboxPermissions {
             }
             try {
                 $GraphRequest = Get-CIPPMailboxPermissionReport @ReportParams
-                if ($User) {
+                if ($User -and $ByUser -eq 'true') {
+                    # Only the user-grouped report has a top-level User property; in the
+                    # mailbox-grouped shape this filter would empty the whole result set.
                     $GraphRequest = @($GraphRequest | Where-Object { $_.User -eq $User })
                 }
                 $StatusCode = [HttpStatusCode]::OK

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListmailboxPermissions.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListmailboxPermissions.ps1
@@ -14,6 +14,7 @@ function Invoke-ListmailboxPermissions {
     $UserID = $Request.Query.userId
     $UseReportDB = $Request.Query.UseReportDB
     $ByUser = $Request.Query.ByUser
+    $User = $Request.Query.User
 
     try {
         # If UseReportDB is specified and no specific UserID, retrieve from report database
@@ -28,6 +29,9 @@ function Invoke-ListmailboxPermissions {
             }
             try {
                 $GraphRequest = Get-CIPPMailboxPermissionReport @ReportParams
+                if ($User) {
+                    $GraphRequest = @($GraphRequest | Where-Object { $_.User -eq $User })
+                }
                 $StatusCode = [HttpStatusCode]::OK
             } catch {
                 $StatusCode = [HttpStatusCode]::InternalServerError

--- a/Tests/Endpoint/Invoke-ExecModifyMBPerms.Tests.ps1
+++ b/Tests/Endpoint/Invoke-ExecModifyMBPerms.Tests.ps1
@@ -263,6 +263,18 @@ Describe 'Invoke-ExecModifyMBPerms' {
             }
         }
 
+        It 'syncs with the resolved UPN when the request identifies the mailbox by object id' {
+            # Cached permission rows are keyed by mailbox UPN, so the sync must use what the
+            # Graph lookup resolved (BeforeEach mock: shared@contoso.com), not the raw request id.
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -UserID '11111111-2222-3333-4444-555555555555' -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Remove'))
+
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter {
+                $MailboxIdentity -eq 'shared@contoso.com'
+            }
+        }
+
         It 'syncs with Action Add for additions' {
             $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'SendAs' -Modification 'Add'))
 

--- a/Tests/Endpoint/Invoke-ExecModifyMBPerms.Tests.ps1
+++ b/Tests/Endpoint/Invoke-ExecModifyMBPerms.Tests.ps1
@@ -34,6 +34,7 @@ BeforeAll {
     function New-ExoBulkRequest { param($tenantid, $cmdletArray, $ReturnWithCommand) }
     function Get-CippException { param($Exception) }
     function Write-LogMessage { param($headers, $API, $tenant, $message, $Sev, $LogData) }
+    function Sync-CIPPMailboxPermissionCache { param($TenantFilter, $MailboxIdentity, $User, $PermissionType, $Action) }
 
     . $PermissionFunctionPath
     . $FunctionPath
@@ -82,6 +83,7 @@ Describe 'Invoke-ExecModifyMBPerms' {
         }
         Mock -CommandName Get-CippException -MockWith { [pscustomobject]@{ NormalizedError = 'boom' } }
         Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Sync-CIPPMailboxPermissionCache -MockWith { }
     }
 
     Context 'Single-operation execution and per-level mapping' {
@@ -244,6 +246,82 @@ Describe 'Invoke-ExecModifyMBPerms' {
             $response = Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
 
             ($response.Body.Results -join "`n") | Should -Match 'Could not find user ghost@contoso.com'
+        }
+    }
+
+    Context 'Cache sync' {
+        # The endpoint executes cmdlets itself (bypassing Set-CIPPMailboxPermission's execute-mode
+        # sync), so it must sync the reporting-DB cache for every operation that succeeded.
+        It 'syncs the cache after a successful single Remove' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'FullAccess' -Modification 'Remove'))
+
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter {
+                $TenantFilter -eq 'contoso.com' -and $MailboxIdentity -eq 'shared@contoso.com' -and
+                $User -eq 'user@contoso.com' -and $PermissionType -eq 'FullAccess' -and $Action -eq 'Remove'
+            }
+        }
+
+        It 'syncs with Action Add for additions' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'SendAs' -Modification 'Add'))
+
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter {
+                $PermissionType -eq 'SendAs' -and $Action -eq 'Add'
+            }
+        }
+
+        It 'syncs every successful operation in a bulk request' {
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(
+                (New-Perm -Level 'FullAccess' -Modification 'Remove')
+                (New-Perm -Level 'SendOnBehalf' -Modification 'Remove')
+            ))
+
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter { $PermissionType -eq 'FullAccess' }
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter { $PermissionType -eq 'SendOnBehalf' }
+        }
+
+        It 'does not sync operations that failed in the bulk response' {
+            # FullAccess Remove (Remove-MailboxPermission) succeeds; SendAs Remove
+            # (Remove-RecipientPermission) comes back with an error attached.
+            Mock -CommandName New-ExoBulkRequest -MockWith {
+                param($tenantid, $cmdletArray, $ReturnWithCommand)
+                $h = @{}
+                foreach ($c in $cmdletArray) {
+                    $name = $c.CmdletInput.CmdletName
+                    if (-not $h.ContainsKey($name)) { $h[$name] = @() }
+                    $entry = [pscustomobject]@{ OperationGuid = $c.OperationGuid }
+                    if ($name -eq 'Remove-RecipientPermission') {
+                        $entry | Add-Member -NotePropertyName error -NotePropertyValue 'denied'
+                    }
+                    $h[$name] += $entry
+                }
+                $h
+            }
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(
+                (New-Perm -Level 'FullAccess' -Modification 'Remove')
+                (New-Perm -Level 'SendAs' -Modification 'Remove')
+            ))
+
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter { $PermissionType -eq 'FullAccess' }
+        }
+
+        It 'does not sync non-cacheable permission levels' {
+            # Comma-joined levels are split per operation; ReadPermission executes but has no
+            # cache representation, so only the FullAccess half syncs.
+            $req = New-ModifyRequest -Mailboxes @(New-Mailbox -Permissions @(New-Perm -Level 'FullAccess, ReadPermission' -Modification 'Remove'))
+
+            Invoke-ExecModifyMBPerms -Request $req -TriggerMetadata $null
+
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly
+            Should -Invoke Sync-CIPPMailboxPermissionCache -Times 1 -Exactly -ParameterFilter { $PermissionType -eq 'FullAccess' }
         }
     }
 


### PR DESCRIPTION
## Summary

Companion to the CIPP frontend PR adding bulk mailbox-permission removal and a per-user "Mailbox Access" card.

- **`Invoke-ExecModifyMBPerms`**: sync the reporting-DB cache (`Sync-CIPPMailboxPermissionCache`) for every successful FullAccess/SendAs/SendOnBehalf operation. The endpoint executes cmdlets via `New-ExoBulkRequest`/`New-ExoRequest` built with `Set-CIPPMailboxPermission -AsCmdletObject`, which returns before its own execute-mode sync — so every change through this endpoint left the cached permission report stale. The sync uses the Graph-resolved UPN (cache rows are keyed by mailbox UPN), and failed operations are not synced.
- **`Invoke-ListmailboxPermissions`**: optional `User` query filter on the `UseReportDB` + `ByUser=true` path, so the frontend can fetch one user's mailbox access without downloading the whole tenant report. The filter is gated on `ByUser=true` because the mailbox-grouped shape has no top-level `User` property.

## Tests

`Tests/Endpoint/Invoke-ExecModifyMBPerms.Tests.ps1`: 25 Pester tests covering per-level cmdlet mapping, bulk/individual/fallback execution paths, user lookup fallbacks, input shapes, guards, and the new cache-sync behaviour (syncs on success with resolved UPN, skips failures and non-cacheable levels). All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)