### PR TITLE
Fix: Added more properties to CVE management, improved efficiency

### DIFF
--- a/Modules/CIPPCore/Public/Get-CIPPCVEReport.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPCVEReport.ps1
@@ -84,9 +84,12 @@ function Get-CIPPCVEReport {
                     softwareName               = $Item.softwareName
                     softwareVendor             = $Item.softwareVendor
                     softwareVersion            = $Item.softwareVersion
+                    lastUpdated                = $Item.lastUpdated
                     TotalDeviceCount           = 0
                     AffectedTenantsList        = [System.Collections.Generic.List[object]]::new()
                     AffectedDevicesList        = [System.Collections.Generic.List[object]]::new()
+                    DiskPathList               = [System.Collections.Generic.List[object]]::new()
+                    RegistryPathList           = [System.Collections.Generic.List[object]]::new()
                     ExceptionMatchCount        = 0
                     TotalTenantGroupCount      = 0
                     ExceptionSources           = [System.Collections.Generic.HashSet[string]]::new()
@@ -102,9 +105,13 @@ function Get-CIPPCVEReport {
             if ($Item.deviceDetailsJson) {
                 $Devices = ConvertFrom-Json $Item.deviceDetailsJson | Sort-Object -Property deviceName -Unique
                 foreach ($Dev in $Devices) {
-                    [void]$CveGroup.AffectedDevicesList.Add(@{ deviceName = $Dev.deviceName })
-                    $CveGroup.TotalDeviceCount ++
-                    }
+                        [void]$CveGroup.AffectedDevicesList.Add(@{ deviceName    = $Dev.deviceName })
+                        if($Dev.registryPaths){[void]$CveGroup.RegistryPathList.Add(@{ deviceName = $Dev.deviceName
+                                                                                       registryPaths = $Dev.registryPaths })}
+                        if($Dev.diskPaths){[void]$CveGroup.DiskPathList.Add(@{ deviceName = $Dev.deviceName
+                                                                               diskPaths = $Dev.diskPaths })}
+                        $CveGroup.TotalDeviceCount ++
+                }
             }
         }
 
@@ -116,11 +123,34 @@ function Get-CIPPCVEReport {
             $ExceptionStatus = 'None'
             $HasException = $false
             $Exceptions = @{}
+            $ExceptionType = ''
+            $ExceptionComment = ''
+            $ExceptionCreatedBy = ''
+            $ExceptionDate = ''
+            $ExceptionExpiry = ''
 
             if ($ExceptionsByCve.ContainsKey($CveKey)){
                 $Exceptions         = @($ExceptionsByCve[$CveKey])
                 $HasException       = $true
                 $ExceptionStatus    = if ($Exceptions.customerId -contains "ALL") { "All" } else { "Partial" }
+            }
+            
+            if ($HasException){
+                $ExceptionType = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $Exceptions.customerId
+                                                    exceptionType = $Exceptions.exceptionType }}
+                $ExceptionComment = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $_.customerId
+                                                    exceptionComment = $_.exceptionComment } }
+                $ExceptionCreatedBy = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $_.customerId
+                                                    exceptionCreatedBy = $_.exceptionCreatedBy } }
+                $ExceptionDate = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $_.customerId
+                                                    exceptionDate = $_.exceptionDate } }
+                $ExceptionExpiry = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $_.customerId
+                                                    exceptionExpiry = $_.exceptionExpiry } }
             }
 
             [void]$SortedCves.Add([PSCustomObject]@{
@@ -132,25 +162,17 @@ function Get-CIPPCVEReport {
                 softwareVersion            = $Target.softwareVersion
                 deviceCount                = $Target.TotalDeviceCount
                 tenantCount                = $Target.TotalTenantGroupCount
+                registryPaths              = $Target.RegistryPathList
+                diskPaths                  = $Target.DiskPathList
                 exceptionStatus            = $ExceptionStatus
                 hasException               = $HasException
                 affectedTenants            = $Target.AffectedTenantsList
                 affectedDevices            = $Target.AffectedDevicesList
-                exceptionType              = if ($HasException){$Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionType = $_.exceptionType } } }else{''}
-                exceptionComment           = if ($HasException){$Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionComment = $_.exceptionComment } } }else{''}
-                exceptionCreatedBy         = if ($HasException){$Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionCreatedBy = $_.exceptionCreatedBy } } }else{''}
-                exceptionDate              = if ($HasException){$Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionDate = $_.exceptionDate } } }else{''}
-                exceptionExpiry            = if ($HasException){$Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionExpiry = $_.exceptionExpiry } } }else{''}
+                exceptionType              = $ExceptionType
+                exceptionComment           = $ExceptionComment
+                exceptionCreatedBy         = $ExceptionCreatedBy
+                exceptionDate              = $ExceptionDate
+                exceptionExpiry            = $ExceptionExpiry
                 cacheTimeStamp             = $Target.lastUpdated
             })
         }

