### PR TITLE
feat(alerts): auto-resolve cleared alerts + ExecResolveAlert endpoint

### DIFF
--- a/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-ExecScheduledCommand.ps1
+++ b/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-ExecScheduledCommand.ps1
@@ -182,6 +182,7 @@ function Push-ExecScheduledCommand {
     }
 
     $Function = $Command
+    $CommandStartTime = [int64](([datetime]::UtcNow) - (Get-Date '1/1/1970')).TotalSeconds
 
     try {
         $PossibleParams = $Function.Parameters.Keys
@@ -284,6 +285,24 @@ function Push-ExecScheduledCommand {
         Write-Information "Results: $($results | ConvertTo-Json -Depth 10)"
         if ($item.command -like 'Get-CIPPAlert*') {
             Write-Information 'This is an alert task. Processing results as alerts.'
+            if ($State -ne 'Failed') {
+                # Output only carries CHANGED data (unchanged conditions stay silent so
+                # notifications don't repeat), so it can't signal "condition cleared".
+                # Write-AlertTrace instead stamps LastSeen on every run with active items;
+                # no trace row stamped during this run means the condition no longer holds
+                # (or every item is snoozed) - clear the stored state so the alert resolves
+                # on the dashboard instead of lingering forever. Use the resolved command
+                # name: rows are keyed by the function's defined name and table filters
+                # are case-sensitive.
+                $AlertTable = Get-CIPPTable -tablename 'AlertLastRun'
+                $TraceRows = Get-CIPPAzDataTableEntity @AlertTable -Filter "RowKey eq '$Tenant-$($Command.Name)'"
+                $StillActive = @($TraceRows | Where-Object {
+                        -not [string]::IsNullOrWhiteSpace($_.LogData) -and [int64]($_.LastSeen ?? 0) -ge $CommandStartTime
+                    })
+                if ($StillActive.Count -eq 0) {
+                    Clear-AlertTrace -CmdletName $Command.Name -TenantFilter $Tenant
+                }
+            }
             $results = @($results)
             $TaskType = 'Alert'
         } else {

--- a/Modules/CIPPCore/Public/GraphHelper/Clear-AlertTrace.ps1
+++ b/Modules/CIPPCore/Public/GraphHelper/Clear-AlertTrace.ps1
@@ -1,0 +1,21 @@
+function Clear-AlertTrace {
+    <#
+    .FUNCTIONALITY
+    Internal function. Removes the stored AlertLastRun state for an alert so a resolved alert stops showing as active.
+    #>
+    param(
+        $CmdletName,
+        $TenantFilter
+    )
+    $Table = Get-CIPPTable -tablename AlertLastRun
+    # Delete every partition for this alert, not just today's: date-partitioned rows from
+    # earlier runs and the fixed partitions (BreachAlert, SecureScore) all key on this RowKey.
+    # Only rows carrying LogData are trace rows - Get-CIPPAlertCheckExtension keeps its
+    # last-run watermark in this table under the same RowKey format, and that must survive.
+    $Rows = Get-CIPPAzDataTableEntity @Table -Filter "RowKey eq '$($TenantFilter)-$($CmdletName)'"
+    $TraceRows = @($Rows | Where-Object { -not [string]::IsNullOrWhiteSpace($_.LogData) })
+    if ($TraceRows.Count -gt 0) {
+        Remove-AzDataTableEntity -Force @Table -Entity $TraceRows | Out-Null
+        Write-Information "Cleared AlertLastRun state for cmdlet '$CmdletName' and tenant '$TenantFilter' ($($TraceRows.Count) row(s))."
+    }
+}

--- a/Modules/CIPPCore/Public/GraphHelper/Write-AlertTrace.ps1
+++ b/Modules/CIPPCore/Public/GraphHelper/Write-AlertTrace.ps1
@@ -18,39 +18,36 @@ function Write-AlertTrace {
     }
 
     $Table = Get-CIPPTable -tablename AlertLastRun
-    #Get current row and compare the $logData object. If it's the same, don't write it.
     $Row = Get-CIPPAzDataTableEntity @table -Filter "RowKey eq '$($tenantFilter)-$($cmdletName)' and PartitionKey eq '$PartitionKey'"
-    try {
-        $RowData = $Row.LogData
-        $Compare = Compare-Object $RowData (ConvertTo-Json -InputObject $data -Compress -Depth 10 | Out-String)
-        Write-Host "Comparing new alert data with existing data for cmdlet '$cmdletName' and tenant '$tenantFilter'. Differences: $Compare"
-        if ($Compare) {
-            $LogData = ConvertTo-Json -InputObject $data -Compress -Depth 10 | Out-String
-            $TableRow = @{
-                'PartitionKey' = $PartitionKey
-                'RowKey'       = "$($tenantFilter)-$($cmdletName)"
-                'CmdletName'   = "$cmdletName"
-                'Tenant'       = "$tenantFilter"
-                'LogData'      = [string]$LogData
-                'AlertComment' = [string]$AlertComment
-            }
-            $Table.Entity = $TableRow
-            Add-CIPPAzDataTableEntity @Table -Force | Out-Null
-            return $data
+    $LogData = ConvertTo-Json -InputObject $data -Compress -Depth 10 | Out-String
+    $Changed = $true
+    if ($Row) {
+        try {
+            $Changed = [bool](Compare-Object $Row.LogData $LogData)
+        } catch {
+            $Changed = $true
         }
-    } catch {
-        $LogData = ConvertTo-Json -InputObject $data -Compress -Depth 10 | Out-String
-        $TableRow = @{
-            'PartitionKey' = $PartitionKey
-            'RowKey'       = "$($tenantFilter)-$($cmdletName)"
-            'CmdletName'   = "$cmdletName"
-            'Tenant'       = "$tenantFilter"
-            'LogData'      = [string]$LogData
-            'AlertComment' = [string]$AlertComment
-        }
-        $Table.Entity = $TableRow
-        Add-CIPPAzDataTableEntity @Table -Force | Out-Null
-        return $data
+        Write-Host "Comparing new alert data with existing data for cmdlet '$cmdletName' and tenant '$tenantFilter'. Changed: $Changed"
     }
 
+    # Written on every run with active items: LastSeen tells the scheduler the alert is
+    # still firing even when the data is unchanged, so it can clear resolved alerts.
+    $TableRow = @{
+        'PartitionKey' = $PartitionKey
+        'RowKey'       = "$($tenantFilter)-$($cmdletName)"
+        'CmdletName'   = "$cmdletName"
+        'Tenant'       = "$tenantFilter"
+        'LogData'      = [string]$LogData
+        'AlertComment' = [string]$AlertComment
+        'LastSeen'     = [string][int64](([datetime]::UtcNow) - (Get-Date '1/1/1970')).TotalSeconds
+    }
+    $Table.Entity = $TableRow
+    Add-CIPPAzDataTableEntity @Table -Force | Out-Null
+
+    # Only changed data is returned: the caller's output drives notifications, and an
+    # unchanged persisting condition must not re-notify on every run (alerts can recur
+    # every 30 minutes, and the fixed-partition alerts keep one row across days).
+    if ($Changed) {
+        return $data
+    }
 }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ExecResolveAlert.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ExecResolveAlert.ps1
@@ -1,0 +1,93 @@
+function Invoke-ExecResolveAlert {
+    <#
+    .FUNCTIONALITY
+        Entrypoint,AnyTenant
+    .ROLE
+        CIPP.Alert.ReadWrite
+    .DESCRIPTION
+        Marks a fired alert item as resolved by removing it from the stored AlertLastRun
+        state, so it disappears from the dashboard immediately. Unlike a snooze this does
+        not suppress the alert: if the underlying condition still exists, the item fires
+        again on the alert's next scheduled run.
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+
+    try {
+        $CmdletName = $Request.Body.CmdletName
+        $TenantFilter = $Request.Body.TenantFilter
+        $AlertItem = $Request.Body.AlertItem
+
+        if ([string]::IsNullOrWhiteSpace($CmdletName) -or [string]::IsNullOrWhiteSpace($TenantFilter) -or $null -eq $AlertItem) {
+            return ([HttpResponseContext]@{
+                    StatusCode = [HttpStatusCode]::BadRequest
+                    Body       = @{ Results = 'CmdletName, TenantFilter, and AlertItem are required.' }
+                })
+        }
+
+        $HashResult = Get-AlertContentHash -AlertItem $AlertItem
+
+        $Table = Get-CIPPTable -tablename 'AlertLastRun'
+        # Remove the item from every partition for this alert, not just the latest:
+        # if the latest row is deleted, ListAlertResults falls back to an older-dated
+        # row, which would resurface the item. TenantFilter/CmdletName are caller
+        # input - escape them so a quote cannot widen the filter to foreign rows.
+        $SafeRowKey = ConvertTo-CIPPODataFilterValue -Value "$($TenantFilter)-$($CmdletName)" -Type String
+        $Rows = Get-CIPPAzDataTableEntity @Table -Filter "RowKey eq '$SafeRowKey'"
+
+        $Removed = 0
+        foreach ($Row in @($Rows)) {
+            if ([string]::IsNullOrWhiteSpace($Row.LogData)) { continue }
+            try {
+                $Items = @($Row.LogData | ConvertFrom-Json -ErrorAction Stop)
+            } catch {
+                continue
+            }
+
+            $Keep = @($Items | Where-Object { (Get-AlertContentHash -AlertItem $_).ContentHash -ne $HashResult.ContentHash })
+            if ($Keep.Count -eq $Items.Count) { continue }
+            $Removed += $Items.Count - $Keep.Count
+
+            if ($Keep.Count -eq 0) {
+                Remove-AzDataTableEntity -Force @Table -Entity $Row | Out-Null
+            } else {
+                $LogData = ConvertTo-Json -InputObject $Keep -Compress -Depth 10 | Out-String
+                $Entity = @{
+                    'PartitionKey' = $Row.PartitionKey
+                    'RowKey'       = $Row.RowKey
+                    'CmdletName'   = "$($Row.CmdletName)"
+                    'Tenant'       = "$($Row.Tenant)"
+                    'LogData'      = [string]$LogData
+                    'AlertComment' = [string]$Row.AlertComment
+                }
+                # Carry the LastSeen stamp over - dropping it would make the scheduler's
+                # post-run check read the surviving items as stale and clear them.
+                if ($Row.LastSeen) { $Entity.LastSeen = [string]$Row.LastSeen }
+                $Table.Entity = $Entity
+                Add-CIPPAzDataTableEntity @Table -Force | Out-Null
+            }
+        }
+
+        $Result = if ($Removed -gt 0) {
+            "Resolved alert: $($HashResult.ContentPreview)"
+        } else {
+            "Alert was already resolved: $($HashResult.ContentPreview)"
+        }
+        Write-LogMessage -headers $Headers -API $APIName -message $Result -Sev 'Info' -tenant $TenantFilter
+
+        return ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::OK
+                Body       = @{ Results = $Result }
+            })
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -headers $Headers -API $APIName -message "Failed to resolve alert: $($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter
+        return ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::InternalServerError
+                Body       = @{ Results = "Failed to resolve alert: $($ErrorMessage.NormalizedError)" }
+            })
+    }
+}

