### PR TITLE
fix(hostname): fall back to request host when no custom domain is bound

### DIFF
--- a/Modules/CIPPCore/Public/Functions/Get-CIPPHostname.ps1
+++ b/Modules/CIPPCore/Public/Functions/Get-CIPPHostname.ps1
@@ -15,7 +15,10 @@ function Get-CIPPHostname {
         Resolve from the custom domain bound to the App Service ahead of the inbound request.
         Use it for anything that outlives the request - webhook registrations, stored URLs - so
         an admin who happens to browse in on the *.azurewebsites.net hostname does not pin
-        background work to it.
+        background work to it. Only a custom domain takes precedence: when none is bound to the
+        App Service the inbound request still decides, so a Static Web App deployment (custom
+        domain on the SWA, API as a linked backend) keeps generating links on the domain the
+        user is actually on rather than the platform hostname.
     .FUNCTIONALITY
         Internal
     .EXAMPLE
@@ -30,17 +33,21 @@ function Get-CIPPHostname {
 
     $Hostname = $null
 
-    # Only an authoritative ARM answer wins here. When the lookup fails we fall through to the
-    # request host rather than guessing: demoting a working custom domain to the platform hostname
-    # on a transient 403 would silently rewrite every link CIPP sends out.
+    # Only an authoritative ARM answer that found a custom domain wins here. When the lookup fails
+    # we fall through to the request host rather than guessing: demoting a working custom domain to
+    # the platform hostname on a transient 403 would silently rewrite every link CIPP sends out.
+    # The same applies when ARM answers but no custom domain is bound: behind a Static Web App the
+    # custom domain lives on the SWA, so the function app's own hostname is never user-facing.
     if ($PreferCustomDomain.IsPresent) {
         try {
             $SiteState = Get-CIPPSiteHostname -IncludeStatus -NoFallback
-            if ($SiteState.Discovered -and ![string]::IsNullOrWhiteSpace($SiteState.PreferredHostname)) {
+            if ($SiteState.Discovered -and $SiteState.CustomHostnames.Count -gt 0 -and ![string]::IsNullOrWhiteSpace($SiteState.PreferredHostname)) {
                 $Hostname = $SiteState.PreferredHostname
                 if ($SiteState.CustomHostnames.Count -gt 1) {
                     Write-Information "Get-CIPPHostname: $($SiteState.CustomHostnames.Count) custom domains bound ($($SiteState.CustomHostnames -join ', ')) - using the first, '$Hostname'"
                 }
+            } elseif ($SiteState.Discovered) {
+                Write-Information 'Get-CIPPHostname: no custom domain is bound to this App Service - falling back to the request host'
             } else {
                 Write-Information "Get-CIPPHostname: custom domain lookup was not authoritative, falling back to the request host: $($SiteState.Error)"
             }

--- a/Tests/Private/Get-CIPPHostname.Tests.ps1
+++ b/Tests/Private/Get-CIPPHostname.Tests.ps1
@@ -1,0 +1,119 @@
+# Pester tests for Get-CIPPHostname
+# -PreferCustomDomain exists so links that outlive the request (GDAP onboarding URLs, webhook
+# registrations) land on the custom domain even when an admin is browsing on the platform hostname.
+# The trap is a deployment where the custom domain is NOT bound to the App Service - the classic
+# Static Web App frontend with the API as a linked backend. There ARM truthfully reports only the
+# *.azurewebsites.net hostname, which never serves the UI, so "authoritative" must not mean "use the
+# platform hostname over the host the user is actually on". These tests pin that boundary.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Functions/Get-CIPPHostname.ps1'
+
+    # Minimal stubs so Mock has commands to replace during tests
+    function Get-CIPPSiteHostname { param([switch]$AsRedirectUri, [switch]$IncludeStatus, [switch]$NoFallback) }
+    function Get-CIPPTable { param($TableName) }
+    function Get-CIPPAzDataTableEntity { param($Context, $Filter) }
+    function Add-CIPPAzDataTableEntity { param($Context, $Entity, [switch]$Force) }
+
+    . $FunctionPath
+}
+
+Describe 'Get-CIPPHostname' {
+    BeforeEach {
+        $script:DefaultHost = 'cippxyz.azurewebsites.net'
+        $script:CustomHost = 'cipp.contoso.com'
+        $script:OriginalWebsiteHostname = $env:WEBSITE_HOSTNAME
+        $env:WEBSITE_HOSTNAME = $script:DefaultHost
+
+        # A request that arrived through the custom domain, as it does behind a Static Web App
+        $script:RequestHeaders = @{
+            'x-ms-original-url' = "https://$script:CustomHost/api/ExecGDAPInvite"
+            referer             = "https://$script:CustomHost/tenant/gdap-management/invites/add"
+        }
+
+        Mock -CommandName Get-CIPPTable -MockWith { @{ Context = 'Config' } }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { $null }
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith { }
+        Mock -CommandName Get-CIPPSiteHostname -MockWith {
+            [PSCustomObject]@{
+                Hostnames         = @($script:DefaultHost, $script:CustomHost)
+                DefaultHostname   = $script:DefaultHost
+                CustomHostnames   = @($script:CustomHost)
+                PreferredHostname = $script:CustomHost
+                Discovered        = $true
+                Error             = $null
+            }
+        }
+    }
+
+    AfterEach {
+        $env:WEBSITE_HOSTNAME = $script:OriginalWebsiteHostname
+    }
+
+    Context 'When -PreferCustomDomain is set' {
+        It 'uses the custom domain bound to the App Service ahead of the request host' {
+            # Admin browsing on the platform hostname must not pin a stored link to it
+            $Headers = @{ 'x-ms-original-url' = "https://$script:DefaultHost/api/ExecGDAPInvite" }
+
+            $Result = Get-CIPPHostname -Headers $Headers -PreferCustomDomain
+
+            $Result | Should -Be $script:CustomHost
+        }
+
+        It 'falls back to the request host when ARM answers but no custom domain is bound to the App Service' {
+            # Static Web App deployments: the custom domain is on the SWA, the function app only has
+            # its *.azurewebsites.net name, and that hostname never serves the frontend.
+            Mock -CommandName Get-CIPPSiteHostname -MockWith {
+                [PSCustomObject]@{
+                    Hostnames         = @($script:DefaultHost)
+                    DefaultHostname   = $script:DefaultHost
+                    CustomHostnames   = @()
+                    PreferredHostname = $script:DefaultHost
+                    Discovered        = $true
+                    Error             = $null
+                }
+            }
+
+            $Result = Get-CIPPHostname -Headers $script:RequestHeaders -PreferCustomDomain
+
+            $Result | Should -Be $script:CustomHost
+        }
+
+        It 'falls back to the request host when the custom domain lookup is not authoritative' {
+            Mock -CommandName Get-CIPPSiteHostname -MockWith {
+                [PSCustomObject]@{
+                    Hostnames         = @()
+                    DefaultHostname   = $script:DefaultHost
+                    CustomHostnames   = @()
+                    PreferredHostname = $null
+                    Discovered        = $false
+                    Error             = 'AuthorizationFailed'
+                }
+            }
+
+            $Result = Get-CIPPHostname -Headers $script:RequestHeaders -PreferCustomDomain
+
+            $Result | Should -Be $script:CustomHost
+        }
+
+        It 'still resolves the platform hostname when no custom domain is bound and there is no request' {
+            # A unified container without a custom domain, called outside an HTTP request, must keep
+            # resolving to the only hostname it has rather than coming back empty.
+            Mock -CommandName Get-CIPPSiteHostname -MockWith {
+                [PSCustomObject]@{
+                    Hostnames         = @($script:DefaultHost)
+                    DefaultHostname   = $script:DefaultHost
+                    CustomHostnames   = @()
+                    PreferredHostname = $script:DefaultHost
+                    Discovered        = $true
+                    Error             = $null
+                }
+            }
+
+            $Result = Get-CIPPHostname -PreferCustomDomain
+
+            $Result | Should -Be $script:DefaultHost
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Since `-PreferCustomDomain` was introduced (10.9.x), `Get-CIPPHostname` treats **any** authoritative ARM answer as final, including one that found **no custom domain** bound to the App Service.

That is exactly what a Static Web App deployment looks like: the custom domain (`cipp.example.com`) is bound to the SWA, and CIPP-API is a linked backend that only carries its `<app>.azurewebsites.net` name. ARM truthfully reports no custom hostnames, `PreferredHostname` falls back to the platform hostname, and the request host is never consulted. Every link built through this path then points at a host that never serves the frontend and answers **401** from EasyAuth:

- `Invoke-ExecGDAPInvite` / `Invoke-ListGDAPInvite` → stored `OnboardingUrl` = `https://<app>.azurewebsites.net/tenant/gdap-management/onboarding/start?id=…`
- `Invoke-ExecPartnerWebhook` → Partner Center webhook registered against `https://<app>.azurewebsites.net/api/PublicWebhooks…`

Trace at the moment of invite creation on an affected instance:

```
[SiteHostname] Discovered hostnames from ARM: <app>.azurewebsites.net
```

Up to 10.8.x the onboarding link was built from the request's `Referer`, which was correct for this layout.

## Fix

Only let the ARM answer win when it actually found a custom domain. When ARM is authoritative but reports zero custom hostnames, fall through to the existing request-host resolution (`x-ms-original-url` → `origin` → `referer` → host header), exactly as already happens when the lookup is not authoritative.

Behaviour is unchanged for everyone else:

- Custom domain bound to the App Service → still wins over the request host (the reason `-PreferCustomDomain` exists).
- Unified container **without** a custom domain → the request host *is* the platform hostname, so the result is identical; outside an HTTP request it still resolves to `WEBSITE_HOSTNAME`.
- Lookup failed → unchanged (request host).

One condition plus a log line; docs and the inline comment updated to describe the boundary.

## Tests

New `Tests/Private/Get-CIPPHostname.Tests.ps1` (4 tests) following the pattern of `Get-CIPPSiteHostname.Tests.ps1`:

| Case | Before | After |
|---|---|---|
| custom domain bound → prefers it over the request host | pass | pass |
| ARM answers, **no** custom domain (SWA layout) → request host | **fail** (`cippxyz.azurewebsites.net`) | pass |
| lookup not authoritative → request host | pass | pass |
| no custom domain and no request → `WEBSITE_HOSTNAME` | pass | pass |

Written red-first: the second case fails on current `dev` and passes with this change. Full `Tests/Private` run: 1080 passed / 9 failed with this branch vs 1076 / 9 on pristine `dev` — the 9 are the two pre-existing `Invoke-CIPPOffboardingJob.*` failures, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018waFMivDwxtRaNJqdrTuh6