--- a/Modules/CIPPCore/Public/Get-CIPPCVEReport.ps1
+++ b/Modules/CIPPCore/Public/Get-CIPPCVEReport.ps1
@@ -133,24 +133,16 @@ function Get-CIPPCVEReport {
                 $Exceptions         = @($ExceptionsByCve[$CveKey])
                 $HasException       = $true
                 $ExceptionStatus    = if ($Exceptions.customerId -contains "ALL") { "All" } else { "Partial" }
-            }
-            
-            if ($HasException){
-                $ExceptionType = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $Exceptions.customerId
-                                                    exceptionType = $Exceptions.exceptionType }}
-                $ExceptionComment = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionComment = $_.exceptionComment } }
-                $ExceptionCreatedBy = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionCreatedBy = $_.exceptionCreatedBy } }
-                $ExceptionDate = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionDate = $_.exceptionDate } }
-                $ExceptionExpiry = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionExpiry = $_.exceptionExpiry } }
+                $ExceptionType      = @{ customerId = $Exceptions.customerId
+                                        exceptionType = $Exceptions.exceptionType }
+                $ExceptionComment   = @{ customerId = $Exceptions.customerId
+                                        exceptionComment = $Exceptions.exceptionComment }
+                $ExceptionCreatedBy = @{ customerId = $Exceptions.customerId
+                                        exceptionCreatedBy = $Exceptions.exceptionCreatedBy }
+                $ExceptionDate      = @{ customerId = $Exceptions.customerId
+                                        exceptionDate = $Exceptions.exceptionDate }
+                $ExceptionExpiry    = @{ customerId = $Exceptions.customerId
+                                        exceptionExpiry = $Exceptions.exceptionExpiry }
             }
 
             [void]$SortedCves.Add([PSCustomObject]@{

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListCVEManagement.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListCVEManagement.ps1
@@ -126,24 +126,16 @@ function Invoke-ListCVEManagement {
                     $Exceptions         = @($ExceptionsByCve[$CveKey])
                     $HasException       = $true
                     $ExceptionStatus    = if ($Exceptions.customerId -contains "ALL") { "All" } else { "Partial" }
-                }
-
-                if ($HasException){
-                $ExceptionType = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $Exceptions.customerId
-                                                    exceptionType = $Exceptions.exceptionType }}
-                $ExceptionComment = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionComment = $_.exceptionComment } }
-                $ExceptionCreatedBy = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionCreatedBy = $_.exceptionCreatedBy } }
-                $ExceptionDate = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionDate = $_.exceptionDate } }
-                $ExceptionExpiry = $Exceptions | ForEach-Object {
-                                                    @{ customerId = $_.customerId
-                                                    exceptionExpiry = $_.exceptionExpiry } }
+                    $ExceptionType      = @{ customerId = $Exceptions.customerId
+                                            exceptionType = $Exceptions.exceptionType }
+                    $ExceptionComment   = @{ customerId = $Exceptions.customerId
+                                            exceptionComment = $Exceptions.exceptionComment }
+                    $ExceptionCreatedBy = @{ customerId = $Exceptions.customerId
+                                            exceptionCreatedBy = $Exceptions.exceptionCreatedBy }
+                    $ExceptionDate      = @{ customerId = $Exceptions.customerId
+                                            exceptionDate = $Exceptions.exceptionDate }
+                    $ExceptionExpiry    = @{ customerId = $Exceptions.customerId
+                                            exceptionExpiry = $Exceptions.exceptionExpiry }
                 }
 
                 [void]$SortedCves.Add([PSCustomObject]@{

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListCVEManagement.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListCVEManagement.ps1
@@ -77,9 +77,12 @@ function Invoke-ListCVEManagement {
                         softwareName               = $Item.softwareName
                         softwareVendor             = $Item.softwareVendor
                         softwareVersion            = $Item.softwareVersion
+                        lastUpdated                = $Item.lastUpdated
                         TotalDeviceCount           = 0
                         AffectedTenantsList        = [System.Collections.Generic.List[object]]::new()
                         AffectedDevicesList        = [System.Collections.Generic.List[object]]::new()
+                        DiskPathList               = [System.Collections.Generic.List[object]]::new()
+                        RegistryPathList           = [System.Collections.Generic.List[object]]::new()
                         ExceptionMatchCount        = 0
                         TotalTenantGroupCount      = 0
                         ExceptionSources           = [System.Collections.Generic.HashSet[string]]::new()
@@ -95,9 +98,13 @@ function Invoke-ListCVEManagement {
                 if ($Item.deviceDetailsJson) {
                     $Devices = ConvertFrom-Json $Item.deviceDetailsJson | Sort-Object -Property deviceName -Unique
                     foreach ($Dev in $Devices) {
-                        [void]$CveGroup.AffectedDevicesList.Add(@{ deviceName = $Dev.deviceName })
+                        [void]$CveGroup.AffectedDevicesList.Add(@{ deviceName    = $Dev.deviceName })
+                        if($Dev.registryPaths){[void]$CveGroup.RegistryPathList.Add(@{ deviceName = $Dev.deviceName
+                                                                                       registryPaths = $Dev.registryPaths })}
+                        if($Dev.diskPaths){[void]$CveGroup.DiskPathList.Add(@{ deviceName = $Dev.deviceName
+                                                                               diskPaths = $Dev.diskPaths })}
                         $CveGroup.TotalDeviceCount ++
-                        }
+                    }
                 }
             }
 
@@ -109,6 +116,11 @@ function Invoke-ListCVEManagement {
                 $ExceptionStatus = 'None'
                 $HasException = $false
                 $Exceptions = @{}
+                $ExceptionType = ''
+                $ExceptionComment = ''
+                $ExceptionCreatedBy = ''
+                $ExceptionDate = ''
+                $ExceptionExpiry = ''
 
                 if ($ExceptionsByCve.ContainsKey($CveKey)){
                     $Exceptions         = @($ExceptionsByCve[$CveKey])
@@ -116,35 +128,45 @@ function Invoke-ListCVEManagement {
                     $ExceptionStatus    = if ($Exceptions.customerId -contains "ALL") { "All" } else { "Partial" }
                 }
 
+                if ($HasException){
+                $ExceptionType = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $Exceptions.customerId
+                                                    exceptionType = $Exceptions.exceptionType }}
+                $ExceptionComment = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $_.customerId
+                                                    exceptionComment = $_.exceptionComment } }
+                $ExceptionCreatedBy = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $_.customerId
+                                                    exceptionCreatedBy = $_.exceptionCreatedBy } }
+                $ExceptionDate = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $_.customerId
+                                                    exceptionDate = $_.exceptionDate } }
+                $ExceptionExpiry = $Exceptions | ForEach-Object {
+                                                    @{ customerId = $_.customerId
+                                                    exceptionExpiry = $_.exceptionExpiry } }
+                }
+
                 [void]$SortedCves.Add([PSCustomObject]@{
-                    cveId                      = $Target.cveId
-                    vulnerabilitySeverityLevel = $Target.vulnerabilitySeverityLevel
-                    exploitabilityLevel        = $Target.exploitabilityLevel
-                    softwareName               = $Target.softwareName
-                    softwareVendor             = $Target.softwareVendor
-                    softwareVersion            = $Target.softwareVersion
-                    deviceCount                = $Target.TotalDeviceCount
-                    tenantCount                = $Target.TotalTenantGroupCount
-                    exceptionStatus            = $ExceptionStatus
-                    hasException               = $HasException
-                    affectedTenants            = $Target.AffectedTenantsList
-                    affectedDevices            = $Target.AffectedDevicesList
-                    exceptionType              = if ($HasException){$Exceptions | ForEach-Object {
-                                                        @{ customerId = $_.customerId
-                                                        exceptionType = $_.exceptionType } } }else{''}
-                    exceptionComment           = if ($HasException){$Exceptions | ForEach-Object {
-                                                        @{ customerId = $_.customerId
-                                                        exceptionComment = $_.exceptionComment } } }else{''}
-                    exceptionCreatedBy         = if ($HasException){$Exceptions | ForEach-Object {
-                                                        @{ customerId = $_.customerId
-                                                        exceptionCreatedBy = $_.exceptionCreatedBy } } }else{''}
-                    exceptionDate              = if ($HasException){$Exceptions | ForEach-Object {
-                                                        @{ customerId = $_.customerId
-                                                        exceptionDate = $_.exceptionDate } } }else{''}
-                    exceptionExpiry            = if ($HasException){$Exceptions | ForEach-Object {
-                                                        @{ customerId = $_.customerId
-                                                        exceptionExpiry = $_.exceptionExpiry } } }else{''}
-                    cacheTimeStamp             = $Target.lastUpdated
+                cveId                      = $Target.cveId
+                vulnerabilitySeverityLevel = $Target.vulnerabilitySeverityLevel
+                exploitabilityLevel        = $Target.exploitabilityLevel
+                softwareName               = $Target.softwareName
+                softwareVendor             = $Target.softwareVendor
+                softwareVersion            = $Target.softwareVersion
+                deviceCount                = $Target.TotalDeviceCount
+                tenantCount                = $Target.TotalTenantGroupCount
+                registryPaths              = $Target.RegistryPathList
+                diskPaths                  = $Target.DiskPathList
+                exceptionStatus            = $ExceptionStatus
+                hasException               = $HasException
+                affectedTenants            = $Target.AffectedTenantsList
+                affectedDevices            = $Target.AffectedDevicesList
+                exceptionType              = $ExceptionType
+                exceptionComment           = $ExceptionComment
+                exceptionCreatedBy         = $ExceptionCreatedBy
+                exceptionDate              = $ExceptionDate
+                exceptionExpiry            = $ExceptionExpiry
+                cacheTimeStamp             = $Target.lastUpdated
                 })
                 $StatusCode = [HttpStatusCode]::OK
             }

