### PR TITLE
Fix: app protection policy deletion by normalizing endpoint URLs

### DIFF
--- a/Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1
+++ b/Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1
@@ -19,6 +19,18 @@ function Set-CIPPAssignedPolicy {
         $AssignmentDirection
     )
 
+    # App protection policy lists expose the singular @odata.type as the URLName, but Graph
+    # needs the plural collection segment. Normalize the known types here.
+    $Type = switch ($Type) {
+        'androidManagedAppProtection' { 'androidManagedAppProtections' }
+        'iosManagedAppProtection' { 'iosManagedAppProtections' }
+        'windowsManagedAppProtection' { 'windowsManagedAppProtections' }
+        'mdmWindowsInformationProtectionPolicy' { 'mdmWindowsInformationProtectionPolicies' }
+        'windowsInformationProtectionPolicy' { 'windowsInformationProtectionPolicies' }
+        'targetedManagedAppConfiguration' { 'targetedManagedAppConfigurations' }
+        default { $Type }
+    }
+
     Write-Host "Assigning policy $PolicyId ($PlatformType/$Type) to $GroupName"
 
     try {

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-RemovePolicy.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-RemovePolicy.ps1
@@ -16,15 +16,23 @@ function Invoke-RemovePolicy {
     $TenantFilter = $Request.Query.tenantFilter ?? $Request.body.tenantFilter
     $PolicyId = $Request.Query.ID ?? $Request.body.ID
     $UrlName = $Request.Query.URLName ?? $Request.body.URLName
-    $BaseEndpoint = switch ($UrlName) {
-        'managedAppPolicies' { 'deviceAppManagement' }
-        'mobileAppConfigurations' { 'deviceAppManagement' }
-        default { 'deviceManagement' }
+    # App protection policy lists expose the singular @odata.type as the URLName, but a Graph
+    # DELETE needs the plural collection segment under deviceAppManagement. Normalize here.
+    $GraphPath = switch ($UrlName) {
+        'androidManagedAppProtection' { 'deviceAppManagement/androidManagedAppProtections' }
+        'iosManagedAppProtection' { 'deviceAppManagement/iosManagedAppProtections' }
+        'windowsManagedAppProtection' { 'deviceAppManagement/windowsManagedAppProtections' }
+        'mdmWindowsInformationProtectionPolicy' { 'deviceAppManagement/mdmWindowsInformationProtectionPolicies' }
+        'windowsInformationProtectionPolicy' { 'deviceAppManagement/windowsInformationProtectionPolicies' }
+        'targetedManagedAppConfiguration' { 'deviceAppManagement/targetedManagedAppConfigurations' }
+        'managedAppPolicies' { 'deviceAppManagement/managedAppPolicies' }
+        'mobileAppConfigurations' { 'deviceAppManagement/mobileAppConfigurations' }
+        default { "deviceManagement/$UrlName" }
     }
     if (!$PolicyId) { exit }
 
     try {
-        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/$($BaseEndpoint)/$($UrlName)('$($PolicyId)')" -type DELETE -tenant $TenantFilter
+        $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/$($GraphPath)('$($PolicyId)')" -type DELETE -tenant $TenantFilter
 
         $Results = "Successfully deleted the $UrlName policy with ID: $($PolicyId)"
         Write-LogMessage -headers $Headers -API $APINAME -message $Results -Sev Info -tenant $TenantFilter

--- a/Tests/Endpoint/Invoke-RemovePolicy.Tests.ps1
+++ b/Tests/Endpoint/Invoke-RemovePolicy.Tests.ps1
@@ -1,0 +1,83 @@
+# Pester tests for Invoke-RemovePolicy Graph URL construction (issue #6384).
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-RemovePolicy.ps1' -File |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    ([PSObject].Assembly.GetType('System.Management.Automation.TypeAccelerators')).GetMethod('Add').Invoke(
+        $null, @('HttpStatusCode', [System.Net.HttpStatusCode]))
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    function New-GraphPostRequest { param($uri, $type, $tenant) }
+    function Write-LogMessage { param($headers, $API, $message, $Sev, $tenant, $LogData) }
+    function Get-CippException { param($Exception) }
+
+    . $FunctionPath
+}
+
+Describe 'Invoke-RemovePolicy Graph URL' {
+    BeforeEach {
+        $script:deleteUri = $null
+        Mock -CommandName New-GraphPostRequest -MockWith {
+            $script:deleteUri = $uri
+        }
+        Mock -CommandName Write-LogMessage -MockWith {}
+    }
+
+    It 'maps singular app protection URLNames to the plural deviceAppManagement segment' {
+        $request = [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'RemovePolicy' }
+            Headers = @{}
+            Query   = [pscustomobject]@{
+                tenantFilter = 'contoso.onmicrosoft.com'
+                ID           = 'T_policy-1'
+                URLName      = 'androidManagedAppProtection'
+            }
+            Body    = [pscustomobject]@{}
+        }
+
+        $response = Invoke-RemovePolicy -Request $request -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        $script:deleteUri | Should -Be "https://graph.microsoft.com/beta/deviceAppManagement/androidManagedAppProtections('T_policy-1')"
+    }
+
+    It 'keeps mobileAppConfigurations under deviceAppManagement' {
+        $request = [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'RemovePolicy' }
+            Headers = @{}
+            Query   = [pscustomobject]@{
+                tenantFilter = 'contoso.onmicrosoft.com'
+                ID           = 'config-1'
+                URLName      = 'mobileAppConfigurations'
+            }
+            Body    = [pscustomobject]@{}
+        }
+
+        $null = Invoke-RemovePolicy -Request $request -TriggerMetadata $null
+
+        $script:deleteUri | Should -Be "https://graph.microsoft.com/beta/deviceAppManagement/mobileAppConfigurations('config-1')"
+    }
+
+    It 'defaults other URLNames to deviceManagement' {
+        $request = [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'RemovePolicy' }
+            Headers = @{}
+            Query   = [pscustomobject]@{
+                tenantFilter = 'contoso.onmicrosoft.com'
+                ID           = 'policy-2'
+                URLName      = 'deviceConfigurations'
+            }
+            Body    = [pscustomobject]@{}
+        }
+
+        $null = Invoke-RemovePolicy -Request $request -TriggerMetadata $null
+
+        $script:deleteUri | Should -Be "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations('policy-2')"
+    }
+}


### PR DESCRIPTION
Normalization of app protection policy URLs ensures that the correct plural segments are used for deletion requests. This change addresses the issue where deletion fails with "Resource not found for the segment" by mapping singular URL names to their respective plural forms under the deviceAppManagement endpoint.

Fixes KelvinTegelaar/CIPP#6384