### PR TITLE
fix: retry outbound webhook delivery on HTTP 429

### DIFF
--- a/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
+++ b/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
@@ -252,53 +252,68 @@ function Send-CIPPAlert {
                     if ($RequestHeaders.Count -gt 0) {
                         $RestMethod['Headers'] = $RequestHeaders
                     }
-                    switch -wildcard ($webhook) {
-                        '*webhook.office.com*' {
-                            if ($UseStandardizedWebhookSchema) {
-                                $RestMethod['Body'] = $ReplacedContent
-                                $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
-                            } else {
-                                $TeamsBody = [PSCustomObject]@{
-                                    text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. <br><br>$ReplacedContent"
-                                } | ConvertTo-Json -Compress
-                                $RestMethod['Body'] = $TeamsBody
-                                $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
-                            }
-                        }
-                        '*discord.com*' {
-                            if ($UseStandardizedWebhookSchema) {
-                                $RestMethod['Body'] = $ReplacedContent
-                                $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
-                            } else {
-                                $DiscordBody = [PSCustomObject]@{
-                                    content = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
-                                } | ConvertTo-Json -Compress
-                                $RestMethod['Body'] = $DiscordBody
-                                $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
-                            }
-                        }
-                        '*slack.com*' {
-                            if ($UseStandardizedWebhookSchema) {
-                                $RestMethod['Body'] = $ReplacedContent
-                                $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
-                            } else {
-                                $SlackBlocks = Get-SlackAlertBlocks -JSONBody $JSONContent
-                                if ($SlackBlocks.blocks) {
-                                    $SlackBody = $SlackBlocks | ConvertTo-Json -Depth 10 -Compress
+                    $MaxRetries = 3
+                    $RetryCount = 0
+                    $RequestSuccessful = $false
+                    do {
+                        switch -wildcard ($webhook) {
+                            '*webhook.office.com*' {
+                                if ($UseStandardizedWebhookSchema) {
+                                    $RestMethod['Body'] = $ReplacedContent
+                                    $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
                                 } else {
-                                    $SlackBody = [PSCustomObject]@{
-                                        text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
+                                    $TeamsBody = [PSCustomObject]@{
+                                        text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. <br><br>$ReplacedContent"
                                     } | ConvertTo-Json -Compress
+                                    $RestMethod['Body'] = $TeamsBody
+                                    $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
                                 }
-                                $RestMethod['Body'] = $SlackBody
+                            }
+                            '*discord.com*' {
+                                if ($UseStandardizedWebhookSchema) {
+                                    $RestMethod['Body'] = $ReplacedContent
+                                    $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
+                                } else {
+                                    $DiscordBody = [PSCustomObject]@{
+                                        content = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
+                                    } | ConvertTo-Json -Compress
+                                    $RestMethod['Body'] = $DiscordBody
+                                    $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
+                                }
+                            }
+                            '*slack.com*' {
+                                if ($UseStandardizedWebhookSchema) {
+                                    $RestMethod['Body'] = $ReplacedContent
+                                    $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
+                                } else {
+                                    $SlackBlocks = Get-SlackAlertBlocks -JSONBody $JSONContent
+                                    if ($SlackBlocks.blocks) {
+                                        $SlackBody = $SlackBlocks | ConvertTo-Json -Depth 10 -Compress
+                                    } else {
+                                        $SlackBody = [PSCustomObject]@{
+                                            text = "You've setup your alert policies to be alerted whenever specific events happen. We've found some of these events in the log. ``````$ReplacedContent``````"
+                                        } | ConvertTo-Json -Compress
+                                    }
+                                    $RestMethod['Body'] = $SlackBody
+                                    $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
+                                }
+                            }
+                            default {
+                                $RestMethod['Body'] = $ReplacedContent
                                 $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
                             }
                         }
-                        default {
-                            $RestMethod['Body'] = $ReplacedContent
-                            $WebhookResponse = Invoke-CIPPRestMethod @RestMethod
+                        if ($WebhookStatusCode -eq 429) {
+                            $RetryCount++
+                            if ($RetryCount -le $MaxRetries) {
+                                $WaitSeconds = Get-Random -Minimum 2 -Maximum 5
+                                Write-LogMessage -API 'Webhook Alerts' -message "Webhook rate limited (429) for $webhook, retrying in $WaitSeconds seconds (attempt $RetryCount/$MaxRetries)" -tenant $TenantFilter -sev warning
+                                Start-Sleep -Seconds $WaitSeconds
+                            }
+                        } else {
+                            $RequestSuccessful = $true
                         }
-                    }
+                    } while (-not $RequestSuccessful -and $RetryCount -le $MaxRetries)
                 }
                 $LogData = @{
                     WebhookUrl = $webhook


### PR DESCRIPTION
## Summary

- Adds a retry loop (max 3 attempts, 2–5s random backoff) around the webhook `switch` block in `Send-CIPPAlert` for HTTP 429 responses
- Previously a 429 from the receiving endpoint (e.g. Power Automate rate limit) caused the alert to be silently dropped
- Mirrors the existing 429 retry pattern in `New-GraphGetRequest` and `New-GraphPOSTRequest`

Resolves CyberDrain/CIPP#349