--- a/Tests/Endpoint/Invoke-ExecResolveAlert.Tests.ps1
+++ b/Tests/Endpoint/Invoke-ExecResolveAlert.Tests.ps1
@@ -1,0 +1,184 @@
+# Pester tests for Invoke-ExecResolveAlert
+
+BeforeAll {
+    # Resolve by name under Modules/ so the test survives the function moving between modules.
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-ExecResolveAlert.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Invoke-ExecResolveAlert.ps1 under Modules/' }
+
+    # Azure Functions binding types do not exist outside the Functions host - fake them.
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+    # The Functions host profile provides 'using namespace System.Net'; outside it the
+    # bare [HttpStatusCode] the function uses needs a type accelerator.
+    $Accelerators = [PowerShell].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+    if (-not $Accelerators::Get.ContainsKey('HttpStatusCode')) {
+        $Accelerators::Add('HttpStatusCode', [System.Net.HttpStatusCode])
+    }
+
+    # Stub every CIPP helper the function calls so Pester's Mock has a command to replace.
+    function Add-CIPPAzDataTableEntity { param($TableName, $Entity, [switch]$Force) }
+    function Get-CIPPAzDataTableEntity { param($TableName, $Filter) }
+    function Get-CippException { param($Exception) }
+    function Get-CIPPTable { param($tablename) }
+    function Remove-AzDataTableEntity { param($TableName, $Entity, [switch]$Force) }
+    function Write-LogMessage { param($headers, $API, $message, $Sev, $tenant) }
+
+    # Use the real hash and filter-escape helpers so the endpoint's matching and
+    # injection hardening stay faithful to production behaviour.
+    foreach ($HelperName in @('Get-AlertContentHash.ps1', 'ConvertTo-CIPPODataFilterValue.ps1')) {
+        $HelperPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter $HelperName -File -ErrorAction SilentlyContinue |
+            Select-Object -First 1 -ExpandProperty FullName
+        if (-not $HelperPath) { throw "Could not locate $HelperName under Modules/" }
+        . $HelperPath
+    }
+
+    . $FunctionPath
+
+    function New-ResolveRequest {
+        param($Body)
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'ExecResolveAlert' }
+            Headers = @{ Authorization = 'token' }
+            Body    = $Body
+        }
+    }
+
+    function New-AlertRow {
+        param($PartitionKey, $Items)
+        [pscustomobject]@{
+            PartitionKey = $PartitionKey
+            RowKey       = 'contoso.com-Get-CIPPAlertMFAAdmins'
+            CmdletName   = 'Get-CIPPAlertMFAAdmins'
+            Tenant       = 'contoso.com'
+            LogData      = (ConvertTo-Json -InputObject @($Items) -Compress -Depth 10 | Out-String)
+            AlertComment = ''
+        }
+    }
+}
+
+Describe 'Invoke-ExecResolveAlert' {
+    BeforeEach {
+        Mock -CommandName Get-CIPPTable -MockWith { @{ TableName = 'AlertLastRun' } }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { }
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith { }
+        Mock -CommandName Remove-AzDataTableEntity -MockWith { }
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Get-CippException -MockWith { @{ NormalizedError = $Exception.Exception.Message } }
+
+        $script:TargetItem = [pscustomobject]@{ UserPrincipalName = 'admin@contoso.com'; Message = 'MFA disabled' }
+        $script:OtherItem = [pscustomobject]@{ UserPrincipalName = 'other@contoso.com'; Message = 'MFA disabled' }
+        $script:ValidBody = [pscustomobject]@{
+            CmdletName   = 'Get-CIPPAlertMFAAdmins'
+            TenantFilter = 'contoso.com'
+            AlertItem    = $script:TargetItem
+        }
+    }
+
+    It 'removes the matching item and rewrites the row when other items remain' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            New-AlertRow -PartitionKey '20260716' -Items @($script:TargetItem, $script:OtherItem)
+        }
+
+        $response = Invoke-ExecResolveAlert -Request (New-ResolveRequest $script:ValidBody) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        $response.Body.Results | Should -Match '^Resolved alert'
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Filter -eq "RowKey eq 'contoso.com-Get-CIPPAlertMFAAdmins'"
+        }
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Entity.LogData -notmatch 'admin@contoso\.com' -and $Entity.LogData -match 'other@contoso\.com'
+        }
+        Should -Invoke Remove-AzDataTableEntity -Times 0 -Exactly
+    }
+
+    It 'deletes the row entirely when the last item is resolved' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            New-AlertRow -PartitionKey '20260716' -Items @($script:TargetItem)
+        }
+
+        $response = Invoke-ExecResolveAlert -Request (New-ResolveRequest $script:ValidBody) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        Should -Invoke Remove-AzDataTableEntity -Times 1 -Exactly
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 0 -Exactly
+    }
+
+    It 'removes the item from every partition so older rows cannot resurface it' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @(
+                New-AlertRow -PartitionKey '20260715' -Items @($script:TargetItem)
+                New-AlertRow -PartitionKey '20260716' -Items @($script:TargetItem)
+            )
+        }
+
+        $response = Invoke-ExecResolveAlert -Request (New-ResolveRequest $script:ValidBody) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        Should -Invoke Remove-AzDataTableEntity -Times 2 -Exactly
+    }
+
+    It 'returns OK with an already-resolved message when no stored item matches' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            New-AlertRow -PartitionKey '20260716' -Items @($script:OtherItem)
+        }
+
+        $response = Invoke-ExecResolveAlert -Request (New-ResolveRequest $script:ValidBody) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        $response.Body.Results | Should -Match 'already resolved'
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 0 -Exactly
+        Should -Invoke Remove-AzDataTableEntity -Times 0 -Exactly
+    }
+
+    It 'preserves the LastSeen stamp when rewriting a row' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            $Row = New-AlertRow -PartitionKey '20260716' -Items @($script:TargetItem, $script:OtherItem)
+            $Row | Add-Member -NotePropertyName LastSeen -NotePropertyValue '1784216400' -PassThru
+        }
+
+        $null = Invoke-ExecResolveAlert -Request (New-ResolveRequest $script:ValidBody) -TriggerMetadata $null
+
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Entity.LastSeen -eq '1784216400'
+        }
+    }
+
+    It 'escapes quotes in caller input so the filter cannot be widened' {
+        $Body = [pscustomobject]@{
+            CmdletName   = 'Get-CIPPAlertMFAAdmins'
+            TenantFilter = "x' or RowKey ge '"
+            AlertItem    = $script:TargetItem
+        }
+
+        $response = Invoke-ExecResolveAlert -Request (New-ResolveRequest $Body) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Filter -eq "RowKey eq 'x'' or RowKey ge ''-Get-CIPPAlertMFAAdmins'"
+        }
+    }
+
+    It 'returns BadRequest when a required field is missing' {
+        $Body = [pscustomobject]@{ CmdletName = ''; TenantFilter = 'contoso.com'; AlertItem = $script:TargetItem }
+
+        $response = Invoke-ExecResolveAlert -Request (New-ResolveRequest $Body) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
+        $response.Body.Results | Should -Match 'required'
+    }
+
+    It 'returns InternalServerError and logs when the table query throws' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { throw 'table unavailable' }
+
+        $response = Invoke-ExecResolveAlert -Request (New-ResolveRequest $script:ValidBody) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::InternalServerError)
+        $response.Body.Results | Should -Match 'Failed to resolve alert'
+        Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $Sev -eq 'Error' }
+    }
+}

