### PR TITLE
fix(webhooks): guard against missing x-ms-original-url in PublicWebhooks

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Alerts/Invoke-PublicWebhooks.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Alerts/Invoke-PublicWebhooks.ps1
@@ -8,9 +8,17 @@ function Invoke-PublicWebhooks {
     param($Request, $TriggerMetadata)
     $Headers = $Request.Headers
     Write-Host 'Received request'
-    $url = ($Headers.'x-ms-original-url').split('/API') | Select-Object -First 1
-    $CIPPURL = [string]$url
-    Write-Host $url
+    # x-ms-original-url is only set by the Static Web App proxy. When a request arrives directly on
+    # the Function App hostname - which is what the Partner Webhooks page registers whenever no
+    # custom domain is bound to the App Service - the header is absent and .split() threw a
+    # NullReferenceException here, returning HTTP 500 before the validation branches below were
+    # ever reached. The derived $CIPPURL was not used anywhere else in this function.
+    $OriginalUrl = [string]$Headers.'x-ms-original-url'
+    if ($OriginalUrl) {
+        Write-Host "Inbound URL: $OriginalUrl"
+    } else {
+        Write-Host 'Inbound URL: no x-ms-original-url - request did not arrive via the SWA proxy'
+    }
 
     # Graph (and Partner Center) validate a new subscription by POSTing a token and comparing the raw
     # response body to it byte for byte. The response has to be the bare token as text/plain - the


### PR DESCRIPTION
## What this fixes

`Invoke-PublicWebhooks` returns HTTP 500 for every inbound webhook whenever the request does not
arrive through the Static Web App proxy.

The first statement in the function is:

```powershell
$url = ($Headers.'x-ms-original-url').split('/API') | Select-Object -First 1
$CIPPURL = [string]$url
Write-Host $url
```

`x-ms-original-url` is injected by the SWA proxy. When Partner Center posts directly to the
Function App hostname the header is absent, `.split()` is called on `$null`, and the function
throws before it ever reaches the `ValidationToken` / `validationCode` branches — so even the
Partner Center validation ping fails. `$CIPPURL` is assigned and never used anywhere else in
the function, so the calculation is dead code.

## Why this is easy to hit

The Partner Webhooks settings page steers you into it.
`Invoke-ExecPartnerWebhook` → `Get-CIPPHostname -PreferCustomDomain` → `Get-CIPPSiteHostname`
resolves the hostname from ARM `Microsoft.Web/sites/$WEBSITE_SITE_NAME`, which is the **Function
App**. Custom domains are normally bound to the **Static Web App**, so `CustomHostnames` comes
back empty and `PreferredHostname` falls through to `<instance>.azurewebsites.net`.

The UI then shows:

> This subscription points at a different URL than the one this instance is published on. Save
> the settings below to re-register it against
> `https://<instance>.azurewebsites.net/api/PublicWebhooks?CIPPID=...&Type=PartnerCenter`.

Saving moves the registration off the only URL that works. Automated Onboarding then stops
silently: `granular-admin-relationship-approved` events no longer reach CIPP, nothing is logged
on the CIPP side, and the only signal is a 500 in the Partner Center delivery result.

## Steps to reproduce

1. A CIPP instance with no custom domain bound to the Function App — the default for anyone who
   binds their domain to the Static Web App, or uses no custom domain.
2. **Settings → Partner Webhooks**, save the page. The subscription is re-registered against the
   Function App hostname.
3. Click **Send Test**.
4. Observed: response code **500**, empty response message. Expected: 200 with the validation
   token echoed back.

Observed on 10.9.1. The same three lines are present on `main` (commit `e9901cb`) and on `dev`
at the time of this PR, so it is not fixed in 10.10.x either.

## The change

Drops the unused `.split()` and keeps the log line, made null-safe. It also records whether the
request came in through the proxy or directly, which is exactly the distinction that causes this
failure.

The endpoint then works on any hostname: Static Web App, Function App, or a custom domain bound
to either.

## Note

Happy to follow up separately on whether `Get-CIPPSiteHostname` should read custom domains from
the Static Web App rather than the App Service for webhook registration purposes. That looked
like a design question rather than a bug, and this null guard is the part that turns a
misconfiguration into a silent outage, so I kept the PR to that.