--- a/Modules/CippExtensions/Public/NinjaOne/Invoke-NinjaOneTenantSync.ps1
+++ b/Modules/CippExtensions/Public/NinjaOne/Invoke-NinjaOneTenantSync.ps1
@@ -2197,70 +2197,68 @@ function Invoke-NinjaOneTenantSync {
                     $DeviceIdHeader      = $ResolvedScanGroup.deviceIdHeader
                     $CveIdHeader         = $ResolvedScanGroup.cveIdHeader
 
-                    if ([string]::IsNullOrWhiteSpace($DeviceIdHeader) -or [string]::IsNullOrWhiteSpace($CveIdHeader)) {
-                        Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync skipped — scan group missing required header config" -sev 'Warning'
+                    $RawVulns = Get-CIPPDbItem -TenantFilter $TenantFilter -Type 'DefenderCVEs' | Where-Object { $_.RowKey -ne 'DefenderCVEs-Count' }
+                    $AllVulns = $RawVulns.Data | ConvertFrom-Json
+                    $CsvRows  = [System.Collections.Generic.List[object]]::new()
+
+                    if (-not $AllVulns) {
+                        Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message 'CVE sync — no vulnerability data returned' -sev 'Warning'
+                        [void]$CsvRows.Add([PSCustomObject]@{
+                                    $DeviceIdHeader = ""
+                                    $CveIdHeader    = ""})
                     } else {
-                        $RawVulns = Get-CIPPDbItem -TenantFilter $TenantFilter -Type 'DefenderCVEs' | Where-Object { $_.RowKey -ne 'DefenderCVEs-Count' }
-                        $AllVulns = $RawVulns.Data | ConvertFrom-Json
+                        $ExceptionsTable      = Get-CIPPTable -TableName 'CveExceptions'
+                        $AllExceptions        = Get-CIPPAzDataTableEntity @ExceptionsTable
+                        $ApplicableExceptions = $AllExceptions | Where-Object { $_.RowKey -eq $TenantFilter -or $_.RowKey -eq 'ALL' }
 
-                        if (-not $AllVulns) {
-                            Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message 'CVE sync — no vulnerability data returned' -sev 'Warning'
-                        } else {
-                            $ExceptionsTable      = Get-CIPPTable -TableName 'CveExceptions'
-                            $AllExceptions        = Get-CIPPAzDataTableEntity @ExceptionsTable
-                            $ApplicableExceptions = $AllExceptions | Where-Object { $_.RowKey -eq $TenantFilter -or $_.RowKey -eq 'ALL' }
+                        if ($ApplicableExceptions) {
+                            $ExceptedCveIds = $ApplicableExceptions | Select-Object -ExpandProperty cveId -Unique
+                            $BeforeCount    = $AllVulns.Count
+                            $AllVulns       = $AllVulns | Where-Object { $_.cveId -notin $ExceptedCveIds }
+                            Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync — filtered $($BeforeCount - $AllVulns.Count) excepted CVEs, $($AllVulns.Count) remaining" -sev 'Info'
+                        }
 
-                            if ($ApplicableExceptions) {
-                                $ExceptedCveIds = $ApplicableExceptions | Select-Object -ExpandProperty cveId -Unique
-                                $BeforeCount    = $AllVulns.Count
-                                $AllVulns       = $AllVulns | Where-Object { $_.cveId -notin $ExceptedCveIds }
-                                Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync — filtered $($BeforeCount - $AllVulns.Count) excepted CVEs, $($AllVulns.Count) remaining" -sev 'Info'
+                        $SkippedCount = 0
+
+                        foreach ($Item in $AllVulns) {
+                            if ([string]::IsNullOrWhiteSpace($Item.cveId)) {
+                                $SkippedCount++
+                                continue
                             }
-
-                            $CsvRows      = [System.Collections.Generic.List[object]]::new()
-                            $SkippedCount = 0
-
-                            foreach ($Item in $AllVulns) {
-                                if ([string]::IsNullOrWhiteSpace($Item.cveId)) {
-                                    $SkippedCount++
-                                    continue
+                            if ($Item.deviceDetailsJson) {
+                                $Devices = ConvertFrom-Json $Item.deviceDetailsJson | Sort-Object -Property deviceName -Unique
+                                foreach ($Dev in $Devices) {
+                                    [void]$CsvRows.Add([PSCustomObject]@{
+                                    $DeviceIdHeader = $Dev.deviceName.Trim()
+                                    $CveIdHeader    = $Item.cveId.Trim()
+                                    })
                                 }
-                                if ($Item.deviceDetailsJson) {
-                                    $Devices = ConvertFrom-Json $Item.deviceDetailsJson | Sort-Object -Property deviceName -Unique
-                                    foreach ($Dev in $Devices) {
-                                        [void]$CsvRows.Add([PSCustomObject]@{
-                                        $DeviceIdHeader = $Dev.deviceName.Trim()
-                                        $CveIdHeader    = $Item.cveId.Trim()
-                                        })
-                                    }
-                                }
-                            }
-
-                            if ($SkippedCount -gt 0) {
-                                Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync — skipped $SkippedCount rows (missing deviceName or cveId)" -sev 'Warning'
-                            }
-
-                            $CsvBytes = New-VulnCsvBytes -Rows $CsvRows -Headers @($DeviceIdHeader, $CveIdHeader)
-
-                            if ($CsvBytes -and $CsvBytes.Length -gt 0) {
-                                $UploadUri = "$NinjaBaseUrl/vulnerability/scan-groups/$ResolvedScanGroupId/upload"
-                                $PollUri   = "$NinjaBaseUrl/vulnerability/scan-groups/$ResolvedScanGroupId"
-                                $CveResp   = Invoke-NinjaOneVulnCsvUpload -Uri $UploadUri -PollUri $PollUri -CsvBytes $CsvBytes -Headers @{ Authorization = "Bearer $($Token.access_token)" }
-
-                                $FinalStatus    = $CveResp.status ?? 'unknown'
-                                $ProcessedCount = $CveResp.recordsProcessed ?? '?'
-
-                                if ($FinalStatus -eq 'COMPLETE') {
-                                    Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync complete — $($CsvRows.Count) CVEs sent to '$ScanGroupName', $ProcessedCount processed" -sev 'Info'
-                                } elseif ($FinalStatus -eq 'IN_PROGRESS') {
-                                    Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync upload accepted — $($CsvRows.Count) CVEs sent to '$ScanGroupName', still processing (timed out polling)" -sev 'Warning'
-                                } else {
-                                    Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync finished with status '$FinalStatus' for '$ScanGroupName', $ProcessedCount processed" -sev 'Warning'
-                                }
-                            } else {
-                                Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message 'CVE sync — failed to generate CSV bytes' -sev 'Warning'
                             }
                         }
+
+                        if ($SkippedCount -gt 0) {
+                            Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync — skipped $SkippedCount rows (missing deviceName or cveId)" -sev 'Warning'
+                        }
+                    }
+                    $CsvBytes = New-VulnCsvBytes -TenantFilter $TenantFilter -Rows $CsvRows -Headers @($DeviceIdHeader, $CveIdHeader)
+
+                    if ($CsvBytes -and $CsvBytes.Length -gt 0) {
+                        $UploadUri = "$NinjaBaseUrl/vulnerability/scan-groups/$ResolvedScanGroupId/upload"
+                        $PollUri   = "$NinjaBaseUrl/vulnerability/scan-groups/$ResolvedScanGroupId"
+                        $CveResp   = Invoke-NinjaOneVulnCsvUpload -Uri $UploadUri -PollUri $PollUri -CsvBytes $CsvBytes -Headers @{ Authorization = "Bearer $($Token.access_token)" }
+
+                        $FinalStatus    = $CveResp.status ?? 'unknown'
+                        $ProcessedCount = $CveResp.recordsProcessed ?? '?'
+
+                        if ($FinalStatus -eq 'COMPLETE') {
+                            Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync complete — $($CsvRows.Count) CVEs sent to '$ScanGroupName', $ProcessedCount processed" -sev 'Info'
+                        } elseif ($FinalStatus -eq 'IN_PROGRESS') {
+                            Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync upload accepted — $($CsvRows.Count) CVEs sent to '$ScanGroupName', still processing (timed out polling)" -sev 'Warning'
+                        } else {
+                            Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message "CVE sync finished with status '$FinalStatus' for '$ScanGroupName', $ProcessedCount processed" -sev 'Warning'
+                        }
+                    } else {
+                        Write-LogMessage -API 'NinjaOneSync' -tenant $TenantFilter -message 'CVE sync — failed to generate CSV bytes' -sev 'Warning'
                     }
                 }
             } catch {


### PR DESCRIPTION
Added more properties sent to the CVE management window
Improved efficiency of compiling exceptions, which can cause it to crash when there are too many
Adjusted the Ninja sync to send over empty CVE listings to ensure they are wiped from Ninja in the event they are all cleaned up