--- a/Tests/Private/Clear-AlertTrace.Tests.ps1
+++ b/Tests/Private/Clear-AlertTrace.Tests.ps1
@@ -1,0 +1,65 @@
+# Pester tests for Clear-AlertTrace
+
+BeforeAll {
+    # Resolve by name under Modules/ so the test survives the function moving between modules.
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Clear-AlertTrace.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Clear-AlertTrace.ps1 under Modules/' }
+
+    # Stub every CIPP helper the function calls so Pester's Mock has a command to replace.
+    function Get-CIPPAzDataTableEntity { param($TableName, $Filter) }
+    function Get-CIPPTable { param($tablename) }
+    function Remove-AzDataTableEntity { param($TableName, $Entity, [switch]$Force) }
+
+    . $FunctionPath
+}
+
+Describe 'Clear-AlertTrace' {
+    BeforeEach {
+        Mock -CommandName Get-CIPPTable -MockWith { @{ TableName = 'AlertLastRun' } }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { }
+        Mock -CommandName Remove-AzDataTableEntity -MockWith { }
+    }
+
+    It 'deletes every AlertLastRun trace row for the tenant+cmdlet RowKey' {
+        $Rows = @(
+            [pscustomobject]@{ PartitionKey = '20260715'; RowKey = 'contoso.com-Get-CIPPAlertApnCertExpiry'; LogData = '[{"Message":"expiring"}]' }
+            [pscustomobject]@{ PartitionKey = '20260716'; RowKey = 'contoso.com-Get-CIPPAlertApnCertExpiry'; LogData = '[{"Message":"expiring"}]' }
+        )
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { $Rows }
+
+        Clear-AlertTrace -CmdletName 'Get-CIPPAlertApnCertExpiry' -TenantFilter 'contoso.com'
+
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Filter -eq "RowKey eq 'contoso.com-Get-CIPPAlertApnCertExpiry'"
+        }
+        Should -Invoke Remove-AzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            @($Entity).Count -eq 2 -and $Force -eq $true
+        }
+    }
+
+    It 'spares rows without LogData, like the CheckExtension last-run watermark' {
+        $Rows = @(
+            [pscustomobject]@{ PartitionKey = 'AlertLastRun'; RowKey = 'contoso.com-Get-CIPPAlertCheckExtension'; LastRunTime = '2026-07-16T00:00:00Z' }
+            [pscustomobject]@{ PartitionKey = '20260716'; RowKey = 'contoso.com-Get-CIPPAlertCheckExtension'; LogData = '[{"Message":"phish"}]' }
+        )
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { $Rows }
+
+        Clear-AlertTrace -CmdletName 'Get-CIPPAlertCheckExtension' -TenantFilter 'contoso.com'
+
+        Should -Invoke Remove-AzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            @($Entity).Count -eq 1 -and @($Entity)[0].PartitionKey -eq '20260716'
+        }
+    }
+
+    It 'does not call Remove-AzDataTableEntity when only non-trace rows exist' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            [pscustomobject]@{ PartitionKey = 'AlertLastRun'; RowKey = 'contoso.com-Get-CIPPAlertCheckExtension'; LastRunTime = '2026-07-16T00:00:00Z' }
+        }
+
+        Clear-AlertTrace -CmdletName 'Get-CIPPAlertCheckExtension' -TenantFilter 'contoso.com'
+
+        Should -Invoke Remove-AzDataTableEntity -Times 0 -Exactly
+    }
+}

