### PR TITLE
feat: add email aliases and hide-from-GAL to group templates

### DIFF
--- a/Modules/CIPPCore/Public/New-CIPPGroup.ps1
+++ b/Modules/CIPPCore/Public/New-CIPPGroup.ps1
@@ -275,6 +275,18 @@ function New-CIPPGroup {
                 }
 
                 $GraphRequest = New-ExoRequest -tenantid $TenantFilter -cmdlet 'New-DistributionGroup' -cmdParams $ExoParams
+
+                $Aliases = @($GroupObject.aliases -split '\r?\n' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+                $SetParams = @{ Identity = $GraphRequest.Identity }
+                if ($GroupObject.hideFromGAL) {
+                    $SetParams.HiddenFromAddressListsEnabled = $true
+                }
+                if ($Aliases.Count -gt 0) {
+                    $SetParams.EmailAddresses = @{ '@odata.type' = '#Exchange.GenericHashTable'; Add = @($Aliases | ForEach-Object { "smtp:$_" }) }
+                }
+                if ($SetParams.Keys.Count -gt 1) {
+                    $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Set-DistributionGroup' -cmdParams $SetParams
+                }
             }
 
             $Result = [PSCustomObject]@{

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-AddGroupTemplate.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-AddGroupTemplate.ps1
@@ -53,6 +53,8 @@ function Invoke-AddGroupTemplate {
             allowExternal   = $Request.Body.allowExternal
             username        = $Request.Body.username  # Can contain variables like @%tenantfilter%
             licenses        = $Request.Body.licenses
+            aliases         = $Request.Body.aliases # One per line, variables allowed
+            hideFromGAL     = $Request.Body.hideFromGAL
             GUID            = $GUID
         } | ConvertTo-Json -Depth 10
         $Table = Get-CippTable -tablename 'templates'

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroupTemplates.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroupTemplates.ps1
@@ -48,6 +48,8 @@ function Invoke-ListGroupTemplates {
                 allowExternal   = $data.allowExternal
                 username        = $data.username
                 licenses        = $data.licenses
+                aliases         = $data.aliases
+                hideFromGAL     = $data.hideFromGAL
                 GUID            = $_.RowKey
                 source          = $_.Source
                 isSynced        = (![string]::IsNullOrEmpty($_.SHA))


### PR DESCRIPTION
- Implements KelvinTegelaar/CIPP#6248
- Group Templates for Distribution Lists and mail enabled security groups can now define **email aliases with variables** and **hide from GAL** option