--- a/Tests/Private/Write-AlertTrace.Tests.ps1
+++ b/Tests/Private/Write-AlertTrace.Tests.ps1
@@ -1,0 +1,79 @@
+# Pester tests for Write-AlertTrace
+
+BeforeAll {
+    # Resolve by name under Modules/ so the test survives the function moving between modules.
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Write-AlertTrace.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Write-AlertTrace.ps1 under Modules/' }
+
+    # Stub every CIPP helper the function calls so Pester's Mock has a command to replace.
+    function Add-CIPPAzDataTableEntity { param($TableName, $Entity, [switch]$Force) }
+    function Get-CIPPAzDataTableEntity { param($TableName, $Filter) }
+    function Get-CIPPTable { param($tablename) }
+    function Remove-SnoozedAlerts { param($Data, $CmdletName, $TenantFilter) }
+
+    . $FunctionPath
+}
+
+Describe 'Write-AlertTrace' {
+    BeforeEach {
+        Mock -CommandName Get-CIPPTable -MockWith { @{ TableName = 'AlertLastRun' } }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { }
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith { }
+        # Pass items through unfiltered (nothing snoozed) unless a test overrides this.
+        Mock -CommandName Remove-SnoozedAlerts -MockWith { $Data }
+
+        $script:AlertData = @([pscustomobject]@{ UserPrincipalName = 'admin@contoso.com'; Message = 'MFA disabled' })
+    }
+
+    It 'writes a new row and returns the data when no row exists for today' {
+        $Result = Write-AlertTrace -cmdletName 'Get-CIPPAlertMFAAdmins' -tenantFilter 'contoso.com' -data $script:AlertData
+
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Entity.RowKey -eq 'contoso.com-Get-CIPPAlertMFAAdmins' -and
+            $Entity.CmdletName -eq 'Get-CIPPAlertMFAAdmins' -and
+            -not [string]::IsNullOrWhiteSpace($Entity.LastSeen)
+        }
+        @($Result).Count | Should -Be 1
+        @($Result)[0].UserPrincipalName | Should -Be 'admin@contoso.com'
+    }
+
+    It 'writes a new row and returns the data when the stored data differs' {
+        $OldData = ConvertTo-Json -InputObject @([pscustomobject]@{ UserPrincipalName = 'other@contoso.com' }) -Compress -Depth 10 | Out-String
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            [pscustomobject]@{ RowKey = 'contoso.com-Get-CIPPAlertMFAAdmins'; LogData = $OldData }
+        }
+
+        $Result = Write-AlertTrace -cmdletName 'Get-CIPPAlertMFAAdmins' -tenantFilter 'contoso.com' -data $script:AlertData
+
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 1 -Exactly
+        @($Result)[0].UserPrincipalName | Should -Be 'admin@contoso.com'
+    }
+
+    It 'refreshes LastSeen but returns nothing when the stored data is unchanged' {
+        # Output drives notifications, so an unchanged persisting condition must stay
+        # silent; the LastSeen stamp is what tells the scheduler the alert still fires.
+        $StoredData = ConvertTo-Json -InputObject $script:AlertData -Compress -Depth 10 | Out-String
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            [pscustomobject]@{ RowKey = 'contoso.com-Get-CIPPAlertMFAAdmins'; LogData = $StoredData }
+        }
+
+        $Result = Write-AlertTrace -cmdletName 'Get-CIPPAlertMFAAdmins' -tenantFilter 'contoso.com' -data $script:AlertData
+
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            -not [string]::IsNullOrWhiteSpace($Entity.LastSeen)
+        }
+        $Result | Should -BeNullOrEmpty
+    }
+
+    It 'returns null and writes nothing when every item is snoozed' {
+        Mock -CommandName Remove-SnoozedAlerts -MockWith { @() }
+
+        $Result = Write-AlertTrace -cmdletName 'Get-CIPPAlertMFAAdmins' -tenantFilter 'contoso.com' -data $script:AlertData
+
+        $Result | Should -BeNullOrEmpty
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 0 -Exactly
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 0 -Exactly
+    }
+}


### PR DESCRIPTION
Companion frontend PR with the **full write-up** (problem, design, trade-offs, testing): KelvinTegelaar/CIPP#6372

In short:

- **Auto-resolve:** `Write-AlertTrace` stamps `LastSeen` on every run with active items (output/notification semantics unchanged); after a successful `Get-CIPPAlert*` run that stamped nothing, the scheduler clears the stored `AlertLastRun` state via the new `Clear-AlertTrace` helper, so alerts whose condition cleared stop lingering on the dashboard forever. Stale alerts self-heal on the next run; no migration.
- **Manual resolve:** new `Invoke-ExecResolveAlert` endpoint (`CIPP.Alert.ReadWrite`) removes a single fired item by content hash across all partitions — unlike snooze, a still-true condition re-fires on the next run.
- 12 new Pester tests, full suite green.
